### PR TITLE
Various updates

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -427,9 +427,9 @@ packages:
   - name : mpc
     source:
       subdir: ports
-      git: 'https://scm.gforge.inria.fr/anonscm/git/mpc/mpc.git'
-      tag: '1.1.0'
-      version: '1.1.0'
+      git: 'https://gitlab.inria.fr/mpc/mpc.git'
+      tag: '1.2.1'
+      version: '1.2.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -458,10 +458,10 @@ packages:
   - name : mpfr
     source:
       subdir: 'ports'
-      url: 'https://ftp.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.xz'
+      url: 'https://ftp.gnu.org/gnu/mpfr/mpfr-4.1.0.tar.xz'
       format: 'tar.xz'
-      extract_path: 'mpfr-4.0.2'
-      version: '4.0.2'
+      extract_path: 'mpfr-4.1.0'
+      version: '4.1.0'
       tools_required:
         - host-autoconf-archive
         - host-autoconf-v2.69

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -8,8 +8,8 @@ sources:
   - name: icu
     subdir: 'ports'
     git: 'https://github.com/unicode-org/icu.git'
-    tag: 'release-67-1'
-    version: '67.1'
+    tag: 'release-68-1'
+    version: '68.1'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -2,8 +2,8 @@ sources:
   - name: glib
     subdir: ports
     git: 'https://gitlab.gnome.org/GNOME/glib'
-    tag: '2.66.1'
-    version: '2.66.1'
+    tag: '2.66.2'
+    version: '2.66.2'
 
   - name: icu
     subdir: 'ports'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -252,10 +252,10 @@ packages:
   - name: less
     source:
       subdir: ports
-      url: 'http://www.greenwoodsoftware.com/less/less-551.tar.gz'
+      url: 'http://www.greenwoodsoftware.com/less/less-563.tar.gz'
       format: 'tar.gz'
-      extract_path: 'less-551'
-      version: '551'
+      extract_path: 'less-563'
+      version: '563'
     tools_required:
       - system-gcc
     pkgs_required:

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -108,9 +108,9 @@ packages:
     default: true
     source:
       subdir: 'ports'
-      url: 'https://data.iana.org/time-zones/releases/tzdata2020a.tar.gz'
+      url: 'https://data.iana.org/time-zones/releases/tzdata2020d.tar.gz'
       format: 'tar.gz'
-      version: '2020a'
+      version: '2020d'
     tools_required:
       - system-gcc
     configure:
@@ -149,12 +149,6 @@ packages:
       - args: ['/usr/sbin/zic', '-L', '/dev/null', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo', '@THIS_BUILD_DIR@/backward']
       - args: ['/usr/sbin/zic', '-L', '/dev/null', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo/posix', '@THIS_BUILD_DIR@/backward']
       - args: ['/usr/sbin/zic', '-L', '@THIS_SOURCE_DIR@/leapseconds', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo/right', '@THIS_BUILD_DIR@/backward']
-      - args: ['/usr/sbin/zic', '-L', '/dev/null', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo', '@THIS_BUILD_DIR@/pacificnew']
-      - args: ['/usr/sbin/zic', '-L', '/dev/null', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo/posix', '@THIS_BUILD_DIR@/pacificnew']
-      - args: ['/usr/sbin/zic', '-L', '@THIS_SOURCE_DIR@/leapseconds', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo/right', '@THIS_BUILD_DIR@/pacificnew']
-      - args: ['/usr/sbin/zic', '-L', '/dev/null', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo', '@THIS_BUILD_DIR@/systemv']
-      - args: ['/usr/sbin/zic', '-L', '/dev/null', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo/posix', '@THIS_BUILD_DIR@/systemv']
-      - args: ['/usr/sbin/zic', '-L', '@THIS_SOURCE_DIR@/leapseconds', '-d', '@THIS_COLLECT_DIR@/usr/share/zoneinfo/right', '@THIS_BUILD_DIR@/systemv']
       # Copy some needed files to their location
       - args: ['cp', '@THIS_BUILD_DIR@/zone.tab', '@THIS_BUILD_DIR@/zone1970.tab', '@THIS_BUILD_DIR@/iso3166.tab', '@THIS_COLLECT_DIR@/usr/share/zoneinfo']
       # Create the posixrules file, POSIX requires daylight saving rules to be in accordance with US rules, thus use New York


### PR DESCRIPTION
This PR updates various packages:

- `glib`, updated from version `2.66.1` to `2.66.2`, fixes a bug in timezone handling with regards to daylight saving time
- `icu`, updated from version `67.1` to `68.1`
- `less`, updated from version `553` to `561`
- `mpc`, updated from version `1.1.0` to `1.2.1`, also updated the source url
- `mpfr`, updated from version `4.0.2` to `4.1.0`
- `tzdata`, updated from version `2020a` to `2020d`