### PR TITLE
Updated required dependencies for a host build

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Now proceed to the Building paragraph.
 
 1.  Certain programs are required to build managarm;
     here we list the corresponding Debian packages:
-    `build-essential`, `pkg-config`, `autopoint`, `bison`, `curl`, `flex`, `gettext`, `git`, `gperf`, `help2man`, `m4`, `mercurial`, `ninja-build`, `python3-mako`, `python3-protobuf`, `python3-yaml`, `texinfo`, `unzip`, `wget`, `xsltproc`, `xz-utils`, `libexpat1-dev`, `rsync`, `python3-pip`.
+    `build-essential`, `pkg-config`, `autopoint`, `bison`, `curl`, `flex`, `gettext`, `git`, `gperf`, `help2man`, `m4`, `mercurial`, `ninja-build`, `python3-mako`, `python3-protobuf`, `python3-yaml`, `texinfo`, `unzip`, `wget`, `xsltproc`, `xz-utils`, `libexpat1-dev`, `rsync`, `python3-pip`, `python3-libxml2`, `netpbm`, `itstool`, `zlib1g-dev`.
 1.  `meson` is required. There is a Debian package, but as of Debian Stretch, a newer version is required.
     Install it from pip: `pip3 install meson`.
 1.  The [xbstrap](https://github.com/managarm/xbstrap) tool is required to build managarm. Install it from pip: `pip3 install xbstrap`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster
 
 ARG USER=1000
-RUN apt-get update && apt-get -y install build-essential pkg-config autopoint bison curl doxygen flex gettext git gperf help2man m4 mercurial ninja-build python3-mako python3-protobuf python3-yaml texinfo unzip wget xsltproc xz-utils libexpat1-dev rsync python3-pip
+RUN apt-get update && apt-get -y install build-essential pkg-config autopoint bison curl doxygen flex gettext git gperf help2man m4 mercurial ninja-build python3-mako python3-protobuf python3-yaml texinfo unzip wget xsltproc xz-utils libexpat1-dev rsync python3-pip python3-libxml2 netpbm itstool zlib1g-dev
 
 RUN pip3 install meson
 RUN pip3 install xbstrap


### PR DESCRIPTION
This should allow host-python to build and adds some dependencies for future use.