### PR TITLE
Add several meta packages

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -104,7 +104,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: xz-utils
-    default: false
     source:
       subdir: ports
       git: 'https://git.tukaani.org/xz.git'

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -4,6 +4,7 @@ sources:
     git: 'https://github.com/python/cpython.git'
     tag: 'v3.8.2'
     version: '3.8.2'
+    rev: '2'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -115,6 +116,7 @@ packages:
       - readline
       - bzip2
       - libressl
+      - xz-utils
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-util.yml
+++ b/bootstrap.d/dev-util.yml
@@ -91,7 +91,6 @@ packages:
 
   - name: pkg-config
     from_source: pkg-config
-    default: false
     tools_required:
       - system-gcc
     pkgs_required:

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -1,0 +1,29 @@
+packages:
+  # Meta package with the bare minimum to boot kmscon and be useful
+  - name: base
+    from_source: managarm
+    pkgs_required:
+      - base-configuration
+      - managarm-kernel
+      - managarm-system
+      - kmscon
+      - bash
+      - xkeyboard-config
+      - coreutils
+      - vim
+      - nano
+      - wget
+      - xbps
+      - grep
+      - sed
+      - gawk
+      - less
+      - tar
+      - bzip2
+      - gzip
+      - which
+      - iana-etc
+      - diffutils
+      - xz-utils
+    configure: []
+    build: []

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -27,3 +27,18 @@ packages:
       - xz-utils
     configure: []
     build: []
+
+  # Meta package with build essentials
+  - name: base-devel
+    from_source: managarm
+    pkgs_required:
+      - base
+      - binutils
+      - gcc
+      - make
+      - patch
+      - m4
+      - nasm
+      - pkg-config
+    configure: []
+    build: []

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -3,7 +3,7 @@ packages:
   - name: base
     from_source: managarm
     pkgs_required:
-      - base-configuration
+      - core-files
       - managarm-kernel
       - managarm-system
       - kmscon

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -89,7 +89,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: wget
-    default: false
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/wget.git'

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -166,7 +166,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: m4
-    default: false
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/m4.git'
@@ -204,7 +203,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: make
-    default: false
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/make.git'
@@ -239,7 +237,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: patch
-    default: false
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/patch.git'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -12,6 +12,7 @@ imports:
   - file: bootstrap.d/games-misc.yml
   - file: bootstrap.d/media-fonts.yml
   - file: bootstrap.d/media-libs.yml
+  - file: bootstrap.d/meta-pkgs.yml
   - file: bootstrap.d/net-misc.yml
   - file: bootstrap.d/sys-apps.yml
   - file: bootstrap.d/sys-devel.yml

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -513,21 +513,6 @@ tools:
         quiet: true
 
 packages:
-  - name: base-configuration
-    from_source: managarm
-    configure: []
-    build:
-      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/']
-      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/bin']
-      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/lib']
-      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/sbin']
-      - args: ['cp', '@SOURCE_ROOT@/extrafiles/passwd', '@THIS_COLLECT_DIR@/etc']
-      - args: ['cp', '@SOURCE_ROOT@/extrafiles/group', '@THIS_COLLECT_DIR@/etc']
-      - args: ['cp', '@SOURCE_ROOT@/extrafiles/resolv.conf', '@THIS_COLLECT_DIR@/etc']
-      - args: ['ln', '-svf', 'usr/bin', '@THIS_COLLECT_DIR@/bin']
-      - args: ['ln', '-svf', 'usr/lib', '@THIS_COLLECT_DIR@/lib']
-      - args: ['ln', '-svf', 'usr/sbin', '@THIS_COLLECT_DIR@/sbin']
-
   - name: binutils
     from_source: binutils
     tools_required:
@@ -571,6 +556,21 @@ packages:
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/include']
       - args: ['cp', '-r', '--dereference', '@THIS_SOURCE_DIR@/boost',
             '@THIS_COLLECT_DIR@/usr/include']
+
+  - name: core-files
+    from_source: managarm
+    configure: []
+    build:
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/bin']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/lib']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/sbin']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/passwd', '@THIS_COLLECT_DIR@/etc']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/group', '@THIS_COLLECT_DIR@/etc']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/resolv.conf', '@THIS_COLLECT_DIR@/etc']
+      - args: ['ln', '-svf', 'usr/bin', '@THIS_COLLECT_DIR@/bin']
+      - args: ['ln', '-svf', 'usr/lib', '@THIS_COLLECT_DIR@/lib']
+      - args: ['ln', '-svf', 'usr/sbin', '@THIS_COLLECT_DIR@/sbin']
 
   - name: fafnir
     source:


### PR DESCRIPTION
This PR adds a `base` meta package which can be used to boot into kmscon and download more packages with `xbps` pending mlibc support (issues managarm/mlibc#51, managarm/mlibc#168, managarm/mlibc#169 and managarm/mlibc#170).
It also adds a `base-devel` meta package which holds the equivalent of `build-essentials` on debian, e.g essential build tools like gcc, binutils and make. As we are still missing software in the ports collection to fill this properly, I expect this meta package to grow in the future

The following ports are enabled by default:

- `xz-utils`
- `wget`
- `make`
- `m4`
- `patch`
- `pkg-config`

Furthermore, the following port received an update
- `python`, bump revision and depend on `xz-utils`