### PR TITLE
Add GTK+-2 and friends

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -45,6 +45,35 @@ tools:
       - args: ['make', 'install']
 
 packages:
+  - name: atk
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/atk.git'
+      tag: 'ATK_2_36_0'
+      version: '2.36.0'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - glib
+    configure:
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson.cross-file'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        - '--buildtype=debugoptimized'
+        - '-Dintrospection=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: fribidi
     source:
       subdir: 'ports'

--- a/bootstrap.d/dev-util.yml
+++ b/bootstrap.d/dev-util.yml
@@ -118,7 +118,6 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
   
   - name: itstool
-    stability_level: broken
     source:
       subdir: ports
       url: 'http://files.itstool.org/itstool/itstool-2.0.6.tar.bz2'

--- a/bootstrap.d/games-misc.yml
+++ b/bootstrap.d/games-misc.yml
@@ -1,4 +1,59 @@
 packages:
+  - name: gtklife
+    source:
+      subdir: 'ports'
+      url: 'http://ironphoenix.org/gtklife/gtklife-5.2.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'gtklife-5.2'
+      version: '5.2'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - gtk+-2
+      - gdk-pixbuf
+      - pango
+      - atk
+      - fontconfig
+      - freetype
+      - harfbuzz
+      - cairo
+      - libx11
+      - glib
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--prefix=/usr'
+        - '--with-gtk2'
+      - args: ['make', 'create_lookup']
+      - args: ['make', 'ul_lookup.c']
+      - args: ['make', 'ur_lookup.c']
+      - args: ['make', 'll_lookup.c']
+      - args: ['make', 'lr_lookup.c']
+      - args: ['cp', '@THIS_BUILD_DIR@/create_lookup', '@THIS_BUILD_DIR@/create_lookup_bak']
+      - args: ['cp', '@THIS_BUILD_DIR@/ul_lookup.c', '@THIS_BUILD_DIR@/ul_lookup.c.bak']
+      - args: ['cp', '@THIS_BUILD_DIR@/ur_lookup.c', '@THIS_BUILD_DIR@/ur_lookup.c.bak']
+      - args: ['cp', '@THIS_BUILD_DIR@/ll_lookup.c', '@THIS_BUILD_DIR@/ll_lookup.c.bak']
+      - args: ['cp', '@THIS_BUILD_DIR@/lr_lookup.c', '@THIS_BUILD_DIR@/lr_lookup.c.bak']
+      - args: ['make', 'mostlyclean']
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--with-gtk2'
+        - '--disable-gtktest'
+      - args: ['cp', '@THIS_BUILD_DIR@/create_lookup_bak', '@THIS_BUILD_DIR@/create_lookup']
+      - args: ['cp', '@THIS_BUILD_DIR@/ul_lookup.c.bak', '@THIS_BUILD_DIR@/ul_lookup.c']
+      - args: ['cp', '@THIS_BUILD_DIR@/ur_lookup.c.bak', '@THIS_BUILD_DIR@/ur_lookup.c']
+      - args: ['cp', '@THIS_BUILD_DIR@/ll_lookup.c.bak', '@THIS_BUILD_DIR@/ll_lookup.c']
+      - args: ['cp', '@THIS_BUILD_DIR@/lr_lookup.c.bak', '@THIS_BUILD_DIR@/lr_lookup.c']
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: nyancat
     source:
       subdir: 'ports'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -252,6 +252,38 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libjpeg-turbo
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/libjpeg-turbo/libjpeg-turbo.git'
+      tag: '2.0.5'
+      version: '2.0.5'
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - host-cmake
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    configure:
+      - args:
+        - 'cmake'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_BUILD_TYPE=RELEASE'
+        - '-DENABLE_STATIC=FALSE'
+        - '-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/libjpeg-turbo-2.0.5'
+        - '-DCMAKE_INSTALL_DEFAULT_LIBDIR=lib'
+        - '-DWITH_JPEG8=ON'
+        # HACK!! Hardcoding this makes it non-portable
+        - '-DCMAKE_SYSTEM_PROCESSOR=amd64'
+        - '@THIS_SOURCE_DIR@/'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: libpng
     source:
       subdir: 'ports'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -111,6 +111,57 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: gtk+-2
+    source:
+      subdir: 'ports'
+      url: 'https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.32.tar.xz'
+      format: 'tar.xz'
+      extract_path: 'gtk+-2.24.32'
+      patch-path-strip: 1
+      version: '2.24.32'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+        - host-xorg-macros
+        - host-glib
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - atk
+      - cairo
+      - glib
+      - gdk-pixbuf
+      - libx11
+      - libxext
+      - libxcb
+      - pango
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--disable-gtk-doc-html'
+        - '--disable-cups'
+        - '--disable-papi'
+        - '--disable-introspection'
+        - '--disable-glibtest'
+        - '--disable-test-print-backend'
+        - '--enable-xkb'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: libdrm
     source:
       subdir: 'ports'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -78,6 +78,39 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: gdk-pixbuf
+    source:
+      subdir: ports
+      git: 'https://gitlab.gnome.org/GNOME/gdk-pixbuf.git'
+      tag: '2.40.0'
+      version: '2.40.0'
+    tools_required:
+      - system-gcc
+      - host-libtool
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - glib
+      - libjpeg-turbo
+      - libpng
+      - shared-mime-info
+      - libx11
+    configure:
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson.cross-file'
+        - '--prefix=/usr'
+        - '-Dgir=false'
+        - '-Dman=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libdrm
     source:
       subdir: 'ports'

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -29,7 +29,6 @@ tools:
 
 packages:
   - name: shared-mime-info
-    stability_level: broken
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xdg/shared-mime-info.git'
@@ -49,6 +48,7 @@ packages:
       - host-python
     pkgs_required:
       - glib
+      - libxml
       - itstool
     configure:
       - args:


### PR DESCRIPTION
This PR adds a port of `gtk+-2` and dependencies, and adds a demo of a game of life written for `gtk`

The following ports have been added:
- `libjpeg-turbo`, add port, dependency of `gdk-pixbuf`,
- `gdk-pixbuf`, add port, core dependency of `gtk`,
- `atk`, add port, used to provide accessibility functions to `gtk`,
- `gtk+-2`, add port, version 2 of the GIMP ToolKit, used throughout GNOME and various other applications for GUI related functionality,
- `gtklife`, add port, a rewrite of the classic game of life for gtk.

Furthermore, the following ports received updates:

- `itstool`, promote to stable as it is needed for `gdk-pixbuf`,
- `shared-mime-info`, promote to stable as it is needed for `gdk-pixbuf`.