### PR TITLE
sys-libs: Add a port of libintl

### DIFF
--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -22,6 +22,8 @@ packages:
       - system-gcc
     pkgs_required:
       - ncurses
+      - libintl
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -448,6 +448,53 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libintl
+    source:
+      subdir: 'ports'
+      url: 'https://ftp.gnu.org/gnu/gettext/gettext-0.21.tar.xz'
+      format: 'tar.xz'
+      extract_path: 'gettext-0.21'
+      version: '0.21'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libiconv
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--without-emacs'
+        - '--without-lispdir'
+        # Normally this controls nls behavior in general, but the libintl
+        # subdir is skipped unless this is explicitly set.
+        - '--enable-nls'
+        # This magic flag enables libintl.
+        - '--with-included-gettext'
+        - '--disable-c++'
+        - '--disable-libasprintf'
+        - '--disable-java'
+        - '--enable-shared'
+        - '--disable-static'
+        - '--enable-threads=posix'
+        - '--disable-curses'
+        - '--without-git'
+        - '--without-cvs'
+        - '--without-bzip2'
+        - '--without-xz'
+    build:
+      - args: ['make', '-C', 'gettext-runtime/intl', '-j@PARALLELISM@']
+      - args: ['make', '-C', 'gettext-runtime/intl', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: libpipeline
     source:
       subdir: ports

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -89,6 +89,8 @@ packages:
       - libffi
       - zlib
       - libiconv
+      - libintl
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -955,6 +955,7 @@ packages:
         - '@THIS_SOURCE_DIR@'
         - '-Dheaders_only=true'
         - '-Ddisable_iconv_option=true'
+        - '-Ddisable_intl_option=true'
     build:
       - args: ['ninja']
       - args: ['ninja', 'install']
@@ -982,6 +983,7 @@ packages:
         - '--buildtype=debugoptimized'
         - '-Dmlibc_no_headers=true'
         - '-Ddisable_iconv_option=true'
+        - '-Ddisable_intl_option=true'
         - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']


### PR DESCRIPTION
This PR adds a port of `libintl` and makes some adjustments to several packages to reflect this. In addition, it disabled building the intl option in mlibc.

This PR adds the following port:
- `libintl` as provided by gettext for internationalization.

Furthermore, the following ports received updates:
- `mlibc` and `mlibc-headers` now disable building the `intl` option,
- `glib`, depend on `libintl` and bump revision,
- `nano`, depend on `libintl` and bump revision.

Blocked on managarm/mlibc#223