### PR TITLE
bootstrap.yml: Add stability_level annotations

### DIFF
--- a/bootstrap.d/app-admin.yml
+++ b/bootstrap.d/app-admin.yml
@@ -1,6 +1,6 @@
 packages:
   - name: sysklogd
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/troglobit/sysklogd.git'

--- a/bootstrap.d/app-shells.yml
+++ b/bootstrap.d/app-shells.yml
@@ -1,5 +1,6 @@
 packages:
   - name: bash
+    default: true
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/bash.git'

--- a/bootstrap.d/dev-db.yml
+++ b/bootstrap.d/dev-db.yml
@@ -1,6 +1,5 @@
 packages:
   - name: sqlite
-    stability_level: broken
     source:
       subdir: 'ports'
       url: 'https://sqlite.org/2020/sqlite-autoconf-3310100.tar.gz'

--- a/bootstrap.d/dev-db.yml
+++ b/bootstrap.d/dev-db.yml
@@ -1,6 +1,6 @@
 packages:
   - name: sqlite
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       url: 'https://sqlite.org/2020/sqlite-autoconf-3310100.tar.gz'

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -61,7 +61,7 @@ packages:
     build: []
 
   - name: perl
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       git: 'https://github.com/Perl/perl5.git'
@@ -141,7 +141,7 @@ packages:
         quiet: true
 
   - name: yasm
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/yasm/yasm.git'

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -4,7 +4,7 @@ sources:
     git: 'https://github.com/python/cpython.git'
     tag: 'v3.8.2'
     version: '3.8.2'
-    rev: '2'
+    rev: '3'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -117,6 +117,7 @@ packages:
       - bzip2
       - libressl
       - xz-utils
+      - gdbm
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -142,7 +142,6 @@ packages:
         quiet: true
 
   - name: yasm
-    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/yasm/yasm.git'
@@ -159,11 +158,11 @@ packages:
         - args: ['cp',
             '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
             '@THIS_SOURCE_DIR@/config/']
+        # Autogen.sh configures for the host os, distclean and reconfigure for managarm
+        - args: ['make', '-C', '@THIS_SOURCE_DIR@', 'distclean']
     tools_required:
       - system-gcc
     configure:
-      # Autogen.sh configures for the host os, distclean and reconfigure for managarm
-      - args: ['make', '-C', '@THIS_SOURCE_DIR@', 'distclean']
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -314,7 +314,6 @@ packages:
         quiet: true
 
   - name: libpipeline
-    stability_level: broken
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/libpipeline.git'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -247,7 +247,6 @@ packages:
         quiet: true
 
   - name: libgpg-error
-    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/gpg/libgpg-error.git'
@@ -259,9 +258,7 @@ packages:
         - host-libtool
       regenerate:
         - args: ['./autogen.sh']
-        - args: ['cp',
-            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
-            '@THIS_SOURCE_DIR@/build-aux/']
+        - args: ['autoreconf', '-f', '-v', '-i']
     tools_required:
       - system-gcc
     configure:

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -94,7 +94,6 @@ packages:
         quiet: true
 
   - name: icu
-    stability_level: broken
     from_source: icu
     tools_required:
       - system-gcc

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -94,7 +94,7 @@ packages:
         quiet: true
 
   - name: icu
-    default: false
+    stability_level: broken
     from_source: icu
     tools_required:
       - system-gcc
@@ -209,7 +209,7 @@ packages:
         quiet: true
 
   - name: libgcrypt
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/gpg/libgcrypt.git'
@@ -248,7 +248,7 @@ packages:
         quiet: true
 
   - name: libgpg-error
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/gpg/libgpg-error.git'
@@ -318,7 +318,7 @@ packages:
         quiet: true
 
   - name: libpipeline
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/libpipeline.git'

--- a/bootstrap.d/dev-util.yml
+++ b/bootstrap.d/dev-util.yml
@@ -63,7 +63,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
   
   - name: itstool
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       url: 'http://files.itstool.org/itstool/itstool-2.0.6.tar.bz2'

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -1,6 +1,6 @@
 packages:
   - name: curl
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/curl/curl.git'
@@ -51,7 +51,7 @@ packages:
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
 
   - name: socat
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       git: 'git://repo.or.cz/socat.git'

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -36,6 +36,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: iana-etc
+    default: true
     source:
       subdir: ports
       url: 'http://anduin.linuxfromscratch.org/LFS/iana-etc-2.30.tar.bz2'

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -52,7 +52,6 @@ packages:
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
 
   - name: socat
-    stability_level: broken
     source:
       subdir: 'ports'
       git: 'git://repo.or.cz/socat.git'
@@ -70,6 +69,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: x86_64-managarm
     pkgs_required:
+      - ncurses
       - readline
       - libressl
     configure:

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -212,7 +212,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: groff
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/groff.git'
@@ -271,7 +271,7 @@ packages:
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
 
   - name: man-db
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/man-db.git'

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -64,7 +64,7 @@ tools:
 
 packages:
   - name: bc
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/gavinhoward/bc.git'
@@ -87,7 +87,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: bison
-    default: false
+    stability_level: broken
     from_source: bison
     tools_required:
       - system-gcc
@@ -107,7 +107,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: flex
-    default: false
+    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/westes/flex.git'
@@ -140,7 +140,7 @@ packages:
 
   - name: gettext
     from_source: gettext
-    default: false
+    stability_level: broken
     tools_required:
       - system-gcc
       - host-autoconf-v2.69

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -64,7 +64,6 @@ tools:
 
 packages:
   - name: bc
-    stability_level: broken
     source:
       subdir: 'ports'
       git: 'https://github.com/gavinhoward/bc.git'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -1,6 +1,5 @@
 packages:
   - name: gdbm
-    stability_level: broken
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gdbm.git'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -1,6 +1,6 @@
 packages:
   - name: gdbm
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gdbm.git'

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -29,7 +29,7 @@ tools:
 
 packages:
   - name: shared-mime-info
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xdg/shared-mime-info.git'
@@ -65,7 +65,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: xbitmaps
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/data/bitmaps.git'

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -65,7 +65,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: xbitmaps
-    stability_level: broken
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/data/bitmaps.git'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -559,6 +559,7 @@ packages:
             '@THIS_COLLECT_DIR@/usr/include']
 
   - name: core-files
+    default: true
     from_source: managarm
     configure: []
     build:
@@ -856,6 +857,7 @@ packages:
         quiet: true
 
   - name: managarm-kernel
+    default: true
     from_source: managarm
     sources_required:
       - frigg
@@ -887,6 +889,7 @@ packages:
         quiet: true
 
   - name: managarm-system
+    default: true
     from_source: managarm
     tools_required:
       - host-llvm-toolchain
@@ -1077,6 +1080,7 @@ packages:
         quiet: true
 
   - name: kmscon
+    default: true
     source:
       subdir: 'ports'
       git: 'https://github.com/dvdhrm/kmscon.git'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -25,6 +25,7 @@ imports:
 general:
     patch_author: The Managarm Project
     patch_email: info@managarm.org
+    everything_by_default: false
 
 repository:
   url: 'https://pkgs.managarm.org/nightly'
@@ -1280,7 +1281,7 @@ packages:
         quiet: true
 
   - name: runit
-    default: false
+    stability_level: broken
     source:
       subdir: ports
       url: 'http://smarden.org/runit/runit-2.1.2.tar.gz'


### PR DESCRIPTION
This PR prepares the repo for the new xbstrap release. It adds `everything_by_default: false` to only build a minimal subset by default (when using `xbstrap`, `xbstrap-pipeline` ignores this), it adds `default: true` to that minimal subset (which can boot `kmscon` with a `bash` shell and some config files, `core-files` for filesystem layout and `iana-etc` for the `/etc/services` and `/etc/protocols` file) and it dropped all the `default: false`, as that is now the default, and added `stability_level: broken` to packages which had `default: false`. I expect to remove this label from some packages in the coming days after I've confirmed that they actually build and do something remotely useful, like not crashing the `posix-subsystem` server on executing their help command.

This PR is blocked on a new xbstrap release (duh), but should be merged immediately after releasing, to not break nightly.