### PR TITLE
Made /bin and friends symlinks to their /usr counterparts

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -494,8 +494,14 @@ packages:
     configure: []
     build:
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/bin']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/lib']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/sbin']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/passwd', '@THIS_COLLECT_DIR@/etc']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/group', '@THIS_COLLECT_DIR@/etc']
+      - args: ['ln', '-svf', 'usr/bin', '@THIS_COLLECT_DIR@/bin']
+      - args: ['ln', '-svf', 'usr/lib', '@THIS_COLLECT_DIR@/lib']
+      - args: ['ln', '-svf', 'usr/sbin', '@THIS_COLLECT_DIR@/sbin']
 
   - name: binutils
     from_source: binutils

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1,16 +1,16 @@
 imports:
-  - file: ../src/bootstrap.d/app-admin.yml
-  - file: ../src/bootstrap.d/app-arch.yml
-  - file: ../src/bootstrap.d/app-misc.yml
-  - file: ../src/bootstrap.d/app-shells.yml
-  - file: ../src/bootstrap.d/dev-lang.yml
-  - file: ../src/bootstrap.d/dev-libs.yml
-  - file: ../src/bootstrap.d/dev-util.yml
-  - file: ../src/bootstrap.d/net-misc.yml
-  - file: ../src/bootstrap.d/sys-apps.yml
-  - file: ../src/bootstrap.d/sys-devel.yml
-  - file: ../src/bootstrap.d/sys-libs.yml
-  - file: ../src/bootstrap.d/x11-misc.yml
+  - file: bootstrap.d/app-admin.yml
+  - file: bootstrap.d/app-arch.yml
+  - file: bootstrap.d/app-misc.yml
+  - file: bootstrap.d/app-shells.yml
+  - file: bootstrap.d/dev-lang.yml
+  - file: bootstrap.d/dev-libs.yml
+  - file: bootstrap.d/dev-util.yml
+  - file: bootstrap.d/net-misc.yml
+  - file: bootstrap.d/sys-apps.yml
+  - file: bootstrap.d/sys-devel.yml
+  - file: bootstrap.d/sys-libs.yml
+  - file: bootstrap.d/x11-misc.yml
 
 repository:
   url: 'https://pkgs.managarm.org/nightly'

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -82,10 +82,11 @@ install -s system-root/usr/managarm/bin/thor $dir/boot/managarm/
 cp initrd.cpio $dir/boot/managarm/
 
 # Copy the sysroot.
-mkdir -p $dir/bin $dir/lib $dir/root $dir/usr/bin $dir/usr/lib $dir/var
+mkdir -p $dir/root $dir/usr/bin $dir/usr/lib $dir/var
 mkdir -p $dir/dev $dir/proc $dir/run $dir/sys $dir/tmp $dir/boot/grub
-rsync -a --delete system-root/bin/ $dir/bin
-rsync -a --delete system-root/lib/ $dir/lib
+rsync -a --delete system-root/bin $dir/bin
+rsync -a --delete system-root/lib $dir/lib
+rsync -a --delete system-root/sbin $dir/sbin
 rsync -a --delete system-root/root/ $dir/root
 echo -n "Updating image via rsync..."
 cp $scriptdir/grub.cfg $dir/boot/grub/

--- a/scripts/prepare-sysroot
+++ b/scripts/prepare-sysroot
@@ -5,15 +5,16 @@ if ! [ -d system-root ]; then
 	exit 1
 fi
 
-mkdir -p system-root/{bin,lib,run,etc}
+mkdir -p system-root/{run,etc}
 mkdir -p system-root/root
 mkdir -p system-root/usr
+mkdir -p system-root/usr/lib
 mkdir -p system-root/usr/share
 mkdir -p system-root/usr/share/X11
 mkdir -p system-root/var
 
 # Create some symlinks that are currently required.
-ln -sf /usr/lib/ld.so system-root/lib/ld-init.so
+ln -sf /usr/lib/ld.so system-root/usr/lib/ld-init.so
 
 # Copy stuff from the host system.
 rsync -a /etc/localtime system-root/etc/localtime


### PR DESCRIPTION
This PR makes `/bin`, `/lib` and `/sbin` symlinks to their counterparts in `/usr`
After merging of this PR, existing build environments should do the following to be sure:

- Either mount the image, and remove the `/bin` and `/lib` folders, or remove the image completely and generate a new one,
- Remove the `/bin` and `/lib` folders from the `system-root` directory,
- Run the `prepare-sysroot` script,
- Run `xbstrap install --all` to get the symlinks and needed configuration files,
- Update the image as usual.

After performing the above steps once, they shouldn't be needed any longer, and regular image updating can be resumed.

This PR is blocked on a new xbstrap release ~~which includes managarm/xbstrap#22 and managarm/xbstrap#23~~(both merged)