### PR TITLE
Add a port of several libraries and rsync

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -83,6 +83,28 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: lz4
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/lz4/lz4.git'
+      tag: 'v1.9.3'
+      version: '1.9.3'
+    tools_required:
+      - host-cmake
+      - system-gcc
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '@THIS_SOURCE_DIR@/build/cmake'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: tar
     source:
       subdir: ports

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -823,6 +823,35 @@ packages:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
 
+  - name: popt
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/rpm-software-management/popt.git'
+      tag: 'popt-1.18-release'
+      version: '1.18'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libiconv
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--disable-nls'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: wayland-protocols
     source:
       subdir: 'ports'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -930,3 +930,27 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: xxhash
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/Cyan4973/xxHash.git'
+      tag: 'v0.8.0'
+      version: '0.8.0'
+    tools_required:
+      - system-gcc
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+        environ:
+          PREFIX: '/usr'
+          LIBDIR: '/usr/lib'
+          CC: '@OPTION:arch-triple@-gcc'
+          AR: '@OPTION:arch-triple@-ar'
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+          PREFIX: '/usr'
+          LIBDIR: '/usr/lib'
+          MANDIR: '/usr/share/man/man1'
+      - args: ['rm', '-v', '@THIS_COLLECT_DIR@/usr/lib/libxxhash.a']

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -74,6 +74,38 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: d0-blind-id
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/divVerent/d0_blind_id.git'
+      tag: 'v1.0'
+      version: '1.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - gmp
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--disable-rijndael'
+        - '--without-openssl'
+        - '--without-tommath'
+        - '--without-tfm'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: fribidi
     source:
       subdir: 'ports'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -343,6 +343,37 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libvorbis
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/xiph/vorbis.git'
+      tag: 'v1.3.7'
+      version: '1.3.7'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            NOCONFIGURE: '1'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libogg
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: mesa
     source:
       subdir: 'ports'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -284,6 +284,35 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libogg
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/xiph/ogg.git'
+      tag: 'v1.3.4'
+      version: '1.3.4'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            NOCONFIGURE: '1'
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libpng
     source:
       subdir: 'ports'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -284,6 +284,34 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libmodplug
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/Konstanty/libmodplug.git'
+      # Check out current master
+      branch: 'master'
+      commit: '5a39f5913d07ba3e61d8d5afdba00b70165da81d'
+      version: '0.8.9.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libogg
     source:
       subdir: 'ports'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -343,6 +343,44 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libtheora
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/xiph/theora.git'
+      tag: 'v1.1.1'
+      version: '1.1.1'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - libogg
+      - libvorbis
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--disable-spec'
+        - '--disable-sdltest'
+        - '--disable-vorbistest'
+        - '--disable-oggtest'
+        - '--disable-examples'
+        - '--disable-asm'
+        environ:
+          HAVE_DOXYGEN: 'false'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libvorbis
     source:
       subdir: 'ports'

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -50,6 +50,65 @@ packages:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
 
+  - name: rsync
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/WayneD/rsync.git'
+      tag: 'v3.2.3'
+      version: '3.2.3'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['aclocal', '-I', 'm4']
+        - args: ['autoconf', '-o', 'configure.sh']
+        - args: ['autoheader']
+        - args: ['touch', 'config.h.in']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/']
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - lz4
+      - libressl
+      - libiconv
+      - zlib
+      - xxhash
+      - zstd
+      - popt
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--enable-openssl'
+        - '--disable-md2man'
+        - '--disable-simd'
+        - '--disable-asm'
+        - '--disable-locale'
+        - '--enable-xxhash'
+        - '--enable-zstd'
+        - '--enable-lz4'
+        - '--enable-iconv'
+        - '--enable-ipv6'
+        - '--disable-acl-support'
+        - '--disable-xattr-support'
+        - '--without-included-zlib'
+        - '--without-included-popt'
+        - '--with-rsyncd-conf=/etc/rscynd.conf'
+        environ:
+          rsync_cv_HAVE_GETTIMEOFDAY_TZ: 'yes'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: socat
     source:
       subdir: 'ports'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1183,6 +1183,46 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxxf86dga
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/xorg/lib/libxxf86dga.git'
+      tag: 'libXxf86dga-1.1.5'
+      version: '1.1.5'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+        - host-libtool
+        - host-pkg-config
+        - host-xorg-macros
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - xorg-util-macros
+      - xorg-proto
+      - libx11
+      - libxtrans
+      - libxext
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-static'
+        - '--disable-malloc0returnsnull'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxxf86vm
     source:
       subdir: ports

--- a/patches/d0-blind-id/0001-Add-managarm-support.patch
+++ b/patches/d0-blind-id/0001-Add-managarm-support.patch
@@ -1,0 +1,48 @@
+From a65eb74e585f43f08b0b5546468e168454b21fc4 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 3 Feb 2021 15:54:42 +0100
+Subject: [PATCH] Add managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ autogen.sh | 0
+ main.c     | 4 ++++
+ sha2.c     | 1 +
+ 3 files changed, 5 insertions(+)
+ mode change 100644 => 100755 autogen.sh
+
+diff --git a/autogen.sh b/autogen.sh
+old mode 100644
+new mode 100755
+diff --git a/main.c b/main.c
+index 1fa088f..7702060 100644
+--- a/main.c
++++ b/main.c
+@@ -52,8 +52,12 @@ void bench(double *b)
+ }
+ 
+ #ifndef WIN32
++#ifdef __managarm__
++#include <signal.h>
++#else
+ #include <sys/signal.h>
+ #endif
++#endif
+ volatile D0_BOOL quit = 0;
+ void mysignal(int signo)
+ {
+diff --git a/sha2.c b/sha2.c
+index 1ca0f81..56d4297 100644
+--- a/sha2.c
++++ b/sha2.c
+@@ -40,6 +40,7 @@ const char *d0_sha2_c_bsd_license_notice D0_USED = "\n"
+ " * $Original-Id: sha2.c,v 1.1 2001/11/08 00:01:51 adg Exp adg $\n"
+ " */\n";
+ 
++#include <endian.h>
+ #include <string.h>	/* memcpy()/memset() or bcopy()/bzero() */
+ #include <assert.h>	/* assert() */
+ #include "sha2.h"
+-- 
+2.30.0
+

--- a/patches/libmodplug/0001-Add-managarm-support.patch
+++ b/patches/libmodplug/0001-Add-managarm-support.patch
@@ -1,0 +1,65 @@
+From 07683190e0e2d5b4b04f82ea692a115adb6e42e8 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 3 Feb 2021 15:48:41 +0100
+Subject: [PATCH] Add managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ src/fastmix.cpp  | 1 +
+ src/load_abc.cpp | 1 +
+ src/load_stm.cpp | 1 +
+ src/load_umx.cpp | 2 +-
+ 4 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/fastmix.cpp b/src/fastmix.cpp
+index d693d20..f25c8be 100644
+--- a/src/fastmix.cpp
++++ b/src/fastmix.cpp
+@@ -8,6 +8,7 @@
+ #include "stdafx.h"
+ #include "sndfile.h"
+ #include <math.h>
++#include <strings.h>
+ 
+ #ifdef MSC_VER
+ #pragma bss_seg(".modplug")
+diff --git a/src/load_abc.cpp b/src/load_abc.cpp
+index ee79f39..2baf693 100644
+--- a/src/load_abc.cpp
++++ b/src/load_abc.cpp
+@@ -28,6 +28,7 @@
+ #include <stdlib.h>
+ #include <time.h>
+ #include <string.h>
++#include <strings.h>
+ #include <math.h>
+ #include <ctype.h>
+ #ifndef _WIN32
+diff --git a/src/load_stm.cpp b/src/load_stm.cpp
+index 6f55b78..8b314ac 100644
+--- a/src/load_stm.cpp
++++ b/src/load_stm.cpp
+@@ -6,6 +6,7 @@
+ 
+ #include "stdafx.h"
+ #include "sndfile.h"
++#include <strings.h>
+ 
+ //#pragma warning(disable:4244)
+ 
+diff --git a/src/load_umx.cpp b/src/load_umx.cpp
+index c3f8c93..d4128da 100644
+--- a/src/load_umx.cpp
++++ b/src/load_umx.cpp
+@@ -11,7 +11,7 @@
+ 
+ #include "stdafx.h"
+ #include "sndfile.h"
+-
++#include <strings.h>
+ 
+ typedef LONG fci_t;		/* FCompactIndex */
+ 
+-- 
+2.30.0
+

--- a/patches/libtheora/0001-Remove-the-force-configure-from-autogen.sh.patch
+++ b/patches/libtheora/0001-Remove-the-force-configure-from-autogen.sh.patch
@@ -1,0 +1,23 @@
+From 2bc3e53c93099e001ce5c09d8cd8f7cd37e0a7ea Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 3 Feb 2021 15:45:29 +0100
+Subject: [PATCH] Remove the force configure from autogen.sh
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ autogen.sh | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index bbca69d..b6d4b13 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -125,5 +125,3 @@ $AUTOMAKE --add-missing $AUTOMAKE_FLAGS || exit 1
+ echo "  autoconf"
+ autoconf || exit 1
+ 
+-cd $olddir
+-$srcdir/configure --enable-maintainer-mode "$@" && echo
+-- 
+2.30.0
+

--- a/patches/popt/0001-Fix-missing-termios-include.patch
+++ b/patches/popt/0001-Fix-missing-termios-include.patch
@@ -1,0 +1,25 @@
+From c56de322d59c4e889bc21fabc1be08c09667debc Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 3 Feb 2021 16:18:36 +0100
+Subject: [PATCH] Fix missing termios include
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ src/popthelp.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/popthelp.c b/src/popthelp.c
+index 3c05acb..902ea1c 100644
+--- a/src/popthelp.c
++++ b/src/popthelp.c
+@@ -12,6 +12,7 @@
+ 
+ #define        POPT_USE_TIOCGWINSZ
+ #ifdef POPT_USE_TIOCGWINSZ
++#include <termios.h>
+ #include <sys/ioctl.h>
+ #endif
+ 
+-- 
+2.30.0
+


### PR DESCRIPTION
This PR adds the following new ports:

- `libogg`,
- `libvorbis`,
- `libtheora`,
- `libmodplug`,
- `d0-blind-id`,
- `libxxf86dga`,
- `popt`, a dependency for `rsync`,
- `lz4`, a dependency for `rsync`,
- `xxhash`, a dependency for `rsync`,
- `rsync`.

Part of #33 