### PR TITLE
libiconv port and various updates

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -57,9 +57,17 @@ packages:
       git: 'https://github.com/libarchive/libarchive.git'
       tag: 'v3.4.3'
       version: '3.4.3'
+      rev: '2'
     tools_required:
       - host-cmake
       - system-gcc
+    pkgs_required:
+      - libressl
+      - zlib
+      - xz-utils
+      - libiconv
+      - libexpat
+      - libxml
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -46,12 +46,14 @@ packages:
       git: 'https://github.com/vim/vim.git'
       tag: 'v8.2.0814'
       version: '8.2.0814'
+      rev: '2'
     tools_required:
       - system-gcc
       - host-pkg-config
       - host-automake-v1.15
     pkgs_required:
       - ncurses
+      - libiconv
     configure:
       # vim does not seem to support out-of-tree builds, so we just copy
       # the source tree into the build directory instead

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -4,6 +4,7 @@ sources:
     git: 'https://gitlab.gnome.org/GNOME/glib'
     tag: '2.66.2'
     version: '2.66.2'
+    rev: '2'
 
   - name: icu
     subdir: 'ports'
@@ -87,6 +88,7 @@ packages:
     pkgs_required:
       - pcre
       - libffi
+      - zlib
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -324,6 +324,70 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libiconv
+    source:
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/git/libiconv.git'
+      # Last release tag is broken for us, use current master (07-12-2020)
+      branch: 'master'
+      commit: '0eb1068ceb77ba383c3ce2fc391ab40ef686c491'
+      version: '1.16'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+        - host-autoconf-archive
+        - host-gettext
+      regenerate:
+        - args: ['./gitsub.sh', 'pull']
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build-aux/']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/libcharset/build-aux/']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-libtool/share/aclocal/libtool.m4',
+            '@THIS_SOURCE_DIR@/m4/']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-libtool/share/aclocal/libtool.m4',
+            '@THIS_SOURCE_DIR@/libcharset/m4/']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-libtool/share/libtool/build-aux/ltmain.sh',
+            '@THIS_SOURCE_DIR@/libcharset/build-aux/']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-libtool/share/libtool/build-aux/ltmain.sh',
+            '@THIS_SOURCE_DIR@/build-aux/']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-libtool/share/aclocal/ltversion.m4',
+            '@THIS_SOURCE_DIR@/m4/']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-libtool/share/aclocal/ltversion.m4',
+            '@THIS_SOURCE_DIR@/libcharset/m4/']
+        - args: ['autoreconf', '-fvi', '-I@THIS_SOURCE_DIR@/m4', '-I@THIS_SOURCE_DIR@/srcm4']
+    tools_required:
+      - system-gcc
+      - host-libtool
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--disable-nls'
+        - '--enable-shared'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: libinput
     source:
       subdir: 'ports'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -5,6 +5,7 @@ packages:
       git: 'https://gitlab.freedesktop.org/fontconfig/fontconfig'
       tag: '2.13.92'
       version: '2.13.92'
+      rev: '2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -19,6 +20,7 @@ packages:
     pkgs_required:
       - freetype
       - libxml
+      - libiconv
     tools_required:
       - system-gcc
       - host-libtool

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -271,12 +271,12 @@ packages:
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
 
   - name: man-db
-    stability_level: broken
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/man-db.git'
       tag: '2.9.1'
       version: '2.9.1'
+      rev: '2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -294,13 +294,14 @@ packages:
       - gdbm
       - groff
       - less
+      - libiconv
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
         - '--disable-nls'
-        - '--docdir=/usr/share/doc/man-db-2.9.0'
+        - '--docdir=/usr/share/doc/man-db-2.9.1'
         - '--sysconfdir=/etc'
         - '--disable-setuid'
         - '--with-systemdtmpfilesdir='
@@ -312,6 +313,22 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: man-pages-posix
+    source:
+      subdir: ports
+      url: 'https://mirrors.edge.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-2017-a.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'man-pages-posix-2017'
+      version: '2017a'
+    tools_required:
+      - system-gcc
+    configure: []
+    build:
+      - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/share/man']
+      - args: ['cp', '-rv', '@THIS_SOURCE_DIR@/man0p', '@THIS_COLLECT_DIR@/usr/share/man/']
+      - args: ['cp', '-rv', '@THIS_SOURCE_DIR@/man1p', '@THIS_COLLECT_DIR@/usr/share/man/']
+      - args: ['cp', '-rv', '@THIS_SOURCE_DIR@/man3p', '@THIS_COLLECT_DIR@/usr/share/man/']
 
   - name: mini-lspci
     source:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -289,8 +289,8 @@ tools:
       name: libtool
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/libtool.git'
-      tag: 'v2.4.5'
-      version: '2.4.5'
+      tag: 'v2.4.6'
+      version: '2.4.6'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1125,6 +1125,7 @@ packages:
       hg: 'https://hg.libsdl.org/SDL'
       tag: 'release-2.0.10'
       version: '2.0.10'
+      rev: '2'
     tools_required:
       - system-gcc
       - host-cmake
@@ -1136,6 +1137,7 @@ packages:
       - mesa
       - wayland
       - wayland-protocols
+      - libiconv
     configure:
       - args:
         - 'cmake'

--- a/patches/libiconv/0001-Remove-calls-to-versioned-binaries.patch
+++ b/patches/libiconv/0001-Remove-calls-to-versioned-binaries.patch
@@ -1,0 +1,50 @@
+From 1e0451005e0f150330390f5440ac52790c1cd502 Mon Sep 17 00:00:00 2001
+From: Dennisbonke <admin@dennisbonke.com>
+Date: Mon, 7 Dec 2020 16:32:04 +0100
+Subject: [PATCH] Remove calls to versioned binaries
+
+Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+---
+ Makefile.devel            | 8 ++++----
+ libcharset/Makefile.devel | 6 +++---
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/Makefile.devel b/Makefile.devel
+index 2a5e101..a179aaf 100644
+--- a/Makefile.devel
++++ b/Makefile.devel
+@@ -4,10 +4,10 @@
+ 
+ SHELL = /bin/sh
+ MAKE = make
+-AUTOCONF = autoconf-2.69
+-AUTOHEADER = autoheader-2.69
+-AUTOMAKE = automake-1.16
+-ACLOCAL = aclocal-1.16
++AUTOCONF = autoconf
++AUTOHEADER = autoheader
++AUTOMAKE = automake
++ACLOCAL = aclocal
+ GPERF = gperf
+ CC = gcc -Wall
+ CFLAGS = -O
+diff --git a/libcharset/Makefile.devel b/libcharset/Makefile.devel
+index 04f4c7a..3e0e2ca 100644
+--- a/libcharset/Makefile.devel
++++ b/libcharset/Makefile.devel
+@@ -3,9 +3,9 @@
+ 
+ SHELL = /bin/sh
+ MAKE = make
+-AUTOCONF = autoconf-2.69
+-AUTOHEADER = autoheader-2.69
+-ACLOCAL = aclocal-1.16
++AUTOCONF = autoconf
++AUTOHEADER = autoheader
++ACLOCAL = aclocal
+ CP = cp
+ RM = rm -f
+ 
+-- 
+2.29.2
+


### PR DESCRIPTION
This PR adds the following new ports:

- `libiconv`, as mlibc doesn't properly implement the `iconv()` functions we use this utility library to provide those.
- `man-pages-posix`, a collection of man pages in the sections `0p`, `1p` and `3p`, mostly related to posix functions.

Furthermore, the following ports were updated:

- `libtool`, updated version from 2.4.5 to 2.4.6.
- `man-db`, add a dependency on `libiconv`, bump revision and fix the install location to use the correct version.
- `libarchive`, bump revision and add a dependency on `libressl`, `zlib`, `xz-utils`, `libiconv`, `libexpat` and `libxml`
- `vim`, bump revision and add a dependency on `libiconv`.
- `glib`, bump revision and add a dependency on `zlib`.
- `fontconfig`, bump revision and add a dependency on `libiconv`.
- `SDL2`, bump revision and add a dependency on `libiconv`.