### PR TITLE
Add a port of zstd

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -67,6 +67,8 @@ packages:
       - libiconv
       - libexpat
       - libxml
+      - zstd
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -140,3 +142,26 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: zstd
+    source:
+      subdir: ports
+      git: 'https://github.com/facebook/zstd.git'
+      tag: 'v1.4.8'
+      version: '1.4.8'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - zlib
+      - xz-utils
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+        environ:
+          CC: 'x86_64-managarm-gcc'
+          CXX: 'x86_64-managarm-g++'
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+          PREFIX: '/usr'


### PR DESCRIPTION
This PR adds the following port:

- `zstd`, required by `xbps` to read the repo.

The following packages received updates:

- `libarchive`, depend on `zstd`.