### PR TITLE
ports: Add truetype support to weston

### DIFF
--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -1,0 +1,77 @@
+packages:
+  - name: fontconfig
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/fontconfig/fontconfig'
+      tag: '2.13.92'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+        - args: ['rm', '-f', 'src/fcobjshash.h']
+    pkgs_required:
+      - freetype
+      - libxml
+    tools_required:
+      - system-gcc
+      - host-libtool
+      - host-pkg-config
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-docs'
+        - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--enable-libxml2'
+        environ:
+          PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'
+          PKG_CONFIG_LIBDIR: '@BUILD_ROOT@/system-root/usr/lib/pkgconfig:@BUILD_ROOT@/system-root/usr/share/pkgconfig'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: freetype
+    source:
+      subdir: 'ports'
+      git: 'git://git.sv.nongnu.org/freetype/freetype2.git'
+      tag: 'VER-2-10-2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            NOCONFIGURE: '1'
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/builds/unix/']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      # TODO: Build with harfbuzz once we have it, this does make a circular dependency
+      - bzip2
+      - libpng
+      - zlib
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -28,6 +28,51 @@ tools:
       - args: ['make', 'install']
 
 packages:
+  - name: cairo
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.freedesktop.org/cairo/cairo.git'
+      tag: '1.16.0'
+      tools_required:
+        - host-autoconf-v2.64
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+      - host-autoconf-v2.64
+      - host-automake-v1.11
+      - host-libtool
+      - host-pkg-config
+    pkgs_required:
+      - freetype
+      - fontconfig
+      - libpng
+      - pixman
+    configure:
+      - args:
+        # For now, we build without glesv2 backend as Weston prefers the image backend.
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--disable-xlib'
+        environ:
+          # freetype-config does not support cross-compilation.
+          FREETYPE_CONFIG: 'no'
+          PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'
+          PKG_CONFIG_LIBDIR: '@BUILD_ROOT@/system-root/usr/lib/pkgconfig:@BUILD_ROOT@/system-root/usr/share/pkgconfig'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+  
   - name: libx11
     default: false
     source:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -7,6 +7,7 @@ imports:
   - file: bootstrap.d/dev-lang.yml
   - file: bootstrap.d/dev-libs.yml
   - file: bootstrap.d/dev-util.yml
+  - file: bootstrap.d/media-libs.yml
   - file: bootstrap.d/net-misc.yml
   - file: bootstrap.d/sys-apps.yml
   - file: bootstrap.d/sys-devel.yml


### PR DESCRIPTION
This PR adds support for `freetype` and `fontconfig` in weston and other `cairo` based applications.
Furthermore, it adds `dejavu` fonts to use with this support