### PR TITLE
ports: Add glxgears and friends

### DIFF
--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -76,6 +76,36 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: glu
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.freedesktop.org/mesa/glu.git'
+      tag: 'glu-9.0.1'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            NOCONFIGURE: '1'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mesa
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libepoxy
     source:
       subdir: 'ports'

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -1,4 +1,50 @@
 packages:
+  - name: mesa-demos
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/mesa/demos.git'
+      tag: 'mesa-demos-8.4.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - glu
+      - libx11
+      - libxext
+      - mesa
+      - wayland
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--disable-egl'
+        - '--disable-gles1'
+        - '--disable-gles2'
+        - '--disable-vg'
+        - '--disable-osmesa'
+        - '--disable-libdrm'
+        - '--disable-gbm'
+        - '--disable-freetype2'
+        - '--disable-rbug'
+        - '--with-glut=no'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+  
   - name: xdpyinfo
     source:
       subdir: ports

--- a/patches/mesa-demos/0001-Disable-GLEW-check.patch
+++ b/patches/mesa-demos/0001-Disable-GLEW-check.patch
@@ -1,0 +1,30 @@
+From 8ff022ffe33dbd3c231b5de90bd8e684f3493608 Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Mon, 24 Aug 2020 04:37:54 +0200
+Subject: [PATCH] Disable GLEW check
+
+Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+---
+ configure.ac | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0b5e9a76..d06203df 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -93,9 +93,9 @@ AC_EGREP_HEADER([glutInitContextProfile],
+ 		[])
+ 
+ dnl Check for GLEW
+-PKG_CHECK_MODULES(GLEW, [glew >= 1.5.4])
+-DEMO_CFLAGS="$DEMO_CFLAGS $GLEW_CFLAGS"
+-DEMO_LIBS="$DEMO_LIBS $GLEW_LIBS"
++dnl PKG_CHECK_MODULES(GLEW, [glew >= 1.5.4])
++dnl DEMO_CFLAGS="$DEMO_CFLAGS $GLEW_CFLAGS"
++dnl DEMO_LIBS="$DEMO_LIBS $GLEW_LIBS"
+ 
+ # LIBS was set by AC_CHECK_LIB above
+ LIBS=""
+-- 
+2.28.0
+


### PR DESCRIPTION
This PR adds a basic port of `mesa-progs`, which includes the GLX only version of `glxgears`.
Not all features are enabled to work around the `GLEW` requirement, which we don't have because it has a shitty build system.

The following ports have been added, and enabled by default.
- `GLU`, the Mesa OpenGL Utility Library, a required dependency for `mesa-progs`.
- `mesa-progs`, a collection of demos and tests for mesa, includes the famous `glxgears` program.

This PR is blocked on managarm/mlibc#143
As this PR satisfies the last requirement of #42, this PR closes #42 