### PR TITLE
Add patch for libinput to fix build errors

### DIFF
--- a/patches/libinput/0001-Add-managarm-specific-changes.patch
+++ b/patches/libinput/0001-Add-managarm-specific-changes.patch
@@ -1,0 +1,36 @@
+From c9c29292acc604c4f71fe44a0d5af6bd0035fd3f Mon Sep 17 00:00:00 2001
+From: no92 <no92.mail@gmail.com>
+Date: Sun, 24 Jan 2021 15:01:28 +0100
+Subject: [PATCH] Add managarm-specific changes
+
+---
+ include/linux/input.h         | 2 ++
+ tools/libinput-debug-tablet.c | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/include/linux/input.h b/include/linux/input.h
+index 03c512e..3d407a0 100644
+--- a/include/linux/input.h
++++ b/include/linux/input.h
+@@ -2,4 +2,6 @@
+ #include "linux/input.h"
+ #elif __FreeBSD__
+ #include "freebsd/input.h"
++#elif __managarm__
++#include_next <linux/input.h>
+ #endif
+diff --git a/tools/libinput-debug-tablet.c b/tools/libinput-debug-tablet.c
+index 642f1e2..a8e683d 100644
+--- a/tools/libinput-debug-tablet.c
++++ b/tools/libinput-debug-tablet.c
+@@ -33,6 +33,7 @@
+ #include <string.h>
+ #include <signal.h>
+ #include <sys/ioctl.h>
++#include <termios.h>
+ #include <unistd.h>
+ #include <libinput.h>
+ #include <libevdev/libevdev.h>
+-- 
+2.29.2
+


### PR DESCRIPTION
This will now use managarm's linux/input.h instead of the in-tree Linux copy, which feels like an ugly hack.

Depends on managarm/mlibc#218