### PR TITLE
Start CI migration to Jenkins pipelines

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,0 +1,48 @@
+node {
+    cleanWs()
+    dir('src') { checkout scm }
+    def userId = sh(returnStdout: true, script: 'id -u').trim()
+    docker.build('managarm_buildenv', "--build-arg USER=${userId} src/docker/")
+          .inside {
+        dir('build') {
+            stage('Build system') {
+                sh '''#!/bin/sh
+                set -xe
+                xbstrap init ../src || true
+                xbstrap install --all
+                '''
+            }
+            stage('Archive packages') {
+                sh 'xbstrap archive --all'
+            }
+        }
+        stage('Make docs') {
+            dir('docs') {
+                sh '''#!/bin/sh
+                set -xe
+                mkdir -p hel
+                sed 's|@ROOTDIR@|../src/managarm/hel|' ../src/managarm/hel/Doxyfile.in > Doxyfile
+                doxygen
+                '''
+            }
+        }
+    }
+
+    stage('Make image') {
+        dir('build') {
+            sh '''#!/bin/sh
+            set -xe
+            xzcat /var/local/image-2gib.xz > image
+            ../src/scripts/prepare-sysroot
+            ../src/scripts/mkimage
+            xz --fast image
+            '''
+        }
+    }
+
+    stage('Collect results') {
+        sh 'rsync -av --delete docs/hel/doc/html/ /var/www/docs'
+        sh 'rsync -av --delete build/packages/*.tar.gz build/image.xz /var/www/pkgs/nightly'
+        archiveArtifacts 'build/packages/*.tar.gz,build/image.xz'
+    }
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:buster
 
-RUN apt-get update
-RUN apt-get -y install build-essential pkg-config autopoint bison curl flex gettext git gperf help2man m4 mercurial ninja-build python3-mako python3-protobuf python3-yaml texinfo unzip wget xsltproc xz-utils libexpat1-dev rsync python3-pip
+ARG USER=1000
+RUN apt-get update && apt-get -y install build-essential pkg-config autopoint bison curl flex gettext git gperf help2man m4 mercurial ninja-build python3-mako python3-protobuf python3-yaml texinfo unzip wget xsltproc xz-utils libexpat1-dev rsync python3-pip
 
 RUN pip3 install meson
 RUN pip3 install xbstrap
 
-RUN useradd -ms /bin/bash managarm_buildenv
+RUN useradd -ms /bin/bash managarm_buildenv -u $USER
 USER managarm_buildenv
 WORKDIR /home/managarm_buildenv
 


### PR DESCRIPTION
Possible defect: the two rsync steps towards the end could make the builds fail on computers of developers not set up right. This is a problem only for those who wish to maintain CI