### PR TITLE
Various updates

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -55,8 +55,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/libarchive/libarchive.git'
-      tag: 'v3.4.3'
-      version: '3.4.3'
+      tag: 'v3.5.0'
+      version: '3.5.0'
     tools_required:
       - host-cmake
       - system-gcc
@@ -67,7 +67,6 @@ packages:
       - libiconv
       - libexpat
       - libxml
-    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -3,8 +3,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/nano.git'
-      tag: 'v5.2'
-      version: '5.2'
+      tag: 'v5.4'
+      version: '5.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -27,6 +27,7 @@ packages:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
+        - '--sysconfdir=/etc'
         - 'CFLAGS=-DSLOW_BUT_NO_HACKS'
         environ:
           PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'

--- a/bootstrap.d/dev-db.yml
+++ b/bootstrap.d/dev-db.yml
@@ -2,10 +2,10 @@ packages:
   - name: sqlite
     source:
       subdir: 'ports'
-      url: 'https://sqlite.org/2020/sqlite-autoconf-3310100.tar.gz'
+      url: 'https://sqlite.org/2020/sqlite-autoconf-3340000.tar.gz'
       format: 'tar.gz'
-      extract_path: 'sqlite-autoconf-3310100'
-      version: '3.31.1'
+      extract_path: 'sqlite-autoconf-3340000'
+      version: '3.34.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -25,7 +25,8 @@ packages:
         - '--prefix=/usr'
         - '--disable-static'
         - '--enable-readline'
-        - 'CFLAGS=-g -O2 -DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_COLUMN_METADATA=1 -DSQLITE_ENABLE_UNLOCK_NOTIFY=1 -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_SECURE_DELETE=1 -DSQLITE_ENABLE_FTS3_TOKENIZER=1'
+        - '--enable-fts5'
+        - 'CFLAGS=-g -O2 -DSQLITE_ENABLE_FTS3=1 -DSQLITE_ENABLE_FTS4=1 -DSQLITE_ENABLE_COLUMN_METADATA=1 -DSQLITE_ENABLE_UNLOCK_NOTIFY=1 -DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_SECURE_DELETE=1 -DSQLITE_ENABLE_FTS3_TOKENIZER=1'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -186,6 +186,7 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -199,6 +200,7 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib']
 
   - name: make
     source:
@@ -258,6 +260,7 @@ packages:
         triple: x86_64-managarm
     pkgs_required:
       - diffutils
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -268,3 +271,4 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib']

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -67,8 +67,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/gavinhoward/bc.git'
-      tag: '2.7.2'
-      version: '2.7.2'
+      tag: '3.2.4'
+      version: '3.2.4'
     tools_required:
       - system-gcc
     configure:


### PR DESCRIPTION
This PR updates the following ports:

- `nano`, update from version 5.2 to 5.4,
- `libarchive`, update from version 3.4.3 to 3.5.0,
- `sqlite`, update from version 3.31.1 to 3.34.0,
- `bc`, update from version 2.7.2 to 3.2.4,
- `patch` and `m4`, bump revision and remove useless file.

I expect this to be the last round of updates for this year, it's been quite productive in my opinion.