### PR TITLE
Add several font-related ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Now proceed to the Building paragraph.
 
 1.  Certain programs are required to build managarm;
     here we list the corresponding Debian packages:
-    `build-essential`, `pkg-config`, `autopoint`, `bison`, `curl`, `flex`, `gettext`, `git`, `gperf`, `help2man`, `m4`, `mercurial`, `ninja-build`, `python3-mako`, `python3-protobuf`, `python3-yaml`, `texinfo`, `unzip`, `wget`, `xsltproc`, `xz-utils`, `libexpat1-dev`, `rsync`, `python3-pip`, `python3-libxml2`, `netpbm`, `itstool`, `zlib1g-dev`, `libgmp-dev`, `libmpfr-dev`, `libmpc-dev`, `subversion`, `gawk`, `libwayland-bin`, `libpng-dev`.
+    `build-essential`, `pkg-config`, `autopoint`, `bison`, `curl`, `flex`, `gettext`, `git`, `gperf`, `help2man`, `m4`, `mercurial`, `ninja-build`, `python3-mako`, `python3-protobuf`, `python3-yaml`, `texinfo`, `unzip`, `wget`, `xsltproc`, `xz-utils`, `libexpat1-dev`, `rsync`, `python3-pip`, `python3-libxml2`, `netpbm`, `itstool`, `zlib1g-dev`, `libgmp-dev`, `libmpfr-dev`, `libmpc-dev`, `subversion`, `gawk`, `libwayland-bin`, `libpng-dev`, `gtk-doc-tools`.
 1.  `meson` is required. There is a Debian package, but as of Debian Stretch, a newer version is required.
     Install it from pip: `pip3 install meson`.
 1.  The [xbstrap](https://github.com/managarm/xbstrap) and [bragi](https://github.com/managarm/bragi) tools are required to build managarm. Install them via pip: `pip3 install bragi xbstrap`.

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -26,6 +26,37 @@ tools:
       - args: ['make', 'install']
 
 packages:
+  - name: fribidi
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/fribidi/fribidi.git'
+      tag: 'v1.0.10'
+      version: '1.0.10'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+        - args: 'sed -i s/"SUBDIRS = gen.tab lib bin doc test"/"SUBDIRS = gen.tab lib bin test"/ @THIS_SOURCE_DIR@/Makefile.am'
+    tools_required:
+      - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: glib
     source:
       subdir: ports

--- a/bootstrap.d/media-gfx.yml
+++ b/bootstrap.d/media-gfx.yml
@@ -1,0 +1,22 @@
+packages:
+  - name: graphite2
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/silnrsi/graphite.git'
+      tag: '1.3.14'
+      version: '1.3.14'
+    tools_required:
+      - system-gcc
+      - host-python
+      - host-cmake
+    configure:
+      - args:
+        - 'cmake'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -92,7 +92,6 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      # TODO: Build with harfbuzz once we have it, this does make a circular dependency
       - bzip2
       - libpng
       - zlib
@@ -163,6 +162,48 @@ packages:
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
         - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: harfbuzz
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/harfbuzz/harfbuzz.git'
+      tag: '2.7.2'
+      version: '2.7.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            NOCONFIGURE: '1'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - graphite2
+      - glib
+      - zlib
+      - freetype
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-gtk-doc-html'
+        - '--without-cairo'
+        - '--without-gobject'
+        - '--without-icu'
+        - '--with-freetype=yes'
+        - '--with-graphite2=yes'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1130,6 +1130,42 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: pango
+    source:
+      subdir: ports
+      git: 'https://gitlab.gnome.org/GNOME/pango.git'
+      tag: '1.46.2'
+      version: '1.46.2'
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - glib
+      - fontconfig
+      - freetype
+      - fribidi
+      - cairo
+      - xorg-proto
+      - libx11
+      - libxtrans
+      - libxext
+    configure:
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson.cross-file'
+        - '--prefix=/usr'
+        - '--buildtype=release'
+        - '-Dintrospection=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: pixman
     source:
       subdir: 'ports'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -11,6 +11,7 @@ imports:
   - file: bootstrap.d/games-board.yml
   - file: bootstrap.d/games-misc.yml
   - file: bootstrap.d/media-fonts.yml
+  - file: bootstrap.d/media-gfx.yml
   - file: bootstrap.d/media-libs.yml
   - file: bootstrap.d/meta-pkgs.yml
   - file: bootstrap.d/net-misc.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 		gettext \
 		git \
 		gperf \
+		gtk-doc-tools \
 		help2man \
 		itstool \
 		libarchive-dev \


### PR DESCRIPTION
This PR adds the following ports:

- `graphite2`, used by harfbuzz for rendering.
- `harfbuzz`, used for rendering fonts and a required dependency of `pango`.
- `fribidi`, used by `pango` for rendering.
- `pango`, used by many gtk based applications for rendering and used by kmscon for freetype font rendering.

Furthermore, this PR updates the Dockerfile and the readme with a new host dependency.