### PR TITLE
Various ports and updates

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -1,6 +1,5 @@
 packages:
   - name: bzip2
-    default: false
     source:
       subdir: ports
       url: 'https://www.sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz'
@@ -18,30 +17,32 @@ packages:
       - args: ['make', 'clean']
       - args: ['make', 'CC=x86_64-managarm-gcc', 'CFLAGS=-fPIC', '-j@PARALLELISM@']
       - args: ['make', 'PREFIX=@THIS_COLLECT_DIR@/usr', 'install']
+      - args: ['ln', '-sf', 'bzdiff', '@THIS_COLLECT_DIR@/usr/bin/bzcmp']
+      - args: ['ln', '-sf', 'bzgrep', '@THIS_COLLECT_DIR@/usr/bin/bzegrep']
+      - args: ['ln', '-sf', 'bzgrep', '@THIS_COLLECT_DIR@/usr/bin/bzfgrep']
+      - args: ['ln', '-sf', 'bzmore', '@THIS_COLLECT_DIR@/usr/bin/bzless']
 
-  - name: xz-utils
-    default: false
+  - name: gzip
     source:
       subdir: ports
-      git: 'https://git.tukaani.org/xz.git'
-      branch: 'v5.2'
+      git: 'https://git.savannah.gnu.org/git/gzip.git'
+      tag: 'v1.10'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
-        - host-libtool
       regenerate:
-        - args: ['./autogen.sh', '--no-po4a']
+        - args: ['./bootstrap']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
-    pkgs_required:
-      - zlib
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
-        - '--disable-static'
-        - '--disable-nls'
+      - args: 'sed -i s/-Werror//g @THIS_BUILD_DIR@/lib/Makefile'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']
@@ -76,27 +77,29 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
-  - name: gzip
+  - name: xz-utils
+    default: false
     source:
       subdir: ports
-      git: 'https://git.savannah.gnu.org/git/gzip.git'
-      tag: 'v1.10'
+      git: 'https://git.tukaani.org/xz.git'
+      branch: 'v5.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
+        - host-libtool
       regenerate:
-        - args: ['./bootstrap']
-        - args: ['cp',
-            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
-            '@THIS_SOURCE_DIR@/build-aux/']
+        - args: ['./autogen.sh', '--no-po4a']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - zlib
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
-      - args: 'sed -i s/-Werror//g @THIS_BUILD_DIR@/lib/Makefile'
+        - '--disable-static'
+        - '--disable-nls'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/dev-db.yml
+++ b/bootstrap.d/dev-db.yml
@@ -1,0 +1,33 @@
+packages:
+  - name: sqlite
+    default: false
+    source:
+      subdir: 'ports'
+      url: 'https://sqlite.org/2020/sqlite-autoconf-3310100.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'sqlite-autoconf-3310100'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+      - host-libtool
+    pkgs_required:
+      - readline
+      - zlib
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--enable-readline'
+        - 'CFLAGS=-g -O2 -DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_COLUMN_METADATA=1 -DSQLITE_ENABLE_UNLOCK_NOTIFY=1 -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_SECURE_DELETE=1 -DSQLITE_ENABLE_FTS3_TOKENIZER=1'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -24,6 +24,26 @@ tools:
       - args: ['make', 'install']
 
 packages:
+  - name: nasm
+    source:
+      subdir: 'ports'
+      url: 'http://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz'
+      format: 'tar.xz'
+      extract_path: 'nasm-2.14.02'
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: perl-cross
     source:
       subdir: 'ports'
@@ -105,6 +125,40 @@ packages:
           CONFIG_SITE: '@SOURCE_ROOT@/scripts/python-config-site'
           PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'
           PKG_CONFIG_LIBDIR: '@BUILD_ROOT@/system-root/usr/lib/pkgconfig:@BUILD_ROOT@/system-root/usr/share/pkgconfig'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
+  - name: yasm
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/yasm/yasm.git'
+      tag: 'v1.3.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['./autogen.sh']
+        # Disable building two tools only useful on windows
+        - args: ['sed', '-i', 's#) ytasm.*#)#', '@THIS_SOURCE_DIR@/Makefile.in']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/config/']
+    tools_required:
+      - system-gcc
+    configure:
+      # Autogen.sh configures for the host os, distclean and reconfigure for managarm
+      - args: ['make', '-C', '@THIS_SOURCE_DIR@', 'distclean']
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-nls'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -1,37 +1,89 @@
 packages:
-  - name: make
+  - name: bc
     default: false
     source:
       subdir: 'ports'
-      git: 'https://git.savannah.gnu.org/git/make.git'
-      tag: '4.2'
-      tools_required:
-        - host-pkg-config
-        - host-autoconf-v2.69
-        - host-automake-v1.15
-        - host-autoconf-archive
-        - host-libtool
-      regenerate:
-        - args: ['autoreconf', '-v', '-f', '-i']
+      git: 'https://github.com/gavinhoward/bc.git'
+      tag: '2.7.2'
     tools_required:
-      - host-autoconf-v2.69
-      - host-automake-v1.15
-      - host-pkg-config
       - system-gcc
-      - virtual: pkgconfig-for-target
-        triple: x86_64-managarm
     configure:
-      - args:
-        - '@THIS_SOURCE_DIR@/configure'
-        - '--host=x86_64-managarm'
-        - '--prefix=/usr'
-        - '--disable-nls'
-        - '--without-guile'
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+      - args: ['./configure.sh', '-G', '-O3']
+        environ:
+          PREFIX: '/usr'
+          CC: 'x86_64-managarm-gcc'
+          CFLAGS: '-std=c99'
+          GEN_HOST: '0'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: bison
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/git/bison.git'
+      tag: 'v3.6.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['git', 'submodule', 'update', '--init']
+        - args: ['./bootstrap']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+    tools_required:
+      - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--docdir=/usr/share/doc/bison-3.6.2'
+        - '--disable-nls'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: flex
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/westes/flex.git'
+      tag: 'v2.6.4'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--docdir=/usr/share/doc/flex-2.6.4'
+        - '--disable-nls'
+        - '--disable-static'
+        - '--disable-bootstrap'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['touch', '@THIS_BUILD_DIR@/doc/flex.1']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['ln', '-s', 'flex', '@THIS_COLLECT_DIR@/usr/bin/lex']
 
   - name: gettext
     default: false
@@ -87,63 +139,6 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
-  - name: patch
-    default: false
-    source:
-      subdir: 'ports'
-      git: 'https://git.savannah.gnu.org/git/patch.git'
-      tag: 'v2.7.6'
-      tools_required:
-        - host-autoconf-v2.69
-        - host-automake-v1.15
-        - host-libtool
-      regenerate:
-        - args: ['./bootstrap']
-        - args: ['cp',
-            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
-            '@THIS_SOURCE_DIR@/build-aux/']
-    tools_required:
-      - host-autoconf-v2.69
-      - host-automake-v1.15
-      - host-pkg-config
-      - system-gcc
-      - virtual: pkgconfig-for-target
-        triple: x86_64-managarm
-    pkgs_required:
-      - diffutils
-    configure:
-      - args:
-        - '@THIS_SOURCE_DIR@/configure'
-        - '--host=x86_64-managarm'
-        - '--prefix=/usr'
-    build:
-      - args: ['make', '-j@PARALLELISM@']
-      - args: ['make', 'install']
-        environ:
-          DESTDIR: '@THIS_COLLECT_DIR@'
-
-  - name: bc
-    default: false
-    source:
-      subdir: 'ports'
-      git: 'https://github.com/gavinhoward/bc.git'
-      tag: '2.7.2'
-    tools_required:
-      - system-gcc
-    configure:
-      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
-      - args: ['./configure.sh', '-G', '-O3']
-        environ:
-          PREFIX: '/usr'
-          CC: 'x86_64-managarm-gcc'
-          CFLAGS: '-std=c99'
-          GEN_HOST: '0'
-    build:
-      - args: ['make', '-j@PARALLELISM@']
-      - args: ['make', 'install']
-        environ:
-          DESTDIR: '@THIS_COLLECT_DIR@'
-
   - name: m4
     default: false
     source:
@@ -175,6 +170,75 @@ packages:
       - args: 'sed -i s/-Werror//g @THIS_BUILD_DIR@/src/Makefile'
       # This sed disables the building of the documentation
       - args: 'sed -i s/"SUBDIRS = . examples lib src doc checks tests"/"SUBDIRS = . examples lib src checks tests"/ @THIS_BUILD_DIR@/Makefile'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: make
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/git/make.git'
+      tag: '4.2'
+      tools_required:
+        - host-pkg-config
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-autoconf-archive
+        - host-libtool
+      regenerate:
+        - args: ['autoreconf', '-v', '-f', '-i']
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-nls'
+        - '--without-guile'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: patch
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/git/patch.git'
+      tag: 'v2.7.6'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['./bootstrap']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - diffutils
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/x11-base.yml
+++ b/bootstrap.d/x11-base.yml
@@ -1,4 +1,44 @@
 packages:
+  - name: xcb-proto
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/proto/xcbproto.git'
+      tag: 'xcb-proto-1.14'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+      - host-python
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libxau
+      - libxdmcp
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        environ:
+          PYTHON: '@BUILD_ROOT@/tools/host-python/bin/python3.8'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: xorg-proto
     default: false
     source:

--- a/bootstrap.d/x11-base.yml
+++ b/bootstrap.d/x11-base.yml
@@ -10,7 +10,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
       regenerate:
         - args: ['./autogen.sh']
           environ:
@@ -19,7 +19,7 @@ packages:
       - system-gcc
       - host-python
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libxau
       - libxdmcp
@@ -50,7 +50,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
       regenerate:
         - args: ['./autogen.sh']
           environ:
@@ -58,7 +58,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-base.yml
+++ b/bootstrap.d/x11-base.yml
@@ -1,0 +1,34 @@
+packages:
+  - name: xorg-proto
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/proto/xorgproto.git'
+      tag: 'xorgproto-2020.1'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1,3 +1,32 @@
+sources:
+  - name: libxtrans
+    subdir: ports
+    git: 'https://gitlab.freedesktop.org/xorg/lib/libxtrans.git'
+    tag: 'xtrans-1.4.0'
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.11
+      - host-libtool
+      - host-pkg-config
+      - host-util-macros
+    regenerate:
+      - args: ['./autogen.sh']
+        environ:
+          'NOCONFIGURE': 'yes'
+
+tools:
+  - name: host-xtrans
+    exports_aclocal: true
+    from_source: libxtrans
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--prefix=@PREFIX@'
+    compile:
+      - args: ['make', '-j@PARALLELISM@']
+    install:
+      - args: ['make', 'install']
+
 packages:
   - name: libxau
     default: false
@@ -99,6 +128,29 @@ packages:
       - util-macros
       - xorg-proto
       - libxau
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxtrans
+    default: false
+    from_source: libxtrans
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libxcb
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -377,6 +377,44 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxshmfence
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxshmfence.git'
+      tag: 'libxshmfence-1.3'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxtrans
     default: false
     from_source: libxtrans
@@ -394,6 +432,45 @@ packages:
         - '--sysconfdir=/etc'
         - '--localstatedir=/var'
         - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxxf86vm
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxxf86vm.git'
+      tag: 'libXxf86vm-1.1.4'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--disable-malloc0returnsnull'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1,0 +1,71 @@
+packages:
+  - name: libxau
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxau.git'
+      tag: 'libXau-1.0.9'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxdmcp
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxdmcp.git'
+      tag: 'libXdmcp-1.1.3'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libxau
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -146,6 +146,45 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxdamage
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxdamage.git'
+      tag: 'libXdamage-1.1.5'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
+      - libxfixes
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxdmcp
     default: false
     source:

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -259,6 +259,124 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxi
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxi.git'
+      tag: 'libXi-1.7.10'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--disable-malloc0returnsnull'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxrandr
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxrandr.git'
+      tag: 'libXrandr-1.5.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
+      - libxrender
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--disable-malloc0returnsnull'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxrender
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxrender.git'
+      tag: 'libXrender-0.9.10'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--disable-malloc0returnsnull'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxtrans
     default: false
     from_source: libxtrans

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -34,6 +34,49 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxcb
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxcb.git'
+      tag: 'libxcb-1.14'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+      - host-python
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libxau
+      - libxdmcp
+      - xcb-proto
+    configure:
+      - args: ['sed', '-i', "s/pthread-stubs//", '@THIS_SOURCE_DIR@/configure']
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--without-doxygen'
+        environ:
+          PYTHON: '@BUILD_ROOT@/tools/host-python/bin/python3.8'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxdmcp
     default: false
     source:

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -28,6 +28,46 @@ tools:
       - args: ['make', 'install']
 
 packages:
+  - name: libx11
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libx11.git'
+      tag: 'libX11-1.6.9'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-xtrans
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libxcb
+      - libxtrans
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--disable-ipv6'
+        - '--disable-malloc0returnsnull'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+  
   - name: libxau
     default: false
     source:

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -67,7 +67,7 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
-  
+
   - name: libxau
     default: false
     source:
@@ -168,6 +168,83 @@ packages:
       - util-macros
       - xorg-proto
       - libxau
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxext
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxext.git'
+      tag: 'libXext-1.3.4'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--disable-malloc0returnsnull'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxfixes
+    default: false
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxfixes.git'
+      tag: 'libXfixes-5.0.3'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-util-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -8,7 +8,7 @@ sources:
       - host-automake-v1.11
       - host-libtool
       - host-pkg-config
-      - host-util-macros
+      - host-xorg-macros
     regenerate:
       - args: ['./autogen.sh']
         environ:
@@ -39,7 +39,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-xtrans
       regenerate:
         - args: ['./autogen.sh']
@@ -48,7 +48,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libxcb
       - libxtrans
@@ -79,7 +79,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
       regenerate:
         - args: ['./autogen.sh']
           environ:
@@ -87,7 +87,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
     configure:
       - args:
@@ -114,7 +114,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
       regenerate:
         - args: ['./autogen.sh']
           environ:
@@ -123,7 +123,7 @@ packages:
       - system-gcc
       - host-python
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libxau
       - libxdmcp
@@ -157,7 +157,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-autoconf-archive
       regenerate:
         - args: ['./autogen.sh']
@@ -166,7 +166,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
@@ -196,7 +196,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
       regenerate:
         - args: ['./autogen.sh']
           environ:
@@ -204,7 +204,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libxau
     configure:
@@ -232,7 +232,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-autoconf-archive
       regenerate:
         - args: ['./autogen.sh']
@@ -241,7 +241,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
@@ -271,7 +271,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-autoconf-archive
       regenerate:
         - args: ['./autogen.sh']
@@ -280,7 +280,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
@@ -309,7 +309,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-autoconf-archive
       regenerate:
         - args: ['./autogen.sh']
@@ -318,7 +318,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
@@ -348,7 +348,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-autoconf-archive
       regenerate:
         - args: ['./autogen.sh']
@@ -357,7 +357,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
@@ -388,7 +388,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-autoconf-archive
       regenerate:
         - args: ['./autogen.sh']
@@ -397,7 +397,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
@@ -427,7 +427,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-autoconf-archive
       regenerate:
         - args: ['./autogen.sh']
@@ -436,7 +436,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
@@ -460,7 +460,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libxcb
     configure:
@@ -488,7 +488,7 @@ packages:
         - host-automake-v1.11
         - host-libtool
         - host-pkg-config
-        - host-util-macros
+        - host-xorg-macros
         - host-autoconf-archive
       regenerate:
         - args: ['./autogen.sh']
@@ -497,7 +497,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - util-macros
+      - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -1,5 +1,5 @@
 sources:
-  - name: 'util-macros'
+  - name: 'xorg-util-macros'
     subdir: ports
     git: 'https://github.com/freedesktop/xorg-macros.git'
     tag: 'util-macros-1.19.1'
@@ -14,9 +14,9 @@ sources:
           'NOCONFIGURE': 'yes'
 
 tools:
-  - name: host-util-macros
+  - name: host-xorg-macros
     exports_aclocal: true
-    from_source: util-macros
+    from_source: xorg-util-macros
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -62,12 +62,12 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
-  - name: util-macros
+  - name: xorg-util-macros
     default: false
-    from_source: util-macros
+    from_source: xorg-util-macros
     tools_required:
       - system-gcc
-      - host-util-macros
+      - host-xorg-macros
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -1,3 +1,31 @@
+sources:
+  - name: 'util-macros'
+    subdir: ports
+    git: 'https://github.com/freedesktop/xorg-macros.git'
+    tag: 'util-macros-1.19.1'
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.11
+      - host-libtool
+      - host-pkg-config
+    regenerate:
+      - args: ['./autogen.sh']
+        environ:
+          'NOCONFIGURE': 'yes'
+
+tools:
+  - name: host-util-macros
+    exports_aclocal: true
+    from_source: util-macros
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--prefix=@PREFIX@'
+    compile:
+      - args: ['make', '-j@PARALLELISM@']
+    install:
+      - args: ['make', 'install']
+
 packages:
   - name: shared-mime-info
     default: false
@@ -28,6 +56,26 @@ packages:
         - '--disable-update-mimedb'
         environ:  
           'ITSTOOL': '/usr/bin/itstool'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: util-macros
+    default: false
+    from_source: util-macros
+    tools_required:
+      - system-gcc
+      - host-util-macros
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -352,29 +352,6 @@ tools:
     install:
       - args: ['make', 'install']
 
-  - name: host-xorg-macros
-    exports_aclocal: true
-    source:
-      name: xorg-macros
-      subdir: 'ports'
-      git: 'https://gitlab.freedesktop.org/xorg/util/macros.git'
-      tag: 'util-macros-1.19.1'
-      tools_required:
-        - host-autoconf-v2.69
-        - host-automake-v1.11
-      regenerate:
-        - args: ['./autogen.sh']
-          environ:
-            'NOCONFIGURE': 'yes'
-    configure:
-      - args:
-        - '@THIS_SOURCE_DIR@/configure'
-        - '--prefix=@PREFIX@'
-    compile:
-      - args: ['make', '-j@PARALLELISM@']
-    install:
-      - args: ['make', 'install']
-
   - name: kernel-gcc
     from_source: gcc
     tools_required:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -3,6 +3,7 @@ imports:
   - file: bootstrap.d/app-arch.yml
   - file: bootstrap.d/app-misc.yml
   - file: bootstrap.d/app-shells.yml
+  - file: bootstrap.d/dev-db.yml
   - file: bootstrap.d/dev-lang.yml
   - file: bootstrap.d/dev-libs.yml
   - file: bootstrap.d/dev-util.yml
@@ -1386,31 +1387,6 @@ packages:
           PKG_CONFIG_LIBDIR: '@BUILD_ROOT@/system-root/usr/lib/pkgconfig:@BUILD_ROOT@/system-root/usr/share/pkgconfig'
     build:
       - args: ['make', '-j@PARALLELISM@']
-      - args: ['make', 'install']
-        environ:
-          DESTDIR: '@THIS_COLLECT_DIR@'
-        quiet: true
-
-  - name: nasm
-    default: false
-    source:
-      subdir: 'ports'
-      git: 'https://repo.or.cz/nasm.git'
-      tag: 'nasm-2.14.02'
-      tools_required:
-        - host-autoconf-v2.69
-        - host-automake-v1.15
-      regenerate:
-        - args: ['./autogen.sh']
-    tools_required:
-      - system-gcc
-    configure:
-      - args:
-        - '@THIS_SOURCE_DIR@/configure'
-        - '--host=x86_64-managarm'
-        - '--prefix=/usr'
-    build:
-      - args: ['make']
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -11,6 +11,7 @@ imports:
   - file: bootstrap.d/sys-apps.yml
   - file: bootstrap.d/sys-devel.yml
   - file: bootstrap.d/sys-libs.yml
+  - file: bootstrap.d/x11-base.yml
   - file: bootstrap.d/x11-misc.yml
 
 repository:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -12,6 +12,7 @@ imports:
   - file: bootstrap.d/sys-devel.yml
   - file: bootstrap.d/sys-libs.yml
   - file: bootstrap.d/x11-base.yml
+  - file: bootstrap.d/x11-libs.yml
   - file: bootstrap.d/x11-misc.yml
 
 repository:

--- a/patches/xorg-proto/0001-Add-managarm-support.patch
+++ b/patches/xorg-proto/0001-Add-managarm-support.patch
@@ -1,0 +1,26 @@
+From 01cb2161d072623320409597c9031ae2d4e1c14d Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Thu, 4 Jun 2020 16:55:11 +0200
+Subject: [PATCH] Add managarm support
+
+Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+---
+ include/X11/Xos_r.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/X11/Xos_r.h b/include/X11/Xos_r.h
+index f963b64..729d8ee 100644
+--- a/include/X11/Xos_r.h
++++ b/include/X11/Xos_r.h
+@@ -318,7 +318,7 @@ static __inline__ void _Xpw_copyPasswd(_Xgetpwparams p)
+   (_Xos_processUnlock), \
+   (p).pwp )
+ 
+-#elif !defined(_POSIX_THREAD_SAFE_FUNCTIONS) && !defined(__APPLE__)
++#elif !defined(_POSIX_THREAD_SAFE_FUNCTIONS) && !defined(__APPLE__) && !defined(__managarm__)
+ # define X_NEEDS_PWPARAMS
+ typedef struct {
+   struct passwd pws;
+-- 
+2.27.0
+


### PR DESCRIPTION
The following ports are added:
- A bunch of xorg ports, see the relevant commit for details
- `bison`, untested but prints help message when invoked
- `flex`, broken, needs `regcomp()` for even `flex --help` to work (issue managarm/mlibc#98)
- `sqlite`, seems to work
- `yasm`, untested

Furthermore, the following ports received updates
- `bzip2`, fix symlink installation and enable by default
- `nasm`, moved to a tarball to allow compilation and enable by default
- meta: A couple of files have been reordered so that the packages are sorted alphabetically.

This pr is part of #33 