### PR TITLE
Make cairo compilable on systems with X11 headers present

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -594,6 +594,7 @@ packages:
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
         - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--disable-xlib'
         environ:
           # freetype-config does not support cross-compilation.
           FREETYPE_CONFIG: 'no'


### PR DESCRIPTION
Cairo compilation fails on my system, complaining about double redefinitions in my X11 system headers. Passing `--disable-xlib` fixes the issue, makes cairo compile, and testing weston does not reveal any glaring issues with this.