### PR TITLE
Add sysklogd and make ports

### DIFF
--- a/bootstrap.d/app-admin.yml
+++ b/bootstrap.d/app-admin.yml
@@ -1,0 +1,30 @@
+packages:
+  - name: sysklogd
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/troglobit/sysklogd.git'
+      tag: 'v2.1.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/run'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/syslog.d']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/syslog.conf', '@THIS_COLLECT_DIR@/etc']

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -1,0 +1,34 @@
+packages:
+  - name: make
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/git/make.git'
+      tag: '4.2'
+      tools_required:
+        - host-pkg-config
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-autoconf-archive
+        - host-libtool
+      regenerate:
+        - args: ['autoreconf', '-v', '-f', '-i']
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-nls'
+        - '--without-guile'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -2,6 +2,7 @@ imports:
   - file: ../src/bootstrap.d/app-admin.yml
   - file: ../src/bootstrap.d/dev-perl.yml
   - file: ../src/bootstrap.d/net-misc.yml
+  - file: ../src/bootstrap.d/sys-devel.yml
   - file: ../src/bootstrap.d/sys-libs.yml
 
 repository:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1,4 +1,5 @@
 imports:
+  - file: ../src/bootstrap.d/app-admin.yml
   - file: ../src/bootstrap.d/dev-perl.yml
   - file: ../src/bootstrap.d/net-misc.yml
   - file: ../src/bootstrap.d/sys-libs.yml

--- a/extrafiles/syslog.conf
+++ b/extrafiles/syslog.conf
@@ -1,0 +1,16 @@
+# Begin /etc/syslog.conf
+
+auth,authpriv.* -/var/log/auth.log
+*.*;auth,authpriv.none -/var/log/sys.log
+daemon.* -/var/log/daemon.log
+kern.* -/var/log/kern.log
+mail.* -/var/log/mail.log
+user.* -/var/log/user.log
+*.emerg *
+
+#
+# Include all config files in /etc/syslog.d/
+#
+include /etc/syslog.d/*.conf
+
+# End /etc/syslog.conf

--- a/patches/make/0001-Fix-for-Managarm-support.patch
+++ b/patches/make/0001-Fix-for-Managarm-support.patch
@@ -1,0 +1,26 @@
+From 9c4456c8bbe96a6b52192cfad0c71cc5034a646c Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Wed, 20 May 2020 09:59:57 +0200
+Subject: [PATCH] Fix for Managarm support
+
+Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index c88c465..670b417 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -31,7 +31,7 @@ else
+   ossrc =	posixos.c
+ endif
+ 
+-SUBDIRS =	glob config po doc $(MAYBE_W32)
++SUBDIRS =	glob config po $(MAYBE_W32)
+ 
+ bin_PROGRAMS =	make
+ include_HEADERS = gnumake.h
+-- 
+2.26.2
+

--- a/patches/sysklogd/0001-Add-managarm-support.patch
+++ b/patches/sysklogd/0001-Add-managarm-support.patch
@@ -1,0 +1,48 @@
+From db834d923a7aaf6b600fc3e8062f4e5734728842 Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Mon, 18 May 2020 13:27:09 +0200
+Subject: [PATCH] Add managarm support
+
+Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+---
+ src/syslog.h  | 2 ++
+ src/syslogd.c | 4 ++++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/src/syslog.h b/src/syslog.h
+index 120a18f..359a5d3 100644
+--- a/src/syslog.h
++++ b/src/syslog.h
+@@ -34,7 +34,9 @@
+ #ifndef _SYS_SYSLOG_H_ /* From NetBSD, for co-existance with C-library header */
+ #define _SYS_SYSLOG_H_
+ 
++#if __has_include(<features.h>)
+ #include <features.h>
++#endif
+ #include <stdarg.h>
+ 
+ /*
+diff --git a/src/syslogd.c b/src/syslogd.c
+index d5270bb..524a84c 100644
+--- a/src/syslogd.c
++++ b/src/syslogd.c
+@@ -78,11 +78,15 @@ static char sccsid[] __attribute__((unused)) =
+ #include <sys/wait.h>
+ 
+ #include <arpa/inet.h>
++#if __has_include(<arpa/nameser.h>)
+ #include <arpa/nameser.h>
++#endif
+ #include <netdb.h>
+ #include <netinet/in.h>
+ #include <resolv.h>
++#if __has_include(<syscall.h>)
+ #include <syscall.h>
++#endif
+ #include <paths.h>
+ 
+ #define SYSLOG_NAMES
+-- 
+2.26.2
+


### PR DESCRIPTION
This PR adds the following two ports:

- `sysklogd`, compiles fine, but complains about `gethostbyname()` on runtime
- `make`, compiles and runs fine, possible issue with binutils `as` on `gcc` invocation from a makefile