### PR TITLE
Add various new ports and enable some stable ports

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -1,3 +1,29 @@
+sources:
+  - name: icu
+    subdir: 'ports'
+    git: 'https://github.com/unicode-org/icu.git'
+    tag: 'release-67-1'
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-libtool
+    regenerate:
+      - args: ['cp',
+          '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+          '@THIS_SOURCE_DIR@/icu4c/source']
+
+tools:
+  - name: host-icu
+    from_source: icu
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/icu4c/source/configure'
+        - '--prefix=@PREFIX@'
+    compile:
+      - args: ['make', '-j@PARALLELISM@']
+    install:
+      - args: ['make', 'install']
+
 packages:
   - name: glib
     source:
@@ -57,6 +83,28 @@ packages:
         - '--enable-cxx'
         - '--disable-static'
         - '--docdir=/usr/share/doc/gmp-6.2.0'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
+  - name: icu
+    default: false
+    from_source: icu
+    tools_required:
+      - system-gcc
+      - host-icu
+    configure:
+      - args: ['cp',
+          '@THIS_SOURCE_DIR@/icu4c/source/config/mh-linux',
+          '@THIS_SOURCE_DIR@/icu4c/source/config/mh-unknown']
+      - args:
+        - '@THIS_SOURCE_DIR@/icu4c/source/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--with-cross-build=@BUILD_ROOT@/tool-builds/host-icu'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/games-board.yml
+++ b/bootstrap.d/games-board.yml
@@ -1,0 +1,36 @@
+packages:
+  - name: ace
+    source:
+      subdir: 'ports'
+      url: 'http://www.delorie.com/store/ace/ace-1.4.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'ace-1.4'
+      patch-path-strip: 1
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['autoreconf', '-f', '-i']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libice
+      - libpng
+      - libx11
+      - zlib
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/games-misc.yml
+++ b/bootstrap.d/games-misc.yml
@@ -1,0 +1,18 @@
+packages:
+  - name: nyancat
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/klange/nyancat.git'
+      tag: '1.5.2'
+    tools_required:
+      - system-gcc
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+        environ:
+          CC: "x86_64-managarm-gcc"
+      - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/bin']
+      - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/share/man/man1']
+      - args: ['cp', '-v', '@THIS_BUILD_DIR@/src/nyancat', '@THIS_COLLECT_DIR@/usr/bin']
+      - args: ['cp', '-v', '@THIS_BUILD_DIR@/nyancat.1', '@THIS_COLLECT_DIR@/usr/share/man/man1']

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -40,6 +40,35 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: freeglut
+    source:
+      subdir: 'ports'
+      url: 'https://downloads.sourceforge.net/freeglut/freeglut-3.2.1.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'freeglut-3.2.1'
+    tools_required:
+      - host-cmake
+      - system-gcc
+    pkgs_required:
+      - libxi
+      - mesa
+      - glu
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DBUILD_SHARED_LIBS=ON'
+        - '-DFREEGLUT_BUILD_DEMOS=OFF'
+        - '-DFREEGLUT_BUILD_STATIC_LIBS=OFF'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: freetype
     source:
       subdir: 'ports'

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -43,6 +43,45 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: xclock
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/app/xclock.git'
+      tag: 'xclock-1.0.9'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-xorg-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libx11
+      - libxmu
+      - libxaw
+      - libxrender
+      - libxft
+      - libxt
+      - libxkbfile
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-selective-werror' # strncasecmp
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: xdpyinfo
     source:
       subdir: ports

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -85,7 +85,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: xdriinfo
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xdriinfo.git'
@@ -103,6 +102,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mesa
       - xorg-util-macros
       - libx11
     configure:
@@ -153,7 +153,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: xkill
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xkill.git'
@@ -189,7 +188,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: xlsclients
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xlsclients.git'
@@ -223,7 +221,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: xwininfo
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xwininfo.git'
@@ -245,7 +242,6 @@ packages:
       - xorg-util-macros
       - libx11
       - xcb-util
-      #- xcb-util-wm
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -16,6 +16,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - freeglut
       - freetype
       - glew
       - glu
@@ -36,7 +37,7 @@ packages:
         - '--disable-vg'
         - '--disable-osmesa'
         - '--disable-rbug'
-        - '--with-glut=no'
+        - '--with-system-data-files'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -306,6 +306,45 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxaw
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxaw.git'
+      tag: 'libXaw-1.0.13'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-xorg-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - xorg-util-macros
+      - xorg-proto
+      - libx11
+      - libxext
+      - libxt
+      - libxmu
+      - libxpm
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxcb
     source:
       subdir: ports
@@ -698,6 +737,43 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxpm
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxpm.git'
+      tag: 'libXpm-3.5.13'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-xorg-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - xorg-util-macros
+      - xorg-proto
+      - libx11
+      - libxext
+      - libxt
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxrandr
     source:
       subdir: ports
@@ -968,7 +1044,7 @@ packages:
         - host-xorg-macros
         - host-autoconf-archive
       regenerate:
-        - args: ['git', 'submodule', 'update', '--init']
+        - args: ['git', 'submodule', 'upate', '--init']
         - args: ['./autogen.sh']
           environ:
             'NOCONFIGURE': 'yes'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -660,7 +660,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: libxmu
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxmu.git'
@@ -957,7 +956,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: xcb-util
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxcb-util.git'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -154,7 +154,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: libice
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libice.git'
@@ -193,7 +192,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: libsm
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libsm.git'
@@ -890,7 +888,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: libxt
-    default: false
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxt.git'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -8,6 +8,7 @@ imports:
   - file: bootstrap.d/dev-lang.yml
   - file: bootstrap.d/dev-libs.yml
   - file: bootstrap.d/dev-util.yml
+  - file: bootstrap.d/games-misc.yml
   - file: bootstrap.d/media-fonts.yml
   - file: bootstrap.d/media-libs.yml
   - file: bootstrap.d/net-misc.yml

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -8,6 +8,7 @@ imports:
   - file: bootstrap.d/dev-lang.yml
   - file: bootstrap.d/dev-libs.yml
   - file: bootstrap.d/dev-util.yml
+  - file: bootstrap.d/games-board.yml
   - file: bootstrap.d/games-misc.yml
   - file: bootstrap.d/media-fonts.yml
   - file: bootstrap.d/media-libs.yml

--- a/patches/ace/ace-1.4-libpng15.patch
+++ b/patches/ace/ace-1.4-libpng15.patch
@@ -1,0 +1,29 @@
+--- a/lib/make-imglib.c
++++ b/lib/make-imglib.c
+@@ -86,7 +86,7 @@
+     png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, 0, 0, 0);
+     info_ptr = png_create_info_struct (png_ptr);
+ 
+-    if (setjmp (png_ptr->jmpbuf)) {
++    if (setjmp (png_jmpbuf(png_ptr))) {
+       fclose (f);
+       continue;
+     }
+--- a/lib/xwin.c
++++ b/lib/xwin.c
+@@ -824,13 +824,13 @@
+   png_ptr = png_create_read_struct (PNG_LIBPNG_VER_STRING, 0, 0, 0);
+   info_ptr = png_create_info_struct (png_ptr);
+ 
+-  if (setjmp (png_ptr->jmpbuf)) {
++  if (setjmp (png_jmpbuf(png_ptr))) {
+     fprintf(stderr, "Invalid PNG image!\n");
+     return;
+   }
+ 
+   file_bytes = src->file_data;
+-  png_set_read_fn (png_ptr, (voidp)&file_bytes, (png_rw_ptr)png_reader);
++  png_set_read_fn (png_ptr, (png_voidp)&file_bytes, (png_rw_ptr)png_reader);
+ 
+   png_read_info (png_ptr, info_ptr);
+ 

--- a/patches/libxaw/0001-Specific-managarm-changes.patch
+++ b/patches/libxaw/0001-Specific-managarm-changes.patch
@@ -1,0 +1,39 @@
+From 3443eb6794078abd8621b4e1e5e21c71b11520e6 Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Sun, 26 Jul 2020 00:43:45 +0200
+Subject: [PATCH] Specific managarm changes
+
+Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+---
+ src/TextAction.c | 1 +
+ src/XawI18n.h    | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/TextAction.c b/src/TextAction.c
+index 6363259..d1e922a 100644
+--- a/src/TextAction.c
++++ b/src/TextAction.c
+@@ -45,6 +45,7 @@ in this Software without prior written authorization from The Open Group.
+ #include <X11/Xaw/TextP.h>
+ #include <X11/Xaw/TextSrcP.h>
+ #include <X11/Xaw/XawImP.h>
++#include <sys/select.h>
+ #include "Private.h"
+ #include "XawI18n.h"
+ 
+diff --git a/src/XawI18n.h b/src/XawI18n.h
+index d50171c..93a05aa 100644
+--- a/src/XawI18n.h
++++ b/src/XawI18n.h
+@@ -38,7 +38,7 @@ in this Software without prior written authorization from The Open Group.
+ #include <wchar.h>
+ #endif
+ 
+-#if defined(AIXV3) || defined(__SCO__)
++#if defined(AIXV3) || defined(__SCO__) || defined(__managarm__)
+ #include <ctype.h>
+ #endif
+ 
+-- 
+2.28.0.rc2
+

--- a/patches/nyancat/0001-Add-managarm-support.patch
+++ b/patches/nyancat/0001-Add-managarm-support.patch
@@ -1,0 +1,26 @@
+From e0b906a500bbbb7e58687a2a0af6bd3f626608e1 Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Thu, 2 Jul 2020 10:01:43 +0200
+Subject: [PATCH] Add managarm support
+
+Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+---
+ src/nyancat.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/nyancat.c b/src/nyancat.c
+index 537225c..17ddfaf 100644
+--- a/src/nyancat.c
++++ b/src/nyancat.c
+@@ -67,7 +67,7 @@
+ 
+ #include <sys/ioctl.h>
+ 
+-#ifndef TIOCGWINSZ
++#if !defined TIOCGWINSZ || defined(__managarm__)
+ #include <termios.h>
+ #endif
+ 
+-- 
+2.28.0
+


### PR DESCRIPTION
This PR adds the following new ports:

- `ace`, `ace` is a collection of card games, like solitaire, built upon the X libraries. This port is enabled by default.
- `freeglut`, `freeglut` is a 100% open sourced clone of the GLUT library. This port is used by `mesa-progs` and enabled by default.
- `icu`, provides unicode support to applications.
- `libXaw`, a dependency for `xclock`, enabled by default.
- `libXpm`, a dependency for `libXaw`, enabled by default.
- `nyancat`, the classic nyancat as used in debian. Written by klange and enabled by default.
- `xclock`, a small graphical clock, enabled by default.

Furthermore, the following ports received updates:

- `libICE`, enabled by default.
- `libSM`, enabled by default.
- `libXmu`, enabled by default.
- `libXt`, enabled by default.
- `mesa-progs`, updated dependency list, use freeglut and make the programs aware of the system-wide data files.
- `xcb-util`, enabled by default.
- `xdriinfo`, enabled by default.
- `xkill`, enabled by default.
- `xlsclients`, enabled by default.
- `xwininfo`, enabled by default.

This PR is blocked on managarm/mlibc#144