### PR TITLE
Enabled the following ports by default as they are (mostly) working.

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1979,7 +1979,6 @@ packages:
       - args: 'install -Dt @THIS_COLLECT_DIR@/bin $(sed s,^,src/, @THIS_BUILD_DIR@/package/commands)'
 
   - name: tar
-    default: false
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/tar.git'
@@ -2008,7 +2007,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: gzip
-    default: false
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gzip.git'
@@ -2036,7 +2034,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: grep
-    default: false
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/grep.git'
@@ -2093,7 +2090,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: diffutils
-    default: false
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/diffutils.git'
@@ -2236,7 +2232,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: less
-    default: false
     source:
       subdir: ports
       url: 'http://www.greenwoodsoftware.com/less/less-551.tar.gz'
@@ -2299,7 +2294,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: file
-    default: false
     source:
       subdir: ports
       git: 'https://github.com/file/file.git'


### PR DESCRIPTION
- `tar`, works fine as is, but when working with gzip compressed archives errors
- `gzip`, works fine on it's own
- `grep`, works fine on small directories, running it on, for example, `/usr/include` will eventually OOM
- `diffutils`, cmp and diff work fine, sdiff is untested and diff3 is broken
- `less`, works fine as is
- `file`, works fine on executables, missing `regcomp()` on text files.