### PR TITLE
Add version info to nearly all packages

### DIFF
--- a/bootstrap.d/app-admin.yml
+++ b/bootstrap.d/app-admin.yml
@@ -5,6 +5,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/troglobit/sysklogd.git'
       tag: 'v2.1.2'
+      version: '2.1.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -5,6 +5,7 @@ packages:
       url: 'https://www.sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz'
       format: 'tar.gz'
       extract_path: 'bzip2-1.0.8'
+      version: '1.0.8'
     tools_required:
       - system-gcc
     configure:
@@ -27,6 +28,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gzip.git'
       tag: 'v1.10'
+      version: '1.10'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -54,6 +56,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/libarchive/libarchive.git'
       tag: 'v3.4.3'
+      version: '3.4.3'
     tools_required:
       - host-cmake
       - system-gcc
@@ -76,6 +79,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/tar.git'
       tag: 'release_1_32'
+      version: '1.32'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -105,6 +109,7 @@ packages:
       subdir: ports
       git: 'https://git.tukaani.org/xz.git'
       branch: 'v5.2'
+      version: '5.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -4,6 +4,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/nano.git'
       tag: 'v5.2'
+      version: '5.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -44,6 +45,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/vim/vim.git'
       tag: 'v8.1.1802'
+      version: '8.1.1802'
     tools_required:
       - system-gcc
       - host-pkg-config

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -4,6 +4,8 @@ packages:
       subdir: ports
       git: 'https://github.com/mtoyoda/sl.git'
       branch: 'master'
+      # While we build directly from master, the Makefile suggests version 5.03.
+      version: '5.03'
     tools_required:
       - system-gcc
     pkgs_required:

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -3,8 +3,7 @@ packages:
     source:
       subdir: ports
       git: 'https://github.com/mtoyoda/sl.git'
-      branch: 'master'
-      # While we build directly from master, the Makefile suggests version 5.03.
+      commit: '923e7d7ebc5c1f009755bdeb789ac25658ccce03'
       version: '5.03'
     tools_required:
       - system-gcc

--- a/bootstrap.d/app-shells.yml
+++ b/bootstrap.d/app-shells.yml
@@ -4,6 +4,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/r/bash.git'
       tag: 'bash-4.4'
+      version: '4.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/dev-db.yml
+++ b/bootstrap.d/dev-db.yml
@@ -6,6 +6,7 @@ packages:
       url: 'https://sqlite.org/2020/sqlite-autoconf-3310100.tar.gz'
       format: 'tar.gz'
       extract_path: 'sqlite-autoconf-3310100'
+      version: '3.31.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -3,6 +3,7 @@ sources:
     subdir: 'ports'
     git: 'https://github.com/python/cpython.git'
     tag: 'v3.8.2'
+    version: '3.8.2'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -30,6 +31,7 @@ packages:
       url: 'http://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz'
       format: 'tar.xz'
       extract_path: 'nasm-2.14.02'
+      version: '2.14.02'
     tools_required:
       - system-gcc
     configure:
@@ -49,6 +51,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/arsv/perl-cross.git'
       tag: '1.3.3'
+      version: '1.3.3'
       sources_required:
         - perl
       regenerate:
@@ -62,6 +65,7 @@ packages:
       subdir: ports
       git: 'https://github.com/Perl/perl5.git'
       tag: 'v5.30.2'
+      version: '5.30.2'
     tools_required:
       - system-gcc
     pkgs_required:
@@ -140,6 +144,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/yasm/yasm.git'
       tag: 'v1.3.0'
+      version: '1.3.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -3,6 +3,7 @@ sources:
     subdir: 'ports'
     git: 'https://github.com/unicode-org/icu.git'
     tag: 'release-67-1'
+    version: '67.1'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -30,6 +31,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.gnome.org/GNOME/glib'
       tag: '2.59.2'
+      version: '2.59.2'
     tools_required:
       - system-gcc
       - host-libtool
@@ -63,6 +65,7 @@ packages:
       subdir: 'ports'
       hg: 'https://gmplib.org/repo/gmp-6.2/'
       tag: 'tip'
+      version: '6.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -117,6 +120,7 @@ packages:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/libevdev/libevdev.git'
       tag: 'libevdev-1.9.1'
+      version: '1.9.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -146,6 +150,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/libexpat/libexpat.git'
       tag: 'R_2_2_9'
+      version: '2.2.9'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -178,6 +183,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/libffi/libffi.git'
       tag: 'v3.3'
+      version: '3.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -208,6 +214,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/gpg/libgcrypt.git'
       tag: 'libgcrypt-1.8.5'
+      version: '1.8.5'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -246,6 +253,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/gpg/libgpg-error.git'
       tag: 'libgpg-error-1.37'
+      version: '1.37'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -279,6 +287,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/wayland-project/libinput.git'
       tag: '1.10.7'
+      version: '1.10.7'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -314,6 +323,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/libpipeline.git'
       tag: '1.5.2'
+      version: '1.5.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -342,6 +352,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.gnome.org/GNOME/libxml2.git'
       tag: 'v2.9.10'
+      version: '2.9.10'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -377,6 +388,7 @@ packages:
       subdir: ports
       git: 'https://scm.gforge.inria.fr/anonscm/git/mpc/mpc.git'
       tag: '1.1.0'
+      version: '1.1.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -408,6 +420,7 @@ packages:
       url: 'https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz'
       format: 'tar.xz'
       extract_path: 'mpfr-4.0.2'
+      version: '4.0.2'
       tools_required:
         - host-autoconf-archive
         - host-autoconf-v2.69
@@ -445,6 +458,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.lysator.liu.se/nettle/nettle.git'
       tag: 'nettle_3.6_release_20200429'
+      version: '3.6'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -479,6 +493,8 @@ packages:
       subdir: ports
       svn: 'svn://vcs.pcre.org/pcre/code/trunk'
       rev: '1764'
+      # Seems to be 8.44?
+      version: '8.44'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -513,6 +529,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/wayland-project/weston.git'
       tag: '4.0.0'
+      version: '4.0.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/dev-util.yml
+++ b/bootstrap.d/dev-util.yml
@@ -3,6 +3,7 @@ sources:
     subdir: 'ports'
     git: 'https://gitlab.freedesktop.org/pkg-config/pkg-config.git'
     tag: 'pkg-config-0.29.2'
+    version: '0.29.2'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.11
@@ -29,37 +30,12 @@ tools:
       - args: ['make', 'install']
 
 packages:
-  - name: itstool
-    default: false
-    source:
-      subdir: ports
-      url: 'http://files.itstool.org/itstool/itstool-2.0.6.tar.bz2'
-      format: 'tar.bz2'
-      extract_path: 'itstool-2.0.6'
-    tools_required:
-      - system-gcc
-      - host-python
-    pkgs_required:
-      - libxml
-      - python
-    configure:
-      - args:
-        - '@THIS_SOURCE_DIR@/configure'
-        - '--host=x86_64-managarm'
-        - '--prefix=/usr'
-        environ:  
-          'PYTHON': '/usr/bin/python3'
-    build:
-      - args: ['make', '-j@PARALLELISM@']
-      - args: ['make', 'install']
-        environ:
-          DESTDIR: '@THIS_COLLECT_DIR@'
-
   - name: desktop-file-utils
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xdg/desktop-file-utils.git'
       tag: '0.24'
+      version: '0.24'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -80,6 +56,33 @@ packages:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+  
+  - name: itstool
+    default: false
+    source:
+      subdir: ports
+      url: 'http://files.itstool.org/itstool/itstool-2.0.6.tar.bz2'
+      format: 'tar.bz2'
+      extract_path: 'itstool-2.0.6'
+      version: '2.0.6'
+    tools_required:
+      - system-gcc
+      - host-python
+    pkgs_required:
+      - libxml
+      - python
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        environ:  
+          'PYTHON': '/usr/bin/python3'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/games-board.yml
+++ b/bootstrap.d/games-board.yml
@@ -6,6 +6,7 @@ packages:
       format: 'tar.gz'
       extract_path: 'ace-1.4'
       patch-path-strip: 1
+      version: '1.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/games-misc.yml
+++ b/bootstrap.d/games-misc.yml
@@ -4,6 +4,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/klange/nyancat.git'
       tag: '1.5.2'
+      version: '1.5.2'
     tools_required:
       - system-gcc
     configure:

--- a/bootstrap.d/media-fonts.yml
+++ b/bootstrap.d/media-fonts.yml
@@ -3,6 +3,7 @@ sources:
     subdir: 'ports'
     git: 'https://gitlab.freedesktop.org/xorg/font/util.git'
     tag: 'font-util-1.3.2'
+    version: '1.3.2'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -34,6 +35,7 @@ packages:
       url: 'http://sourceforge.net/projects/dejavu/files/dejavu/2.37/dejavu-fonts-ttf-2.37.tar.bz2'
       format: 'tar.bz2'
       extract_path: 'dejavu-fonts-ttf-2.37'
+      version: '2.37'
     pkgs_required:
       - freetype
       - fontconfig

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -4,6 +4,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/fontconfig/fontconfig'
       tag: '2.13.92'
+      version: '2.13.92'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -46,6 +47,7 @@ packages:
       url: 'https://downloads.sourceforge.net/freeglut/freeglut-3.2.1.tar.gz'
       format: 'tar.gz'
       extract_path: 'freeglut-3.2.1'
+      version: '3.2.1'
     tools_required:
       - host-cmake
       - system-gcc
@@ -74,6 +76,7 @@ packages:
       subdir: 'ports'
       git: 'git://git.sv.nongnu.org/freetype/freetype2.git'
       tag: 'VER-2-10-2'
+      version: '2.10.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -111,6 +114,7 @@ packages:
       url: 'https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz'
       format: 'tar.gz'
       extract_path: 'glew-2.1.0'
+      version: '2.1.0'
     tools_required:
       - system-gcc
     pkgs_required:
@@ -138,6 +142,7 @@ packages:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/mesa/glu.git'
       tag: 'glu-9.0.1'
+      version: '9.0.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -169,6 +174,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/anholt/libepoxy.git'
       tag: '1.5.4'
+      version: '1.5.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -207,6 +213,7 @@ packages:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/mesa/mesa.git'
       tag: 'mesa-20.0.5'
+      version: '20.0.5'
       tools_required:
         - host-pkg-config
     tools_required:

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -1,10 +1,62 @@
 packages:
+  - name: curl
+    default: false
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/curl/curl.git'
+      tag: 'curl-7_70_0'
+      version: '7.70.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./buildconf']
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - libressl
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-ipv6'
+        - '--disable-static'
+        - '--with-ca-path=/etc/ssl/certs'
+        - '--enable-threaded-resolver'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: iana-etc
+    source:
+      subdir: ports
+      url: 'http://anduin.linuxfromscratch.org/LFS/iana-etc-2.30.tar.bz2'
+      format: 'tar.bz2'
+      extract_path: 'iana-etc-2.30'
+      version: '2.30'
+    tools_required:
+      - system-gcc
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
+
   - name: socat
     default: false
     source:
       subdir: 'ports'
       git: 'git://repo.or.cz/socat.git'
       tag: 'tag-1.7.3.4'
+      version: '1.7.3.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -42,6 +94,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/wget.git'
       tag: 'v1.20.3'
+      version: '1.20.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -74,52 +127,3 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
-
-  - name: curl
-    default: false
-    source:
-      subdir: 'ports'
-      git: 'https://github.com/curl/curl.git'
-      tag: 'curl-7_70_0'
-      tools_required:
-        - host-autoconf-v2.69
-        - host-automake-v1.15
-        - host-libtool
-        - host-autoconf-archive
-      regenerate:
-        - args: ['./buildconf']
-    tools_required:
-      - host-pkg-config
-      - system-gcc
-      - virtual: pkgconfig-for-target
-        triple: x86_64-managarm
-    pkgs_required:
-      - libressl
-    configure:
-      - args:
-        - '@THIS_SOURCE_DIR@/configure'
-        - '--host=x86_64-managarm'
-        - '--prefix=/usr'
-        - '--disable-ipv6'
-        - '--disable-static'
-        - '--with-ca-path=/etc/ssl/certs'
-        - '--enable-threaded-resolver'
-    build:
-      - args: ['make', '-j@PARALLELISM@']
-      - args: ['make', 'install']
-        environ:
-          DESTDIR: '@THIS_COLLECT_DIR@'
-
-  - name: iana-etc
-    source:
-      subdir: ports
-      url: 'http://anduin.linuxfromscratch.org/LFS/iana-etc-2.30.tar.bz2'
-      format: 'tar.bz2'
-      extract_path: 'iana-etc-2.30'
-    tools_required:
-      - system-gcc
-    configure:
-      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
-    build:
-      - args: ['make', '-j@PARALLELISM@']
-      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -3,6 +3,7 @@ sources:
     subdir: ports
     git: 'https://github.com/file/file.git'
     tag: 'FILE5_39'
+    version: '5.39'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -28,6 +29,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/r/coreutils.git'
       tag: 'v8.32'
+      version: '8.32'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -67,6 +69,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/diffutils.git'
       tag: 'v3.7'
+      version: '3.7'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -117,6 +120,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/findutils.git'
       tag: 'v4.7.0'
+      version: '4.7.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -146,6 +150,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gawk.git'
       tag: 'gawk-4.2.1'
+      version: '4.2.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -176,6 +181,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/grep.git'
       tag: 'v3.4-almost'
+      version: '3.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -207,6 +213,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/groff.git'
       tag: '1.22.4'
+      version: '1.22.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -244,6 +251,7 @@ packages:
       url: 'http://www.greenwoodsoftware.com/less/less-551.tar.gz'
       format: 'tar.gz'
       extract_path: 'less-551'
+      version: '551'
     tools_required:
       - system-gcc
     pkgs_required:
@@ -264,6 +272,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/man-db.git'
       tag: '2.9.1'
+      version: '2.9.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -329,6 +338,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/sed.git'
       tag: 'v4.8'
+      version: '4.8'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -357,6 +367,7 @@ packages:
       url: 'https://ftp.gnu.org/gnu/which/which-2.21.tar.gz'
       format: 'tar.gz'
       extract_path: 'which-2.21'
+      version: '2.21'
     tools_required:
       - system-gcc
     configure:
@@ -375,6 +386,7 @@ packages:
       subdir: ports
       git: 'https://github.com/void-linux/xbps.git'
       tag: '0.59.1'
+      version: '0.59.1'
       tools_required:
         - host-pkg-config
     tools_required:

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -3,6 +3,7 @@ sources:
     subdir: 'ports'
     git: 'https://git.savannah.gnu.org/git/bison.git'
     tag: 'v3.6.2'
+    version: '3.6.2'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -66,6 +67,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/gavinhoward/bc.git'
       tag: '2.7.2'
+      version: '2.7.2'
     tools_required:
       - system-gcc
     configure:
@@ -108,6 +110,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/westes/flex.git'
       tag: 'v2.6.4'
+      version: '2.6.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -168,6 +171,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/m4.git'
       tag: 'v1.4.18'
+      version: '1.4.18'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -205,6 +209,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/make.git'
       tag: '4.2'
+      version: '4.2'
       tools_required:
         - host-pkg-config
         - host-autoconf-v2.69
@@ -239,6 +244,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/patch.git'
       tag: 'v2.7.6'
+      version: '2.7.6'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -5,6 +5,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gdbm.git'
       tag: 'v1.18.1'
+      version: '1.18.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -34,6 +35,7 @@ packages:
       git: 'https://bitmath.org/git/mtdev.git'
       disable_shallow_fetch: true
       tag: 'v1.1.6'
+      version: '1.1.6'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -60,6 +62,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/ThomasDickey/ncurses-snapshots.git'
       tag: 'v6_1'
+      version: '6.1'
     tools_required:
       - system-gcc
     configure:
@@ -83,6 +86,7 @@ packages:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/readline.git'
       tag: 'readline-8.0'
+      version: '8.0'
     tools_required:
       - system-gcc
     pkgs_required:

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -4,6 +4,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/mesa/demos.git'
       tag: 'mesa-demos-8.4.0'
+      version: '8.4.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -49,6 +50,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xclock.git'
       tag: 'xclock-1.0.9'
+      version: '1.0.9'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -89,6 +91,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xdpyinfo.git'
       tag: 'xdpyinfo-1.3.2'
+      version: '1.3.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -130,6 +133,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xdriinfo.git'
       tag: 'xdriinfo-1.0.6'
+      version: '1.0.6'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -164,6 +168,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xkbcomp.git'
       tag: 'xkbcomp-1.4.3'
+      version: '1.4.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -198,6 +203,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xkill.git'
       tag: 'xkill-1.0.5'
+      version: '1.0.5'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -233,6 +239,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xlsclients.git'
       tag: 'xlsclients-1.1.4'
+      version: '1.1.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -266,6 +273,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/app/xwininfo.git'
       tag: 'xwininfo-1.1.5'
+      version: '1.1.5'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11

--- a/bootstrap.d/x11-base.yml
+++ b/bootstrap.d/x11-base.yml
@@ -4,6 +4,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/proto/xcbproto.git'
       tag: 'xcb-proto-1.14'
+      version: '1.14'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -43,6 +44,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/proto/xorgproto.git'
       tag: 'xorgproto-2020.1'
+      version: '2020.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -76,6 +78,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/xserver.git'
       tag: 'xorg-server-1.20.8'
+      version: '1.20.8'
     tools_required:
       - system-gcc
       - wayland-scanner

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -3,6 +3,7 @@ sources:
     subdir: ports
     git: 'https://gitlab.freedesktop.org/xorg/lib/libxtrans.git'
     tag: 'xtrans-1.4.0'
+    version: '1.4.0'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.11
@@ -33,6 +34,7 @@ packages:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/cairo/cairo.git'
       tag: '1.16.0'
+      version: '1.16.0'
       tools_required:
         - host-autoconf-v2.64
         - host-automake-v1.11
@@ -79,6 +81,7 @@ packages:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/mesa/drm'
       tag: 'libdrm-2.4.89'
+      version: '2.4.89'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -117,6 +120,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libfontenc.git'
       tag: 'libfontenc-1.1.4'
+      version: '1.1.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -159,6 +163,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libice.git'
       tag: 'libICE-1.0.10'
+      version: '1.0.10'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -197,6 +202,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libsm.git'
       tag: 'libSM-1.2.3'
+      version: '1.2.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -236,6 +242,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libx11.git'
       tag: 'libX11-1.6.9'
+      version: '1.6.9'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -276,6 +283,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxau.git'
       tag: 'libXau-1.0.9'
+      version: '1.0.9'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -310,6 +318,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxaw.git'
       tag: 'libXaw-1.0.13'
+      version: '1.0.13'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -349,6 +358,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxcb.git'
       tag: 'libxcb-1.14'
+      version: '1.14'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -391,6 +401,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxcursor.git'
       tag: 'libXcursor-1.2.0'
+      version: '1.2.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -428,6 +439,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxdamage.git'
       tag: 'libXdamage-1.1.5'
+      version: '1.1.5'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -466,6 +478,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxdmcp.git'
       tag: 'libXdmcp-1.1.3'
+      version: '1.1.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -501,6 +514,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxext.git'
       tag: 'libXext-1.3.4'
+      version: '1.3.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -539,6 +553,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxfixes.git'
       tag: 'libXfixes-5.0.3'
+      version: '5.0.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -576,6 +591,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxfont.git'
       tag: 'libXfont2-2.0.4'
+      version: '2.0.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -626,6 +642,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxft.git'
       tag: 'libXft-2.3.3'
+      version: '2.3.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -664,6 +681,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxi.git'
       tag: 'libXi-1.7.10'
+      version: '1.7.10'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -704,6 +722,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxkbfile.git'
       tag: 'libxkbfile-1.1.0'
+      version: '1.1.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -740,6 +759,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxmu.git'
       tag: 'libXmu-1.1.3'
+      version: '1.1.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -780,6 +800,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxpm.git'
       tag: 'libXpm-3.5.13'
+      version: '3.5.13'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -817,6 +838,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxrandr.git'
       tag: 'libXrandr-1.5.2'
+      version: '1.5.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -857,6 +879,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxrender.git'
       tag: 'libXrender-0.9.10'
+      version: '0.9.10'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -895,6 +918,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxshmfence.git'
       tag: 'libxshmfence-1.3'
+      version: '1.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -932,6 +956,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxt.git'
       tag: 'libXt-1.2.0'
+      version: '1.2.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -995,6 +1020,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxtst.git'
       tag: 'libXtst-1.2.3'
+      version: '1.2.3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -1034,6 +1060,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxxf86vm.git'
       tag: 'libXxf86vm-1.1.4'
+      version: '1.1.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -1073,6 +1100,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxcb-util.git'
       tag: '0.4.0'
+      version: '0.4.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -3,6 +3,7 @@ sources:
     subdir: ports
     git: 'https://github.com/freedesktop/xorg-macros.git'
     tag: 'util-macros-1.19.1'
+    version: '1.19.1'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.11
@@ -33,6 +34,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xdg/shared-mime-info.git'
       tag: 'Release-1-15'
+      version: '1.15'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -68,6 +70,7 @@ packages:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/data/bitmaps.git'
       tag: 'xbitmaps-1.1.2'
+      version: '1.1.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -100,6 +103,7 @@ packages:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config.git'
       tag: 'xkeyboard-config-2.30'
+      version: '2.30'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -33,6 +33,7 @@ sources:
     subdir: 'ports'
     git: 'git://sourceware.org/git/binutils-gdb.git'
     tag: 'binutils-2_32'
+    version: '2.32'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -64,11 +65,13 @@ sources:
     subdir: 'ports'
     git: 'https://github.com/llvm/llvm-project'
     tag: 'llvmorg-10.0.0'
+    version: '10.0.0'
 
   - name: gcc
     subdir: 'ports'
     git: 'git://gcc.gnu.org/git/gcc.git'
     tag: 'releases/gcc-9.2.0'
+    version: '9.2.0'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.11
@@ -82,6 +85,7 @@ sources:
     subdir: 'ports'
     git: 'https://github.com/google/protobuf.git'
     tag: 'v3.1.0'
+    version: '3.1.0'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.11
@@ -133,6 +137,7 @@ sources:
     subdir: 'ports'
     git: 'https://github.com/wayland-project/wayland.git'
     tag: '1.17.0'
+    version: '1.17.0'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -151,6 +156,7 @@ tools:
       url: 'https://ftp.gnu.org/gnu/autoconf/autoconf-2.64.tar.xz'
       format: 'tar.xz'
       extract_path: 'autoconf-2.64'
+      version: '2.64'
     configure:
       # Despite its efforts to be POSIX-compatible, autoconf 2.64 fails to configure on dash
       # (as it assumes that echo does not evaluate backslash escapes).
@@ -172,6 +178,7 @@ tools:
       url: 'https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.xz'
       format: 'tar.xz'
       extract_path: 'autoconf-2.69'
+      version: '2.69'
     configure:
       - args: ['@THIS_SOURCE_DIR@/configure', '--prefix=@PREFIX@']
     compile:
@@ -185,6 +192,7 @@ tools:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/r/automake.git'
       tag: 'v1.11.6'
+      version: '1.11.6'
       tools_required:
         - host-autoconf-v2.69
       regenerate:
@@ -209,20 +217,22 @@ tools:
       subdir: 'ports'
       git: 'https://github.com/autoconf-archive/autoconf-archive.git'
       tag: 'v2019.01.06'
+      version: '2019.01.06'
     install:
       - args: ['mkdir', '-p', '@BUILD_ROOT@/tools/host-autoconf-archive/share/']
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/m4', '@BUILD_ROOT@/tools/host-autoconf-archive/share/aclocal']
 
   - name: host-automake-v1.15
     source:
-        name: automake-v1.15
-        subdir: 'ports'
-        git: 'https://git.savannah.gnu.org/r/automake.git'
-        tag: 'v1.15.1'
-        tools_required:
-          - host-autoconf-v2.69
-        regenerate:
-          - args: ['./bootstrap']
+      name: automake-v1.15
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/r/automake.git'
+      tag: 'v1.15.1'
+      version: '1.15.1'
+      tools_required:
+        - host-autoconf-v2.69
+      regenerate:
+        - args: ['./bootstrap']
     tools_required:
       - host-autoconf-v2.69
     configure:
@@ -271,6 +281,7 @@ tools:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/r/libtool.git'
       tag: 'v2.4.5'
+      version: '2.4.5'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -349,6 +360,7 @@ tools:
       subdir: 'ports'
       git: 'https://gitlab.kitware.com/cmake/cmake.git'
       tag: 'v3.14.5'
+      version: '3.14.5'
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/bootstrap'
@@ -544,6 +556,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/boostorg/boost.git'
       tag: 'boost-1.62.0'
+      version: '1.62.0'
       regenerate:
         - args: |
             if ! git -C '@THIS_SOURCE_DIR@' remote | grep -q origin; then
@@ -652,6 +665,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/gentoo/eudev.git'
       tag: 'v3.2.2'
+      version: '3.2.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -731,6 +745,7 @@ packages:
       subdir: 'ports'
       git: 'https://git.code.sf.net/p/libpng/code'
       tag: 'v1.6.34'
+      version: '1.6.34'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -760,6 +775,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/libressl-portable/portable.git'
       tag: 'v3.0.2'
+      version: '3.0.2'
       regenerate:
         - args: ['./update.sh']
     tools_required:
@@ -808,6 +824,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/xkbcommon/libxkbcommon.git'
       tag: 'xkbcommon-0.8.0'
+      version: '0.8.0'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -1022,6 +1039,7 @@ packages:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/pixman/pixman.git'
       tag: 'pixman-0.34.0'
+      version: '0.34.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -1103,6 +1121,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/wayland-project/wayland-protocols.git'
       tag: '1.18'
+      version: '1.18'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -1131,6 +1150,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/madler/zlib.git'
       tag: 'v1.2.11'
+      version: '1.2.11'
     tools_required:
       - system-gcc
     configure:
@@ -1151,6 +1171,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/managarm/libtsm-mirror.git'
       tag: 'libtsm-3'
+      version: '3'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -1182,6 +1203,7 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/dvdhrm/kmscon.git'
       tag: 'kmscon-8'
+      version: '8'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -1226,6 +1248,7 @@ packages:
       subdir: 'ports'
       hg: 'https://hg.libsdl.org/SDL'
       tag: 'release-2.0.10'
+      version: '2.0.10'
     tools_required:
       - system-gcc
       - host-cmake
@@ -1292,6 +1315,7 @@ packages:
       subdir: 'ports'
       git: 'git://disenchant.net/tyrquake'
       tag: 'v0.65'
+      version: '0.65'
     tools_required:
       - system-gcc
       - host-pkg-config
@@ -1321,6 +1345,7 @@ packages:
       url: 'https://www.lua.org/ftp/lua-5.3.5.tar.gz'
       format: 'tar.gz'
       extract_path: 'lua-5.3.5'
+      version: '5.3.5'
     tools_required:
       - system-gcc
     configure:
@@ -1347,6 +1372,7 @@ packages:
       url: 'https://mednafen.github.io/releases/files/mednafen-1.24.0-UNSTABLE.tar.xz'
       format: 'tar.xz'
       extract_path: 'mednafen'
+      version: '1.24.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -1384,6 +1410,7 @@ packages:
       format: 'tar.gz'
       extract_path: 'admin/runit-2.1.2'
       patch-path-strip: 1
+      version: '2.1.2'
     tools_required:
       - system-gcc
     configure:


### PR DESCRIPTION
This PR adds versioning information for use in packaging where it was known, e.g. everything that is not built directly from master (with a few small exceptions).