### PR TITLE
atk, gdk-pixbuf, libjpeg-turbo: Use the arch suffixed cross files

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -62,7 +62,7 @@ packages:
       - args:
         - 'meson'
         - '--cross-file'
-        - '@SOURCE_ROOT@/scripts/meson.cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
         - '--libdir=lib'
         - '--buildtype=debugoptimized'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -267,7 +267,7 @@ packages:
     configure:
       - args:
         - 'cmake'
-        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain.txt'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
         - '-DCMAKE_INSTALL_PREFIX=/usr'
         - '-DCMAKE_BUILD_TYPE=RELEASE'
         - '-DENABLE_STATIC=FALSE'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -100,7 +100,7 @@ packages:
       - args:
         - 'meson'
         - '--cross-file'
-        - '@SOURCE_ROOT@/scripts/meson.cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
         - '-Dgir=false'
         - '-Dman=false'


### PR DESCRIPTION
This fixes several build failures introduced by pr #69 