### PR TITLE
Add ports of wget, curl and patch; fix ncurses

### DIFF
--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -35,3 +35,78 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: wget
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/git/wget.git'
+      tag: 'v1.20.3'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-autoconf-archive
+        - host-pkg-config
+      regenerate:
+        - args: ['./bootstrap']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - pcre
+      - libressl
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-ipv6'
+        - '--disable-nls'
+        - '--with-ssl=openssl'
+        - '--with-openssl'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: curl
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/curl/curl.git'
+      tag: 'curl-7_70_0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./buildconf']
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - libressl
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-ipv6'
+        - '--disable-static'
+        - '--with-ca-path=/etc/ssl/certs'
+        - '--enable-threaded-resolver'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -86,3 +86,38 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: patch
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/git/patch.git'
+      tag: 'v2.7.6'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['./bootstrap']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - diffutils
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -55,3 +55,31 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: ncurses
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/ThomasDickey/ncurses-snapshots.git'
+      tag: 'v6_1'
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--without-ada'
+        - '--enable-pc-files'
+        - '--with-shared'
+        - '--without-normal'
+        - '--with-manpage-format=normal'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
+        quiet: true
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/lib/pkgconfig']
+      - args: ['mv', '@THIS_COLLECT_DIR@/usr/lib/x86_64-linux-gnu/pkgconfig/form.pc', '@THIS_COLLECT_DIR@/usr/lib/pkgconfig']
+      - args: ['mv', '@THIS_COLLECT_DIR@/usr/lib/x86_64-linux-gnu/pkgconfig/menu.pc', '@THIS_COLLECT_DIR@/usr/lib/pkgconfig']
+      - args: ['mv', '@THIS_COLLECT_DIR@/usr/lib/x86_64-linux-gnu/pkgconfig/panel.pc', '@THIS_COLLECT_DIR@/usr/lib/pkgconfig']
+      - args: ['mv', '@THIS_COLLECT_DIR@/usr/lib/x86_64-linux-gnu/pkgconfig/ncurses.pc', '@THIS_COLLECT_DIR@/usr/lib/pkgconfig']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib/x86_64-linux-gnu']

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1454,32 +1454,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
-  - name: ncurses
-    source:
-      subdir: 'ports'
-      url: 'https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.1.tar.gz'
-      format: 'tar.gz'
-      extract_path: 'ncurses-6.1'
-      tools_required:
-        - host-automake-v1.11
-      regenerate:
-        - args: ['cp',
-            '@BUILD_ROOT@/tools/host-automake-v1.11/share/automake-1.11/config.sub',
-            '@THIS_SOURCE_DIR@/']
-
-    tools_required:
-      - system-gcc
-    configure:
-      - args:
-        - '@THIS_SOURCE_DIR@/configure'
-        - '--host=x86_64-managarm'
-        - '--prefix=/usr'
-        - '--without-ada'
-    build:
-      - args: ['make', '-j@PARALLELISM@', 'all']
-      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
-        quiet: true
-
   - name: pixman
     source:
       subdir: 'ports'

--- a/patches/ncurses/0001-Add-managarm-support.patch
+++ b/patches/ncurses/0001-Add-managarm-support.patch
@@ -1,0 +1,42 @@
+From 44848b51a1cc66cbec3b97a7d751113df5c329bf Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Fri, 22 May 2020 16:42:10 +0200
+Subject: [PATCH] Add managarm support
+
+Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+---
+ config.sub | 2 +-
+ configure  | 4 ++++
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/config.sub b/config.sub
+index 00f68b8e..5f6344ab 100755
+--- a/config.sub
++++ b/config.sub
+@@ -1416,7 +1416,7 @@ case $os in
+ 	      | -morphos* | -superux* | -rtmk* | -rtmk-nova* | -windiss* \
+ 	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
+ 	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* \
+-	      | -onefs* | -tirtos* | -phoenix* | -fuchsia* | -redox*)
++	      | -onefs* | -tirtos* | -phoenix* | -fuchsia* | -redox* | -managarm*)
+ 	# Remember, each alternative MUST END IN *, to match a version number.
+ 		;;
+ 	-qnx*)
+diff --git a/configure b/configure
+index adead920..7fbdd312 100755
+--- a/configure
++++ b/configure
+@@ -6335,6 +6335,10 @@ echo "${ECHO_T}$cf_cv_ldflags_search_paths_first" >&6
+ 
+ 		MK_SHARED_LIB='${CC} ${LDFLAGS} ${CFLAGS} -shared -Wl,-soname,'$cf_cv_shared_soname',-stats,-lc -o $@'
+ 		;;
++	(managarm*)
++		CC_SHARED_OPTS='-fPIC'
++                MK_SHARED_LIB='${CC} -shared -o $@'
++		;;
+ 	(mingw*)
+ 		cf_cv_shlib_version=mingw
+ 		cf_cv_shlib_version_infix=mingw
+-- 
+2.26.2
+


### PR DESCRIPTION
This PR adds the following ports:

- `wget`, seems to work with direct ip's, barring improvements to the experimental tcp implementation, doesn't correctly work with hostnames.
- `curl`, builds, when given an ip or hostname, dies on `inet_pton`
- `patch`, should work out of the box

Furthermore, the following port has been updated
- `ncurses`, the source is now a git repo, and with a nice little patch `ncurses` is now able to produce shared libraries, satisfying various other packages, notably the `curses` module of `python`

This PR is part of #33