### PR TITLE
Fix for ci image generation and some updates

### DIFF
--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -42,5 +42,22 @@ packages:
       - m4
       - nasm
       - pkg-config
+      - cmake
+      - bc
+    configure: []
+    build: []
+
+  # Meta package for weston and usefull utilities
+  - name: gui
+    from_source: managarm
+    pkgs_required:
+      - base
+      - weston
+      - xwininfo
+      - xkill
+      - xclock
+      - xlsclients
+      - xdpyinfo
+      - xdriinfo
     configure: []
     build: []

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1301,7 +1301,7 @@ packages:
 
       
 tasks:
-  - name: make-useful-image
+  - name: useful-image-dependencies
     pkgs_required:
       - base
       - gui
@@ -1314,7 +1314,7 @@ tasks:
       - managarm-kernel
       - managarm-system
     tasks_required:
-      - task: make-useful-image
+      - task: useful-image-dependencies
         order_only: true
     args:
       - '@SOURCE_ROOT@/scripts/mkimage'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1301,10 +1301,21 @@ packages:
 
       
 tasks:
+  - name: make-useful-image
+    pkgs_required:
+      - base
+      - gui
+    tools_required:
+      - system-gcc
+    args: []
+
   - name: make-image
     pkgs_required:
       - managarm-kernel
       - managarm-system
+    tasks_required:
+      - task: make-useful-image
+        order_only: true
     args:
       - '@SOURCE_ROOT@/scripts/mkimage'
     workdir: '@BUILD_ROOT@'

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,5 +14,5 @@ jobs:
 
   - name: image
     tasks:
-      - make-useful-image
+      - useful-image-dependencies
       - make-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,4 +14,5 @@ jobs:
 
   - name: image
     tasks:
+      - make-useful-image
       - make-image


### PR DESCRIPTION
This PR fixes the image generation for the ci and updates the `base-devel` meta package with `bc` and `cmake` now that those are available. Furthermore, a new meta package called `gui` is added, which depends on `base`, `weston` and some X based utility programs.