### PR TITLE
Added a port of man-db and required dependencies

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -2131,16 +2131,22 @@ packages:
     build:
       - args: ['make', 'CC=x86_64-managarm-gcc', '-j@PARALLELISM@']
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/bin']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/share/man/man1']
       - args: ['cp', '@THIS_BUILD_DIR@/sl', '@THIS_COLLECT_DIR@/usr/bin']
+      - args: ['cp', '@THIS_BUILD_DIR@/sl.1', '@THIS_COLLECT_DIR@/usr/share/man/man1']
 
   - name: libpipeline
     default: false
     source:
       subdir: ports
-      url: 'http://download.savannah.gnu.org/releases/libpipeline/libpipeline-1.5.2.tar.gz'
-      format: 'tar.gz'
-      extract_path: 'libpipeline-1.5.2'
+      git: 'https://git.savannah.gnu.org/git/libpipeline.git'
+      tag: '1.5.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-pkg-config
       regenerate:
+        - args: ['./bootstrap']
         - args: ['cp',
             '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
             '@THIS_SOURCE_DIR@/build-aux/']
@@ -2161,13 +2167,14 @@ packages:
     default: false
     source:
       subdir: ports
-      url: 'http://ftp.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz'
-      format: 'tar.gz'
-      extract_path: 'gdbm-1.18.1'
+      git: 'https://git.savannah.gnu.org/git/gdbm.git'
+      tag: 'v1.18.1'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
       regenerate:
-        - args: ['cp',
-            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
-            '@THIS_SOURCE_DIR@/build-aux/']
+        - args: ['./bootstrap']
     tools_required:
       - system-gcc
     configure:
@@ -2189,10 +2196,14 @@ packages:
     default: false
     source:
       subdir: ports
-      url: 'http://download.savannah.gnu.org/releases/man-db/man-db-2.9.0.tar.xz'
-      format: 'tar.xz'
-      extract_path: 'man-db-2.9.0'
+      git: 'https://git.savannah.gnu.org/git/man-db.git'
+      tag: '2.9.1'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-pkg-config
       regenerate:
+        - args: ['./bootstrap']
         - args: ['cp',
             '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
             '@THIS_SOURCE_DIR@/build-aux/']

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -2133,6 +2133,92 @@ packages:
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/bin']
       - args: ['cp', '@THIS_BUILD_DIR@/sl', '@THIS_COLLECT_DIR@/usr/bin']
 
+  - name: libpipeline
+    default: false
+    source:
+      subdir: ports
+      url: 'http://download.savannah.gnu.org/releases/libpipeline/libpipeline-1.5.2.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'libpipeline-1.5.2'
+      regenerate:
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: gdbm
+    default: false
+    source:
+      subdir: ports
+      url: 'http://ftp.gnu.org/gnu/gdbm/gdbm-1.18.1.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'gdbm-1.18.1'
+      regenerate:
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-nls'
+        - '--disable-static'
+        - '--enable-libgdbm-compat'
+        - '--without-readline'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: man-db
+    default: false
+    source:
+      subdir: ports
+      url: 'http://download.savannah.gnu.org/releases/man-db/man-db-2.9.0.tar.xz'
+      format: 'tar.xz'
+      extract_path: 'man-db-2.9.0'
+      regenerate:
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libpipeline
+      - gdbm
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-nls'
+        - '--docdir=/usr/share/doc/man-db-2.9.0'
+        - '--sysconfdir=/etc'
+        - '--disable-setuid'
+        - '--with-systemdtmpfilesdir='
+        - '--with-systemdsystemunitdir='
+        - '--disable-manual'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
 tasks:
   - name: make-image
     pkgs_required:


### PR DESCRIPTION
This pull request adds the following ports.

- `libpipeline`, this being a direct dependency to `man-db`. This seems to work fine.
- `gdbm`, again, being a direct dependency to `man-db`, as `man-db` needs a database. Should work fine with the changes I proposed in mlibc.
- `man-db`, this port is incomplete at the moment, as calling `man man` crashes with a call to `towlower()`, which is currently unimplemented.