### PR TITLE
Various ports and fixes

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -95,6 +95,19 @@ sources:
         environ:
           'NOCONFIGURE': 'yes'
 
+  - name: 'pkg-config'
+    subdir: 'ports'
+    git: 'https://gitlab.freedesktop.org/pkg-config/pkg-config.git'
+    tag: 'pkg-config-0.29.2'
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.11
+      - host-libtool
+    regenerate:
+      - args: ['./autogen.sh']
+        environ:
+          'NOCONFIGURE': 'yes'
+
   - name: 'python'
     subdir: 'ports'
     git: 'https://github.com/python/cpython.git'
@@ -285,19 +298,7 @@ tools:
   # The easiest way to ensure that they are available is to just install pkg-config.
   - name: host-pkg-config
     exports_aclocal: true
-    source:
-      name: 'pkg-config'
-      subdir: 'ports'
-      git: 'https://gitlab.freedesktop.org/pkg-config/pkg-config.git'
-      tag: 'pkg-config-0.29.2'
-      tools_required:
-        - host-autoconf-v2.69
-        - host-automake-v1.11
-        - host-libtool
-      regenerate:
-        - args: ['./autogen.sh']
-          environ:
-            'NOCONFIGURE': 'yes'
+    from_source: pkg-config
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1066,11 +1067,12 @@ packages:
         quiet: true
 
   - name: libressl
-    default: false
     source:
       subdir: 'ports'
       git: 'https://github.com/libressl-portable/portable.git'
       tag: 'v3.0.2'
+      regenerate:
+        - args: ['./update.sh']
     tools_required:
       - host-cmake
       - system-gcc
@@ -1080,6 +1082,8 @@ packages:
         - '-GNinja'
         - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain.txt'
         - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DLIBRESSL_APPS=OFF'
+        - '-DBUILD_SHARED_LIBS=ON'
         - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']
@@ -1552,6 +1556,7 @@ packages:
       - zlib
       - libexpat
       - libffi
+      - libressl
       - ncurses
     configure:
       - args:
@@ -2098,12 +2103,13 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - pcre
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
-        - '--disable-perl-regexp' # Explicitly disable pcre support to suppres a warning in configure
         - '--disable-nls'
       - args: 'sed -i s/-Werror//g @THIS_BUILD_DIR@/lib/Makefile'
     build:
@@ -2344,7 +2350,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: file
-    default: false
     from_source: file
     tools_required:
       - system-gcc
@@ -2423,7 +2428,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: pcre
-    default: false
     source:
       subdir: ports
       url: 'https://ftp.pcre.org/pub/pcre/pcre-8.44.tar.gz'
@@ -2458,7 +2462,6 @@ packages:
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
 
   - name: glib
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.gnome.org/GNOME/glib'
@@ -2491,8 +2494,26 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
-  - name: desktop-file-utils
+  - name: pkg-config
+    from_source: pkg-config
     default: false
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - glib
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: desktop-file-utils
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xdg/desktop-file-utils.git'
@@ -2536,6 +2557,101 @@ packages:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxml
+    source:
+      subdir: ports
+      git: 'https://gitlab.gnome.org/GNOME/libxml2.git'
+      tag: 'v2.9.10'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+      - host-python
+    pkgs_required:
+      - zlib
+      - python
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--with-python=@SYSROOT_DIR@/usr/bin/python3.8'
+        - '--disable-static'
+        - '--with-threads'
+        - '--disable-ipv6'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: itstool
+    default: false
+    source:
+      subdir: ports
+      url: 'http://files.itstool.org/itstool/itstool-2.0.6.tar.bz2'
+      format: 'tar.bz2'
+      extract_path: 'itstool-2.0.6'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libxml
+      - python
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        environ:  
+          'PYTHON': '/usr/bin/python3'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: shared-mime-info
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xdg/shared-mime-info.git'
+      tag: 'Release-1-15'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+      - host-python
+    pkgs_required:
+      - glib
+      - itstool
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-update-mimedb'
+        environ:  
+          'ITSTOOL': '/usr/bin/itstool'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/patches/libressl/0001-Various-fixes-for-managarm-support.patch
+++ b/patches/libressl/0001-Various-fixes-for-managarm-support.patch
@@ -1,0 +1,39 @@
+From 5b466b2132b4dfaf3e76eb2da726c164c5f92b8f Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Thu, 7 May 2020 11:00:57 +0200
+Subject: [PATCH] Various fixes for managarm support
+
+---
+ crypto/compat/arc4random.h      | 2 +-
+ include/compat/machine/endian.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/crypto/compat/arc4random.h b/crypto/compat/arc4random.h
+index 762aec2..e7a0457 100644
+--- a/crypto/compat/arc4random.h
++++ b/crypto/compat/arc4random.h
+@@ -12,7 +12,7 @@
+ #elif defined(__hpux)
+ #include "arc4random_hpux.h"
+ 
+-#elif defined(__linux__)
++#elif defined(__linux__) || defined(__managarm__)
+ #include "arc4random_linux.h"
+ 
+ #elif defined(__NetBSD__)
+diff --git a/include/compat/machine/endian.h b/include/compat/machine/endian.h
+index 5ec39af..c8d2496 100644
+--- a/include/compat/machine/endian.h
++++ b/include/compat/machine/endian.h
+@@ -21,7 +21,7 @@
+ #define BYTE_ORDER BIG_ENDIAN
+ #endif
+ 
+-#elif defined(__linux__)
++#elif defined(__linux__) || defined(__managarm__)
+ #include <endian.h>
+ 
+ #elif defined(__sun) || defined(_AIX) || defined(__hpux)
+-- 
+2.26.2
+

--- a/scripts/prepare-sysroot
+++ b/scripts/prepare-sysroot
@@ -13,6 +13,7 @@ mkdir -p system-root/usr/share/X11
 
 # Create some symlinks that are currently required.
 ln -sf /usr/bin/bash system-root/bin/bash
+ln -sf /usr/bin/bash system-root/bin/sh
 ln -sf /usr/lib/ld.so system-root/lib/ld-init.so
 
 # Copy stuff from the host system.


### PR DESCRIPTION
This PR adds the following new ports

- `pkg-config`, still needs some libc work in regards to ungetc at the moment
- `libxml2`, works, some programs require `pthread_equal` and the `python3` module doesn't install
- `itstool`, has some issues, build time dep for `shared-mime-info`
- `shared-mime-info`, wants `pthread_equal`

Furthermore, the following ports received updates

- `libressl`, fixup on the port and added a patch
- `python` and `grep`, updated dependencies

A few ports have been enabled by default, these are: `pcre`, `glib`, `file`, `desktop-file-utils`, `libxml2` and `libressl`

Lastly an update to `scripts/prepare-sysroot` to satisfy a dependency on `/bin/sh` is included in this PR