### PR TITLE
Updates of various packages

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -87,8 +87,8 @@ packages:
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/tar.git'
-      tag: 'release_1_32'
-      version: '1.32'
+      tag: 'release_1_33'
+      version: '1.33'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -54,8 +54,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/vim/vim.git'
-      tag: 'v8.2.0814'
-      version: '8.2.0814'
+      tag: 'v8.2.2433'
+      version: '8.2.2433'
     tools_required:
       - system-gcc
       - host-pkg-config
@@ -63,7 +63,6 @@ packages:
     pkgs_required:
       - ncurses
       - libiconv
-    revision: 3
     configure:
       # vim does not seem to support out-of-tree builds, so we just copy
       # the source tree into the build directory instead

--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -24,7 +24,7 @@ packages:
       - ncurses
       - libintl
       - zlib
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -39,12 +39,16 @@ packages:
           gl_cv_type_wctrans_t: 'yes'
     build:
       - args: ['make', '-j@PARALLELISM@']
-      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc']
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
-      - args: ['cp', '@THIS_BUILD_DIR@/doc/sample.nanorc', '@THIS_COLLECT_DIR@/etc/nanorc']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/home/managarm']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/root']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/nanorc', '@THIS_COLLECT_DIR@/etc/nanorc']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/nanorc', '@THIS_COLLECT_DIR@/home/managarm/.nanorc']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/root-nanorc', '@THIS_COLLECT_DIR@/root/.nanorc']
 
   - name: vim
     source:

--- a/bootstrap.d/app-shells.yml
+++ b/bootstrap.d/app-shells.yml
@@ -4,8 +4,10 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/bash.git'
-      tag: 'bash-4.4'
-      version: '4.4'
+      # Checkout bash 5.1 patch 4 to fix build issues
+      branch: 'master'
+      commit: '76404c85d492c001f59f2644074333ffb7608532'
+      version: '5.1.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -19,7 +21,6 @@ packages:
       - ncurses
       - readline
       - libiconv
-    revision: 5
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -28,6 +29,8 @@ packages:
         - '--without-bash-malloc'
         - '--disable-nls'
         - '--with-installed-readline=$SYSROOT_DIR$/usr'
+        environ:
+          ac_cv_func_wcswidth: 'no'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']

--- a/bootstrap.d/app-shells.yml
+++ b/bootstrap.d/app-shells.yml
@@ -19,7 +19,7 @@ packages:
       - ncurses
       - readline
       - libiconv
-    revision: 4
+    revision: 5
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -33,8 +33,10 @@ packages:
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
         quiet: true
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/root/']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/home/managarm/']
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/.bashrc', '@THIS_COLLECT_DIR@/root']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/.bashrc', '@THIS_COLLECT_DIR@/home/managarm']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/profile', '@THIS_COLLECT_DIR@/etc']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/bash.bashrc', '@THIS_COLLECT_DIR@/etc']
       - args: ['ln', '-sf', 'bash', '@THIS_COLLECT_DIR@/usr/bin/sh']

--- a/bootstrap.d/dev-db.yml
+++ b/bootstrap.d/dev-db.yml
@@ -2,10 +2,10 @@ packages:
   - name: sqlite
     source:
       subdir: 'ports'
-      url: 'https://sqlite.org/2020/sqlite-autoconf-3340000.tar.gz'
+      url: 'https://sqlite.org/2021/sqlite-autoconf-3340100.tar.gz'
       format: 'tar.gz'
-      extract_path: 'sqlite-autoconf-3340000'
-      version: '3.34.0'
+      extract_path: 'sqlite-autoconf-3340100'
+      version: '3.34.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -2,8 +2,8 @@ sources:
   - name: glib
     subdir: ports
     git: 'https://gitlab.gnome.org/GNOME/glib'
-    tag: '2.66.4'
-    version: '2.66.4'
+    tag: '2.66.6'
+    version: '2.66.6'
 
   - name: icu
     subdir: 'ports'
@@ -119,7 +119,6 @@ packages:
       - zlib
       - libiconv
       - libintl
-    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -112,10 +112,10 @@ packages:
   - name: glew
     source:
       subdir: 'ports'
-      url: 'https://github.com/nigels-com/glew/releases/download/glew-2.1.0/glew-2.1.0.tgz'
+      url: 'https://github.com/nigels-com/glew/releases/download/glew-2.2.0/glew-2.2.0.tgz'
       format: 'tar.gz'
-      extract_path: 'glew-2.1.0'
-      version: '2.1.0'
+      extract_path: 'glew-2.2.0'
+      version: '2.2.0'
     tools_required:
       - system-gcc
     pkgs_required:

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -92,8 +92,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/wget.git'
-      tag: 'v1.20.3'
-      version: '1.20.3'
+      tag: 'v1.21.1'
+      version: '1.21.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -38,17 +38,18 @@ packages:
     default: true
     source:
       subdir: ports
-      url: 'http://anduin.linuxfromscratch.org/LFS/iana-etc-2.30.tar.bz2'
-      format: 'tar.bz2'
-      extract_path: 'iana-etc-2.30'
-      version: '2.30'
+      url: 'https://github.com/Mic92/iana-etc/releases/download/20210202/iana-etc-20210202.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'iana-etc-20210202'
+      version: '20210202'
     tools_required:
       - system-gcc
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
-      - args: ['make', '-j@PARALLELISM@']
-      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc']
+      - args: ['cp', '@THIS_BUILD_DIR@/services', '@THIS_COLLECT_DIR@/etc/']
+      - args: ['cp', '@THIS_BUILD_DIR@/protocols', '@THIS_COLLECT_DIR@/etc/']
 
   - name: socat
     source:

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -3,8 +3,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/curl/curl.git'
-      tag: 'curl-7_70_0'
-      version: '7.70.0'
+      tag: 'curl-7_75_0'
+      version: '7.75.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -24,7 +24,6 @@ packages:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
-        - '--disable-ipv6'
         - '--disable-static'
         - '--with-ca-path=/etc/ssl/certs'
         - '--enable-threaded-resolver'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -118,8 +118,8 @@ packages:
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/findutils.git'
-      tag: 'v4.7.0'
-      version: '4.7.0'
+      tag: 'v4.8.0'
+      version: '4.8.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -60,11 +60,10 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/ThomasDickey/ncurses-snapshots.git'
-      tag: 'v6_1'
-      version: '6.1'
+      tag: 'v6_2'
+      version: '6.2'
     tools_required:
       - system-gcc
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -64,7 +64,7 @@ packages:
       version: '6.1'
     tools_required:
       - system-gcc
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -78,6 +78,8 @@ packages:
         - '--with-pkg-config-libdir=/usr/lib/pkgconfig'
         - '--with-termlib'
         - '--enable-widec'
+        environ:
+          cf_cv_func_nanosleep: 'yes'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -120,9 +120,9 @@ packages:
     default: true
     source:
       subdir: 'ports'
-      url: 'https://data.iana.org/time-zones/releases/tzdata2020f.tar.gz'
+      url: 'https://data.iana.org/time-zones/releases/tzdata2021a.tar.gz'
       format: 'tar.gz'
-      version: '2020f'
+      version: '2021a'
     tools_required:
       - system-gcc
     configure:

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -99,8 +99,8 @@ packages:
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/readline.git'
-      tag: 'readline-8.0'
-      version: '8.0'
+      tag: 'readline-8.1'
+      version: '8.1'
     tools_required:
       - system-gcc
     pkgs_required:

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1227,8 +1227,8 @@ packages:
     source:
       subdir: ports
       git: 'https://gitlab.gnome.org/GNOME/pango.git'
-      tag: '1.46.2'
-      version: '1.46.2'
+      tag: '1.48.1'
+      version: '1.48.1'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -1254,7 +1254,7 @@ packages:
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
         - '--buildtype=release'
-        - '-Dintrospection=false'
+        - '-Dintrospection=disabled'
         - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1083,8 +1083,8 @@ packages:
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxt.git'
-      tag: 'libXt-1.2.0'
-      version: '1.2.0'
+      tag: 'libXt-1.2.1'
+      version: '1.2.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -1,9 +1,9 @@
 sources:
   - name: 'xorg-util-macros'
     subdir: ports
-    git: 'https://github.com/freedesktop/xorg-macros.git'
-    tag: 'util-macros-1.19.1'
-    version: '1.19.1'
+    git: 'https://gitlab.freedesktop.org/xorg/util/macros.git'
+    tag: 'util-macros-1.19.3'
+    version: '1.19.3'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.11

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -567,12 +567,14 @@ packages:
   - name: core-files
     default: true
     from_source: managarm
+    revision: 2
     configure: []
     build:
       # Create initial directories
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc']
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/run']
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/root']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/home/managarm']
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr']
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/share']
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/var']

--- a/extrafiles/nanorc
+++ b/extrafiles/nanorc
@@ -1,0 +1,303 @@
+## Sample initialization file for GNU nano.
+##
+## For the options that take parameters, the default value is shown.
+## Other options are unset by default.  To make sure that an option
+## is disabled, you can use "unset <option>".
+##
+## Characters that are special in a shell should not be escaped here.
+## Inside string parameters, quotes should not be escaped -- the last
+## double quote on the line will be seen as the closing quote.
+
+## Make 'nextword' (Ctrl+Right) and 'chopwordright' (Ctrl+Delete)
+## stop at word ends instead of at beginnings.
+# set afterends
+
+## When soft line wrapping is enabled, make it wrap lines at blanks
+## (tabs and spaces) instead of always at the edge of the screen.
+# set atblanks
+
+## Automatically indent a newly created line to the same number of
+## tabs and/or spaces as the preceding line -- or as the next line
+## if the preceding line is the beginning of a paragraph.
+set autoindent
+
+## Back up files to the current filename plus a tilde.
+# set backup
+
+## The directory to put unique backup files in.
+# set backupdir ""
+
+## Use bold text instead of reverse video text.
+# set boldtext
+
+## Treat any line with leading whitespace as the beginning of a paragraph.
+# set bookstyle
+
+## The characters treated as closing brackets when justifying paragraphs.
+## This may not include any blank characters.  Only closing punctuation,
+## optionally followed by these closing brackets, can end sentences.
+# set brackets ""')>]}"
+
+## Automatically hard-wrap the current line when it becomes overlong.
+# set breaklonglines
+
+## Do case-sensitive searches by default.
+# set casesensitive
+
+## Constantly display the cursor position in the status bar.  Note that
+## this overrides "quickblank".
+set constantshow
+
+## Use cut-from-cursor-to-end-of-line by default.
+# set cutfromcursor
+
+## Do not use the line below the title bar, leaving it entirely blank.
+# set emptyline
+
+## Set the target width for automatic hard-wrapping and for justifying
+## paragraphs.  If the specified value is 0 or less, the wrapping point
+## will be the terminal's width minus this number.
+# set fill -8
+
+## Remember the used search/replace strings for the next session.
+set historylog
+
+## Display a "scrollbar" on the righthand side of the edit window.
+# set indicator
+
+## Scroll the buffer contents per half-screen instead of per line.
+# set jumpyscrolling
+
+## Display line numbers to the left (and any anchors in the margin).
+set linenumbers
+
+## Enable vim-style lock-files.  This is just to let a vim user know you
+## are editing a file [s]he is trying to edit and vice versa.  There are
+## no plans to implement vim-style undo state in these files.
+# set locking
+
+## Fall back to slow libmagic to try and determine an applicable syntax.
+# set magic
+
+# After a search, set the mark at the end of the found match (if any).
+# set markmatch
+
+## The opening and closing brackets that can be found by bracket
+## searches.  They cannot contain blank characters.  The former set must
+## come before the latter set, and both must be in the same order.
+# set matchbrackets "(<[{)>]}"
+
+## Suppress title bar and show file name and editor state at the bottom.
+# set minibar
+
+## Enable mouse support, if available for your system.  When enabled,
+## mouse clicks can be used to place the cursor, set the mark (with a
+## double click), and execute shortcuts.  The mouse will work in the X
+## Window System, and on the console when gpm is running.
+# set mouse
+
+## Switch on multiple file buffers (inserting a file will put it into
+## a separate buffer).
+# set multibuffer
+
+## Don't convert files from DOS/Mac format.
+# set noconvert
+
+## Don't display the helpful shortcut lists at the bottom of the screen.
+# set nohelp
+
+## Don't automatically add a newline when a file does not end with one.
+# set nonewlines
+
+## Set operating directory.  nano will not read or write files outside
+## this directory and its subdirectories.  Also, the current directory
+## is changed to here, so any files are inserted from this dir.  A blank
+## string means the operating-directory feature is turned off.
+# set operatingdir ""
+
+## Remember the cursor position in each file for the next editing session.
+set positionlog
+
+## Preserve the XON and XOFF keys (^Q and ^S).
+# set preserve
+
+## The characters treated as closing punctuation when justifying
+## paragraphs.  They cannot contain blank characters.  Only closing
+## punctuation, optionally followed by closing brackets, can end
+## sentences.
+# set punct "!.?"
+
+## Do quick status-bar blanking.  Status-bar messages will disappear after
+## 1 keystroke instead of 26.  Note that "constantshow" overrides this.
+# set quickblank
+
+## The regular expression that matches quoting characters in email
+## or line-comment introducers in source code.  The default is:
+# set quotestr "^([ 	]*([!#%:;>|}]|//))+"
+
+## Try to work around a mismatching terminfo terminal description.
+# set rawsequences
+
+## Fix Backspace/Delete confusion problem.
+# set rebinddelete
+
+## Do regular-expression searches by default.
+## Regular expressions are of the extended type (ERE).
+set regexp
+
+## Save a changed buffer automatically on exit; don't prompt.
+# set saveonexit
+## (The old form of this option, 'set tempfile', is deprecated.)
+
+## Put the cursor on the highlighted item in the file browser, and show
+## the cursor in the help viewer; useful for people who use a braille
+## display and people with poor vision.
+# set showcursor
+
+## Make the Home key smarter.  When Home is pressed anywhere but at the
+## very beginning of non-whitespace characters on a line, the cursor
+## will jump to that beginning (either forwards or backwards).  If the
+## cursor is already at that position, it will jump to the true
+## beginning of the line.
+# set smarthome
+
+## Spread overlong lines over multiple screen lines.
+# set softwrap
+
+## Use this spelling checker instead of the internal one.  This option
+## does not have a default value.
+# set speller "aspell -x -c"
+
+## Use the end of the title bar for some state flags: I = auto-indenting,
+## M = mark, L = hard-wrapping long lines, R = recording, S = soft-wrapping.
+# set stateflags
+
+## Allow nano to be suspended (with ^Z by default).
+set suspendable
+## (The old form of this option, 'set suspend', is deprecated.)
+
+## Use this tab size instead of the default; it must be greater than 0.
+# set tabsize 8
+
+## Convert typed tabs to spaces.
+# set tabstospaces
+
+## Snip whitespace at the end of lines when justifying or hard-wrapping.
+# set trimblanks
+
+## The two single-column characters used to display the first characters
+## of tabs and spaces.  187 in ISO 8859-1 (0000BB in Unicode) and 183 in
+## ISO-8859-1 (0000B7 in Unicode) seem to be good values for these.
+## The default when in a UTF-8 locale:
+# set whitespace "»·"
+## The default otherwise:
+# set whitespace ">."
+
+## Detect word boundaries differently by treating punctuation
+## characters as parts of words.
+# set wordbounds
+
+## The characters (besides alphanumeric ones) that should be considered
+## as parts of words.  This option does not have a default value.  When
+## set, it overrides option 'set wordbounds'.
+# set wordchars "<_>."
+
+## Let an unmodified Backspace or Delete erase the marked region (instead
+## of a single character, and without affecting the cutbuffer).
+# set zap
+
+## Paint the interface elements of nano.  These are examples;
+## by default there are no colors, except for errorcolor.
+set titlecolor bold,lightwhite,blue
+set promptcolor lightwhite,lightblack
+set statuscolor bold,lightwhite,green
+set errorcolor bold,lightwhite,red
+set selectedcolor lightwhite,magenta
+set stripecolor ,yellow
+set scrollercolor cyan
+set numbercolor cyan
+set keycolor cyan
+set functioncolor green
+
+## In root's .nanorc you might want to use:
+# set titlecolor bold,lightwhite,red
+# set promptcolor black,yellow
+# set statuscolor bold,lightwhite,red
+# set errorcolor bold,lightwhite,red
+# set selectedcolor lightwhite,cyan
+# set stripecolor ,yellow
+# set scrollercolor magenta
+# set numbercolor magenta
+# set keycolor lightmagenta
+# set functioncolor magenta
+
+
+## === Syntax coloring ===
+## For all details, see 'man nanorc', section SYNTAX HIGHLIGHTING.
+
+## To include most of the existing syntax definitions, you can do:
+include "/usr/share/nano/*.nanorc"
+
+## Or you can select just the ones you need.  For example:
+# include "/usr/share/nano/html.nanorc"
+# include "/usr/share/nano/python.nanorc"
+# include "/usr/share/nano/sh.nanorc"
+
+## In /usr/share/nano/extra/ you can find some syntaxes that are
+## specific for certain distros or for some less common languages.
+
+
+## If <Tab> should always produce four spaces when editing a Python file,
+## independent of the settings of 'tabsize' and 'tabstospaces':
+# extendsyntax python tabgives "    "
+
+## If <Tab> should always produce an actual TAB when editing a Makefile:
+# extendsyntax makefile tabgives "	"
+
+
+## === Key bindings ===
+## For all details, see 'man nanorc', section REBINDING KEYS.
+
+## The <Ctrl+Delete> keystroke deletes the word to the right of the cursor.
+## On some terminals the <Ctrl+Backspace> keystroke produces ^H, which is
+## the ASCII character for backspace, so it is bound by default to the
+## backspace function.  The <Backspace> key itself produces a different
+## keycode, which is hard-bound to the backspace function.  So, if you
+## normally use <Backspace> for backspacing and not ^H, you can make
+## <Ctrl+Backspace> delete the word to the left of the cursor with:
+# bind ^H chopwordleft main
+
+## If you would like nano to have keybindings that are more "usual",
+## such as ^O for Open, ^F for Find, ^H for Help, and ^Q for Quit,
+## then uncomment these:
+#bind ^Q exit all
+#bind ^S savefile main
+#bind ^W writeout main
+#bind ^O insert main
+#bind ^H help all
+#bind ^H exit help
+#bind ^F whereis all
+#bind ^G findnext all
+#bind ^B wherewas all
+#bind ^D findprevious all
+#bind ^R replace main
+#bind M-X flipnewbuffer all
+#bind ^X cut all
+#bind ^C copy main
+#bind ^V paste all
+#bind ^P location main
+#bind ^A mark main
+#unbind ^K main
+#unbind ^U all
+#unbind ^N main
+#unbind ^Y all
+#unbind M-J main
+#unbind M-T main
+#bind ^T gotoline main
+#bind ^T gotodir browser
+#bind ^Y speller main
+#bind M-U undo main
+#bind M-R redo main
+#bind ^U undo main
+#bind ^E redo main
+#set multibuffer

--- a/extrafiles/root-nanorc
+++ b/extrafiles/root-nanorc
@@ -1,0 +1,303 @@
+## Sample initialization file for GNU nano.
+##
+## For the options that take parameters, the default value is shown.
+## Other options are unset by default.  To make sure that an option
+## is disabled, you can use "unset <option>".
+##
+## Characters that are special in a shell should not be escaped here.
+## Inside string parameters, quotes should not be escaped -- the last
+## double quote on the line will be seen as the closing quote.
+
+## Make 'nextword' (Ctrl+Right) and 'chopwordright' (Ctrl+Delete)
+## stop at word ends instead of at beginnings.
+# set afterends
+
+## When soft line wrapping is enabled, make it wrap lines at blanks
+## (tabs and spaces) instead of always at the edge of the screen.
+# set atblanks
+
+## Automatically indent a newly created line to the same number of
+## tabs and/or spaces as the preceding line -- or as the next line
+## if the preceding line is the beginning of a paragraph.
+set autoindent
+
+## Back up files to the current filename plus a tilde.
+# set backup
+
+## The directory to put unique backup files in.
+# set backupdir ""
+
+## Use bold text instead of reverse video text.
+# set boldtext
+
+## Treat any line with leading whitespace as the beginning of a paragraph.
+# set bookstyle
+
+## The characters treated as closing brackets when justifying paragraphs.
+## This may not include any blank characters.  Only closing punctuation,
+## optionally followed by these closing brackets, can end sentences.
+# set brackets ""')>]}"
+
+## Automatically hard-wrap the current line when it becomes overlong.
+# set breaklonglines
+
+## Do case-sensitive searches by default.
+# set casesensitive
+
+## Constantly display the cursor position in the status bar.  Note that
+## this overrides "quickblank".
+set constantshow
+
+## Use cut-from-cursor-to-end-of-line by default.
+# set cutfromcursor
+
+## Do not use the line below the title bar, leaving it entirely blank.
+# set emptyline
+
+## Set the target width for automatic hard-wrapping and for justifying
+## paragraphs.  If the specified value is 0 or less, the wrapping point
+## will be the terminal's width minus this number.
+# set fill -8
+
+## Remember the used search/replace strings for the next session.
+set historylog
+
+## Display a "scrollbar" on the righthand side of the edit window.
+# set indicator
+
+## Scroll the buffer contents per half-screen instead of per line.
+# set jumpyscrolling
+
+## Display line numbers to the left (and any anchors in the margin).
+set linenumbers
+
+## Enable vim-style lock-files.  This is just to let a vim user know you
+## are editing a file [s]he is trying to edit and vice versa.  There are
+## no plans to implement vim-style undo state in these files.
+# set locking
+
+## Fall back to slow libmagic to try and determine an applicable syntax.
+# set magic
+
+# After a search, set the mark at the end of the found match (if any).
+# set markmatch
+
+## The opening and closing brackets that can be found by bracket
+## searches.  They cannot contain blank characters.  The former set must
+## come before the latter set, and both must be in the same order.
+# set matchbrackets "(<[{)>]}"
+
+## Suppress title bar and show file name and editor state at the bottom.
+# set minibar
+
+## Enable mouse support, if available for your system.  When enabled,
+## mouse clicks can be used to place the cursor, set the mark (with a
+## double click), and execute shortcuts.  The mouse will work in the X
+## Window System, and on the console when gpm is running.
+# set mouse
+
+## Switch on multiple file buffers (inserting a file will put it into
+## a separate buffer).
+# set multibuffer
+
+## Don't convert files from DOS/Mac format.
+# set noconvert
+
+## Don't display the helpful shortcut lists at the bottom of the screen.
+# set nohelp
+
+## Don't automatically add a newline when a file does not end with one.
+# set nonewlines
+
+## Set operating directory.  nano will not read or write files outside
+## this directory and its subdirectories.  Also, the current directory
+## is changed to here, so any files are inserted from this dir.  A blank
+## string means the operating-directory feature is turned off.
+# set operatingdir ""
+
+## Remember the cursor position in each file for the next editing session.
+set positionlog
+
+## Preserve the XON and XOFF keys (^Q and ^S).
+# set preserve
+
+## The characters treated as closing punctuation when justifying
+## paragraphs.  They cannot contain blank characters.  Only closing
+## punctuation, optionally followed by closing brackets, can end
+## sentences.
+# set punct "!.?"
+
+## Do quick status-bar blanking.  Status-bar messages will disappear after
+## 1 keystroke instead of 26.  Note that "constantshow" overrides this.
+# set quickblank
+
+## The regular expression that matches quoting characters in email
+## or line-comment introducers in source code.  The default is:
+# set quotestr "^([ 	]*([!#%:;>|}]|//))+"
+
+## Try to work around a mismatching terminfo terminal description.
+# set rawsequences
+
+## Fix Backspace/Delete confusion problem.
+# set rebinddelete
+
+## Do regular-expression searches by default.
+## Regular expressions are of the extended type (ERE).
+set regexp
+
+## Save a changed buffer automatically on exit; don't prompt.
+# set saveonexit
+## (The old form of this option, 'set tempfile', is deprecated.)
+
+## Put the cursor on the highlighted item in the file browser, and show
+## the cursor in the help viewer; useful for people who use a braille
+## display and people with poor vision.
+# set showcursor
+
+## Make the Home key smarter.  When Home is pressed anywhere but at the
+## very beginning of non-whitespace characters on a line, the cursor
+## will jump to that beginning (either forwards or backwards).  If the
+## cursor is already at that position, it will jump to the true
+## beginning of the line.
+# set smarthome
+
+## Spread overlong lines over multiple screen lines.
+# set softwrap
+
+## Use this spelling checker instead of the internal one.  This option
+## does not have a default value.
+# set speller "aspell -x -c"
+
+## Use the end of the title bar for some state flags: I = auto-indenting,
+## M = mark, L = hard-wrapping long lines, R = recording, S = soft-wrapping.
+# set stateflags
+
+## Allow nano to be suspended (with ^Z by default).
+set suspendable
+## (The old form of this option, 'set suspend', is deprecated.)
+
+## Use this tab size instead of the default; it must be greater than 0.
+# set tabsize 8
+
+## Convert typed tabs to spaces.
+# set tabstospaces
+
+## Snip whitespace at the end of lines when justifying or hard-wrapping.
+# set trimblanks
+
+## The two single-column characters used to display the first characters
+## of tabs and spaces.  187 in ISO 8859-1 (0000BB in Unicode) and 183 in
+## ISO-8859-1 (0000B7 in Unicode) seem to be good values for these.
+## The default when in a UTF-8 locale:
+# set whitespace "»·"
+## The default otherwise:
+# set whitespace ">."
+
+## Detect word boundaries differently by treating punctuation
+## characters as parts of words.
+# set wordbounds
+
+## The characters (besides alphanumeric ones) that should be considered
+## as parts of words.  This option does not have a default value.  When
+## set, it overrides option 'set wordbounds'.
+# set wordchars "<_>."
+
+## Let an unmodified Backspace or Delete erase the marked region (instead
+## of a single character, and without affecting the cutbuffer).
+# set zap
+
+## Paint the interface elements of nano.  These are examples;
+## by default there are no colors, except for errorcolor.
+# set titlecolor bold,lightwhite,blue
+# set promptcolor lightwhite,lightblack
+# set statuscolor bold,lightwhite,green
+# set errorcolor bold,lightwhite,red
+# set selectedcolor lightwhite,magenta
+# set stripecolor ,yellow
+# set scrollercolor cyan
+# set numbercolor cyan
+# set keycolor cyan
+# set functioncolor green
+
+## In root's .nanorc you might want to use:
+set titlecolor bold,lightwhite,red
+set promptcolor black,yellow
+set statuscolor bold,lightwhite,red
+set errorcolor bold,lightwhite,red
+set selectedcolor lightwhite,cyan
+set stripecolor ,yellow
+set scrollercolor magenta
+set numbercolor magenta
+set keycolor lightmagenta
+set functioncolor magenta
+
+
+## === Syntax coloring ===
+## For all details, see 'man nanorc', section SYNTAX HIGHLIGHTING.
+
+## To include most of the existing syntax definitions, you can do:
+include "/usr/share/nano/*.nanorc"
+
+## Or you can select just the ones you need.  For example:
+# include "/usr/share/nano/html.nanorc"
+# include "/usr/share/nano/python.nanorc"
+# include "/usr/share/nano/sh.nanorc"
+
+## In /usr/share/nano/extra/ you can find some syntaxes that are
+## specific for certain distros or for some less common languages.
+
+
+## If <Tab> should always produce four spaces when editing a Python file,
+## independent of the settings of 'tabsize' and 'tabstospaces':
+# extendsyntax python tabgives "    "
+
+## If <Tab> should always produce an actual TAB when editing a Makefile:
+# extendsyntax makefile tabgives "	"
+
+
+## === Key bindings ===
+## For all details, see 'man nanorc', section REBINDING KEYS.
+
+## The <Ctrl+Delete> keystroke deletes the word to the right of the cursor.
+## On some terminals the <Ctrl+Backspace> keystroke produces ^H, which is
+## the ASCII character for backspace, so it is bound by default to the
+## backspace function.  The <Backspace> key itself produces a different
+## keycode, which is hard-bound to the backspace function.  So, if you
+## normally use <Backspace> for backspacing and not ^H, you can make
+## <Ctrl+Backspace> delete the word to the left of the cursor with:
+# bind ^H chopwordleft main
+
+## If you would like nano to have keybindings that are more "usual",
+## such as ^O for Open, ^F for Find, ^H for Help, and ^Q for Quit,
+## then uncomment these:
+#bind ^Q exit all
+#bind ^S savefile main
+#bind ^W writeout main
+#bind ^O insert main
+#bind ^H help all
+#bind ^H exit help
+#bind ^F whereis all
+#bind ^G findnext all
+#bind ^B wherewas all
+#bind ^D findprevious all
+#bind ^R replace main
+#bind M-X flipnewbuffer all
+#bind ^X cut all
+#bind ^C copy main
+#bind ^V paste all
+#bind ^P location main
+#bind ^A mark main
+#unbind ^K main
+#unbind ^U all
+#unbind ^N main
+#unbind ^Y all
+#unbind M-J main
+#unbind M-T main
+#bind ^T gotoline main
+#bind ^T gotodir browser
+#bind ^Y speller main
+#bind M-U undo main
+#bind M-R redo main
+#bind ^U undo main
+#bind ^E redo main
+#set multibuffer

--- a/patches/bash/0001-Remove-config.h-from-build-machine-source-files.patch
+++ b/patches/bash/0001-Remove-config.h-from-build-machine-source-files.patch
@@ -1,27 +1,28 @@
-From b2f094e8bc576366f48a99283038a4eba377f948 Mon Sep 17 00:00:00 2001
-From: Alexander van der Grinten <alexander.vandergrinten@gmail.com>
-Date: Sun, 9 Dec 2018 10:36:12 +0100
-Subject: [PATCH 1/3] Remove config.h from build-machine source files
+From 9aa37707064485088bde26cfc70f53c35f91bc17 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 9 Feb 2021 21:35:14 +0100
+Subject: [PATCH 1/3] Remove config.h from build machine source files.
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- builtins/psize.c      | 27 +++++---------------------
- mksyntax.c            | 54 ++-------------------------------------------------
- support/bashversion.c |  7 ++-----
- support/man2html.c    | 24 -----------------------
- support/mksignames.c  |  8 +-------
- support/signames.c    |  9 +--------
- 6 files changed, 11 insertions(+), 118 deletions(-)
+ builtins/psize.c      | 27 ++++------------------
+ mksyntax.c            | 53 ++-----------------------------------------
+ support/bashversion.c |  7 ++----
+ support/man2html.c    | 24 --------------------
+ support/mksignames.c  |  8 +------
+ support/signames.c    |  8 +------
+ 6 files changed, 10 insertions(+), 117 deletions(-)
 
 diff --git a/builtins/psize.c b/builtins/psize.c
-index 30881fb..54d19d2 100644
+index 30881fb3..fec55ae1 100644
 --- a/builtins/psize.c
 +++ b/builtins/psize.c
-@@ -21,33 +21,16 @@
+@@ -21,33 +21,14 @@
  /*  Write output in 128-byte chunks until we get a sigpipe or write gets an
      EPIPE.  Then report how many bytes we wrote.  We assume that this is the
      pipe size. */
 -#include <config.h>
- 
+-
 -#if defined (HAVE_UNISTD_H)
 -#  ifdef _MINIX
 -#    include <sys/types.h>
@@ -33,8 +34,8 @@ index 30881fb..54d19d2 100644
 -#ifndef _MINIX
 -#include "../bashtypes.h"
 -#endif
--#include <signal.h>
- #include <errno.h>
+ #include <signal.h>
+-#include <errno.h>
 -
 -#include "../command.h"
 -#include "../general.h"
@@ -43,7 +44,6 @@ index 30881fb..54d19d2 100644
 -#ifndef errno
 -extern int errno;
 -#endif
-+#include <signal.h>
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <unistd.h>
@@ -56,10 +56,10 @@ index 30881fb..54d19d2 100644
       int sig;
  {
 diff --git a/mksyntax.c b/mksyntax.c
-index 0385686..4a52c76 100644
+index 03856866..f09fdebc 100644
 --- a/mksyntax.c
 +++ b/mksyntax.c
-@@ -20,30 +20,18 @@
+@@ -20,30 +20,19 @@
     along with Bash.  If not, see <http://www.gnu.org/licenses/>.
  */
  
@@ -70,7 +70,7 @@ index 0385686..4a52c76 100644
  #include "bashansi.h"
  #include "chartypes.h"
  #include <errno.h>
--
+ 
 -#ifdef HAVE_UNISTD_H
 -#  include <unistd.h>
 -#endif
@@ -92,7 +92,7 @@ index 0385686..4a52c76 100644
  struct wordflag {
  	int	flag;
  	char	*fstr;
-@@ -375,41 +363,3 @@ main(argc, argv)
+@@ -375,41 +364,3 @@ main(argc, argv)
      fclose (fp);
    exit (0);
  }
@@ -135,7 +135,7 @@ index 0385686..4a52c76 100644
 -}
 -#endif /* HAVE_STRERROR */
 diff --git a/support/bashversion.c b/support/bashversion.c
-index 59c2321..6700fc4 100644
+index 4f86b134..64779de1 100644
 --- a/support/bashversion.c
 +++ b/support/bashversion.c
 @@ -18,15 +18,12 @@
@@ -157,7 +157,7 @@ index 59c2321..6700fc4 100644
  #include "bashansi.h"
  
 diff --git a/support/man2html.c b/support/man2html.c
-index 6ba5061..d86bd28 100644
+index e6f441b4..846bd540 100644
 --- a/support/man2html.c
 +++ b/support/man2html.c
 @@ -62,9 +62,6 @@
@@ -199,7 +199,7 @@ index 6ba5061..d86bd28 100644
  strgrow(char *old, int len)
  {
 diff --git a/support/mksignames.c b/support/mksignames.c
-index 5618879..f8a7646 100644
+index ba87ae8b..5bcbb167 100644
 --- a/support/mksignames.c
 +++ b/support/mksignames.c
 @@ -19,17 +19,11 @@
@@ -222,10 +222,10 @@ index 5618879..f8a7646 100644
  /* Duplicated from signames.c */
  #if !defined (NSIG)
 diff --git a/support/signames.c b/support/signames.c
-index d297808..1997e0b 100644
+index aba4842a..e369a73d 100644
 --- a/support/signames.c
 +++ b/support/signames.c
-@@ -18,18 +18,11 @@
+@@ -18,18 +18,12 @@
     along with Bash.  If not, see <http://www.gnu.org/licenses/>.
  */
  
@@ -235,7 +235,7 @@ index d297808..1997e0b 100644
  
  #include <sys/types.h>
  #include <signal.h>
--
+ 
 -#if defined (HAVE_STDLIB_H)
 -#  include <stdlib.h>
 -#else
@@ -246,5 +246,5 @@ index d297808..1997e0b 100644
  #if !defined (NSIG)
  #  define NSIG 64
 -- 
-2.11.0
+2.30.0
 

--- a/patches/bash/0002-Add-managarm-to-config.sub.patch
+++ b/patches/bash/0002-Add-managarm-to-config.sub.patch
@@ -1,28 +1,26 @@
-From 1d5cc4efde39a87a42714be4ea2c6c50b24da18f Mon Sep 17 00:00:00 2001
-From: Alexander van der Grinten <alexander.vandergrinten@gmail.com>
-Date: Sun, 9 Dec 2018 10:47:09 +0100
-Subject: [PATCH 2/3] Add managarm to config.sub
+From 77d7b051df39fdb3ebc37add566042bf38741de6 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 9 Feb 2021 21:36:42 +0100
+Subject: [PATCH 2/3] Add Managarm to config.sub
 
-bash does not cleanly rebuild its build system using autoreconf
-and there is not autogen.sh script, so we just patch config.sub.
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- support/config.sub | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
+ support/config.sub | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/support/config.sub b/support/config.sub
-index 61cb4bc..81baee6 100644
+index c874b7a9..58e76391 100755
 --- a/support/config.sub
 +++ b/support/config.sub
-@@ -1376,7 +1376,8 @@ case $os in
- 	      | -os2* | -vos* | -palmos* | -uclinux* | -nucleus* \
- 	      | -morphos* | -superux* | -rtmk* | -rtmk-nova* | -windiss* \
- 	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
--	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es*)
-+	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* \
-+		  | -managarm*)
- 	# Remember, each alternative MUST END IN *, to match a version number.
+@@ -1720,7 +1720,7 @@ case $os in
+ 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+-	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx*)
++	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | managarm*)
  		;;
- 	-qnx*)
+ 	# This one is extra strict with allowed versions
+ 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
 -- 
-2.11.0
+2.30.0
 

--- a/patches/bash/0003-Fix-use-of-SEEK-constants.patch
+++ b/patches/bash/0003-Fix-use-of-SEEK-constants.patch
@@ -1,15 +1,16 @@
-From 057bec27815a919cb06840a07a96c48964157c64 Mon Sep 17 00:00:00 2001
-From: Alexander van der Grinten <alexander.vandergrinten@gmail.com>
-Date: Fri, 17 May 2019 21:07:47 +0200
+From 3f48c17af65ea57aa57a51398043eb7a494bbcdb Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 9 Feb 2021 21:37:45 +0100
 Subject: [PATCH 3/3] Fix use of SEEK constants
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  lib/termcap/termcap.c | 2 +-
  shell.c               | 4 ++--
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/lib/termcap/termcap.c b/lib/termcap/termcap.c
-index ba3dab2..2882f0c 100644
+index ba3dab2c..2882f0c4 100644
 --- a/lib/termcap/termcap.c
 +++ b/lib/termcap/termcap.c
 @@ -627,7 +627,7 @@ scan_file (str, fd, bufp)
@@ -22,10 +23,10 @@ index ba3dab2..2882f0c 100644
    while (!bufp->ateof)
      {
 diff --git a/shell.c b/shell.c
-index 45b77f9..9e9aa0e 100644
+index ce8087f7..b7475dd2 100644
 --- a/shell.c
 +++ b/shell.c
-@@ -1548,7 +1548,7 @@ open_shell_script (script_name)
+@@ -1614,7 +1614,7 @@ open_shell_script (script_name)
  #endif
  
    /* Only do this with non-tty file descriptors we can seek on. */
@@ -34,7 +35,7 @@ index 45b77f9..9e9aa0e 100644
      {
        /* Check to see if the `file' in `bash file' is a binary file
  	 according to the same tests done by execute_simple_command (),
-@@ -1579,7 +1579,7 @@ open_shell_script (script_name)
+@@ -1651,7 +1651,7 @@ open_shell_script (script_name)
  	  exit (EX_BINARY_FILE);
  	}
        /* Now rewind the file back to the beginning. */
@@ -44,5 +45,5 @@ index 45b77f9..9e9aa0e 100644
  
    /* Open the script.  But try to move the file descriptor to a randomly
 -- 
-2.11.0
+2.30.0
 

--- a/patches/ncurses/0001-Add-managarm-support.patch
+++ b/patches/ncurses/0001-Add-managarm-support.patch
@@ -1,42 +1,42 @@
-From 44848b51a1cc66cbec3b97a7d751113df5c329bf Mon Sep 17 00:00:00 2001
-From: Dennisbonke <admin@dennisbonke.com>
-Date: Fri, 22 May 2020 16:42:10 +0200
+From 3c5c2fe0ce67f80ce9698f0c6154cc1d41a113bd Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 9 Feb 2021 22:45:04 +0100
 Subject: [PATCH] Add managarm support
 
-Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  config.sub | 2 +-
  configure  | 4 ++++
  2 files changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/config.sub b/config.sub
-index 00f68b8e..5f6344ab 100755
+index 0f2234c1..69ffcaa9 100755
 --- a/config.sub
 +++ b/config.sub
-@@ -1416,7 +1416,7 @@ case $os in
- 	      | -morphos* | -superux* | -rtmk* | -rtmk-nova* | -windiss* \
- 	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
- 	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* \
--	      | -onefs* | -tirtos* | -phoenix* | -fuchsia* | -redox*)
-+	      | -onefs* | -tirtos* | -phoenix* | -fuchsia* | -redox* | -managarm*)
+@@ -1366,7 +1366,7 @@ case $os in
+ 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+-	     | nsk* | powerunix)
++	     | nsk* | powerunix | managarm*)
  	# Remember, each alternative MUST END IN *, to match a version number.
  		;;
- 	-qnx*)
+ 	qnx*)
 diff --git a/configure b/configure
-index adead920..7fbdd312 100755
+index 06f344f3..72e641d3 100755
 --- a/configure
 +++ b/configure
-@@ -6335,6 +6335,10 @@ echo "${ECHO_T}$cf_cv_ldflags_search_paths_first" >&6
+@@ -5961,6 +5961,10 @@ echo "${ECHO_T}$cf_cv_ldflags_search_paths_first" >&6
  
  		MK_SHARED_LIB='${CC} ${LDFLAGS} ${CFLAGS} -shared -Wl,-soname,'$cf_cv_shared_soname',-stats,-lc -o $@'
  		;;
-+	(managarm*)
-+		CC_SHARED_OPTS='-fPIC'
-+                MK_SHARED_LIB='${CC} -shared -o $@'
-+		;;
++  (managarm*)
++    CC_SHARED_OPTS='-fPIC'
++                 MK_SHARED_LIB='${CC} -shared -o $@'
++    ;;
  	(mingw*)
  		cf_cv_shlib_version=mingw
  		cf_cv_shlib_version_infix=mingw
 -- 
-2.26.2
+2.30.0
 

--- a/patches/readline/0001-Add-managarm-support.patch
+++ b/patches/readline/0001-Add-managarm-support.patch
@@ -1,29 +1,29 @@
-From 9e4fabbecc9c725760f4ebdf781755efedf03d74 Mon Sep 17 00:00:00 2001
-From: Dennisbonke <admin@dennisbonke.com>
-Date: Tue, 26 May 2020 01:29:33 +0200
+From 983b779d546a3e7657a46e46ec3946083420c14a Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 9 Feb 2021 22:36:49 +0100
 Subject: [PATCH] Add managarm support
 
-Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  support/config.sub    | 2 +-
  support/shlib-install | 4 ++--
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/support/config.sub b/support/config.sub
-index f208558..c0c1594 100755
+index c874b7a..58e7639 100755
 --- a/support/config.sub
 +++ b/support/config.sub
-@@ -1360,7 +1360,7 @@ case $os in
- 	     | powermax* | dnix* | nx6 | nx7 | sei* | dragonfly* \
+@@ -1720,7 +1720,7 @@ case $os in
  	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
  	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
--	     | midnightbsd*)
-+	     | midnightbsd* | managarm*)
- 	# Remember, each alternative MUST END IN *, to match a version number.
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+-	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx*)
++	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | managarm*)
  		;;
- 	qnx*)
+ 	# This one is extra strict with allowed versions
+ 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
 diff --git a/support/shlib-install b/support/shlib-install
-index f4eea27..1123a48 100755
+index 661355d..2d554f3 100755
 --- a/support/shlib-install
 +++ b/support/shlib-install
 @@ -71,7 +71,7 @@ fi
@@ -45,5 +45,5 @@ index f4eea27..1123a48 100755
  	${echo} ${RM} ${INSTALLDIR}/$LINK1
  	if [ -z "$uninstall" ]; then
 -- 
-2.26.2
+2.30.0
 

--- a/scripts/update-image.py
+++ b/scripts/update-image.py
@@ -336,7 +336,7 @@ class UpdateFsAction:
 		plan_install('usr/managarm/bin/thor', 'boot/managarm', strip = True)
 		plan_install('initrd.cpio', 'boot/managarm', ignore_sysroot = True)
 
-		for dir in ['root', 'usr/bin', 'usr/lib', 'var', 'dev', 'proc', 'run', 'sys', 'tmp', 'boot/grub']:
+		for dir in ['root', 'usr/bin', 'usr/lib', 'var', 'dev', 'proc', 'run', 'sys', 'tmp', 'boot/grub', 'home']:
 			plan_create_dir(dir)
 
 		plan_cp(os.path.join(scriptdir, 'grub.cfg'), 'boot/grub')
@@ -361,6 +361,7 @@ class UpdateFsAction:
 		plan_rsync('usr/')
 		plan_rsync('etc/')
 		plan_rsync('var/')
+		plan_rsync('home/')
 
 		plan_cp(f'tools/system-gcc/{self.arch}/lib64/libgcc_s.so.1', 'usr/lib')
 		plan_cp(f'tools/system-gcc/{self.arch}/lib64/libstdc++.so.6', 'usr/lib')


### PR DESCRIPTION
This PR updates the following packages:

- `glew`, updated from version 2.1.0 to 2.2.0,
- `wget`, updated from version 1.20.3 to 1.21.1,
- `sqlite`, updated from version 3.34.0 to 3.34.1,
- `tar`, updated from version 1.32 to 1.33,
- `findutils`, updated from version 4.7.0 to 4.8.0,
- `tzdata`, updated from version 2020f to 2021a,
- `bash`, install additional files and updated from version 4.4 to 5.1.4,
- `ncurses`, yes, our nanosleep works fine, please use it and updated from version 6.1 to 6.2,
- `nano`, install a nanorc in the users home dir by default and modify the default,
- `vim`, updated from version 8.2.0814 to 8.2.2433,
- `iana-etc`, updated from version 2.30 to 20210202,
- `xorg-util-macros`, updated from version 1.19.1 to 1.19.3,
- `libxt`, updated from version 1.2.0 to 1.2.1,
- `pango`, updated from version 1.46.2 to 1.48.1,
- `glib`, updated from version 2.66.4 to 2.66.6 (critical security fix),
- `curl`, updated from version 7.70.0 to 7.75.0,
- `readline`, updated from version 8.0 to 8.1.

Furthermore, there was an update to `core-files` to create `/home/managarm` by default and an update to the `mkimage` script to sync the `/home` directory to the image.