### PR TITLE
Added various ports

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -2822,6 +2822,31 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: xbps
+    # Disabled due to linking issues with libressl.
+    default: false
+    source:
+      subdir: ports
+      git: 'https://github.com/void-linux/xbps.git'
+      tag: '0.59.1'
+      tools_required:
+        - host-pkg-config
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libarchive
+      - libressl
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+      - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+  
   - name: findutils
     default: false
     source:
@@ -2848,6 +2873,7 @@ packages:
         - '--prefix=/usr'
         - '--without-selinux'
         - '--disable-nls'
+        - '--localstatedir=/var/lib/locate'
         environ:  
           'PYTHON': '@BUILD_ROOT@/tools/host-python/bin/python3'
     build:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -752,6 +752,7 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
+      - args: ['ln', '-sf', 'gcc', '@THIS_COLLECT_DIR@/usr/bin/cc']
 
   - name: coreutils
     source:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -2674,6 +2674,59 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: gettext
+    default: false
+    source:
+      subdir: ports
+      git: 'https://git.savannah.gnu.org/git/gettext.git'
+      tag: 'v0.20.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: 'sed -i s/"SUBDIRS = doc intl intl-java intl-csharp gnulib-lib \$(SUBDIR_libasprintf)\ src po man m4 tests"/"SUBDIRS = intl intl-java intl-csharp gnulib-lib \$(SUBDIR_libasprintf)\ src po m4 tests"/ @THIS_SOURCE_DIR@/gettext-runtime/Makefile.am'
+        - args: 'sed -i s/"SUBDIRS = intl gnulib-lib libgrep src libgettextpo po its projects styles emacs misc man m4 tests system-tests gnulib-tests examples doc"/"SUBDIRS = intl gnulib-lib libgrep src libgettextpo po its projects styles emacs misc m4 tests system-tests gnulib-tests examples"/ @THIS_SOURCE_DIR@/gettext-tools/Makefile.am'
+        - args: ['./gitsub.sh', 'pull']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-libtool/share/aclocal/libtool.m4',
+            '@THIS_SOURCE_DIR@/m4/']
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/libtextstyle/build-aux/']
+    tools_required:
+      - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--docdir=/usr/share/doc/gettext-0.20.2'
+        - '--enable-static=no'
+        - '--enable-shared=yes'
+        - '--disable-java'
+        - '--disable-nls'
+        - '--disable-acl'
+        - '--without-emacs'
+        - '--without-git'
+        - '--without-bzip2'
+        - '--without-xz'
+        - '--disable-curses'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxml
     source:
       subdir: ports
@@ -2768,6 +2821,58 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: findutils
+    default: false
+    source:
+      subdir: ports
+      git: 'https://git.savannah.gnu.org/git/findutils.git'
+      tag: 'v4.7.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./bootstrap']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+    tools_required:
+      - system-gcc
+      - host-python
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--without-selinux'
+        - '--disable-nls'
+        environ:  
+          'PYTHON': '@BUILD_ROOT@/tools/host-python/bin/python3'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: bzip2
+    default: false
+    source:
+      subdir: ports
+      url: 'https://www.sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'bzip2-1.0.8'
+    tools_required:
+      - system-gcc
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+      - args: 'sed -i s/"all: libbz2.a bzip2 bzip2recover test"/"all: libbz2.a bzip2 bzip2recover"/ @THIS_BUILD_DIR@/Makefile'
+    build:
+      - args: ['make', 'CC=x86_64-managarm-gcc', 'CFLAGS=-fPIC', '-f', 'Makefile-libbz2_so']
+      - args: ['make', 'clean']
+      - args: ['make', 'CC=x86_64-managarm-gcc', 'CFLAGS=-fPIC', '-j@PARALLELISM@']
+      - args: ['make', 'PREFIX=@THIS_COLLECT_DIR@/usr', 'install']
 
 tasks:
   - name: make-image

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -81,7 +81,7 @@ install -s system-root/usr/managarm/bin/thor $dir/boot/managarm/
 cp initrd.cpio $dir/boot/managarm/
 
 # Copy the sysroot.
-mkdir -p $dir/bin $dir/lib $dir/root $dir/usr/bin $dir/usr/lib
+mkdir -p $dir/bin $dir/lib $dir/root $dir/usr/bin $dir/usr/lib $dir/var
 mkdir -p $dir/dev $dir/proc $dir/run $dir/sys $dir/tmp $dir/boot/grub
 rsync -a --delete system-root/bin/ $dir/bin
 rsync -a --delete system-root/lib/ $dir/lib
@@ -91,6 +91,7 @@ cp $scriptdir/grub.cfg $dir/boot/grub/
 cp $scriptdir/qloader2.cfg $dir/boot/
 rsync -a --delete system-root/usr/ $dir/usr
 rsync -a --delete system-root/etc/ $dir/etc
+rsync -a --delete system-root/var/ $dir/var
 cp tools/system-gcc/x86_64-managarm/lib64/libgcc_s.so.1 $dir/usr/lib
 cp tools/system-gcc/x86_64-managarm/lib64/libstdc++.so.6 $dir/usr/lib
 echo " done"

--- a/scripts/prepare-sysroot
+++ b/scripts/prepare-sysroot
@@ -10,6 +10,9 @@ mkdir -p system-root/root
 mkdir -p system-root/usr
 mkdir -p system-root/usr/share
 mkdir -p system-root/usr/share/X11
+mkdir -p system-root/var
+mkdir -p system-root/var/lib
+mkdir -p system-root/var/lib/locate
 
 # Create some symlinks that are currently required.
 ln -sf /usr/bin/bash system-root/bin/bash


### PR DESCRIPTION
This PR adds the following ports:

- `gettext`
- `findutils`
- `bzip2`

Furthermore, it adds a compatibility symlink from `gcc` to `cc`, so build systems that call `cc` can work.