### PR TITLE
Updates of various packages

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -755,8 +755,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://git.lysator.liu.se/nettle/nettle.git'
-      tag: 'nettle_3.6_release_20200429'
-      version: '3.6'
+      tag: 'nettle_3.7.1_release_20210217'
+      version: '3.7.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -621,8 +621,8 @@ packages:
     source:
       subdir: ports
       git: 'https://github.com/libuv/libuv.git'
-      tag: 'v1.39.0'
-      version: '1.39.0'
+      tag: 'v1.41.0'
+      version: '1.41.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -2,8 +2,8 @@ sources:
   - name: glib
     subdir: ports
     git: 'https://gitlab.gnome.org/GNOME/glib'
-    tag: '2.66.6'
-    version: '2.66.6'
+    tag: '2.66.7'
+    version: '2.66.7'
 
   - name: icu
     subdir: 'ports'

--- a/bootstrap.d/dev-util.yml
+++ b/bootstrap.d/dev-util.yml
@@ -2,8 +2,8 @@ sources:
   - name: 'cmake'
     subdir: 'ports'
     git: 'https://gitlab.kitware.com/cmake/cmake.git'
-    tag: 'v3.18.0'
-    version: '3.18.0'
+    tag: 'v3.19.5'
+    version: '3.19.5'
 
   - name: 'pkg-config'
     subdir: 'ports'
@@ -31,7 +31,7 @@ tools:
       - args: ['make', '-j@PARALLELISM@']
     install:
       - args: ['make', 'install']
-      - args: ['ln', '-sf', '@SOURCE_ROOT@/scripts/managarm.cmake', '@PREFIX@/share/cmake-3.18/Modules/Platform/']
+      - args: ['ln', '-sf', '@SOURCE_ROOT@/scripts/managarm.cmake', '@PREFIX@/share/cmake-3.19/Modules/Platform/']
 
   # We could run an external pkg-config; however, we need the aclocal files.
   # The easiest way to ensure that they are available is to just install pkg-config.
@@ -62,6 +62,7 @@ packages:
       - libxml
       - xz-utils
       - zlib
+      - zstd
     configure:
       - args: ['sed', '-i', '/"lib64"/s/64//', '@THIS_SOURCE_DIR@/Modules/GNUInstallDirs.cmake']
       - args: ['cp', '-f', '@SOURCE_ROOT@/scripts/managarm.cmake', '@THIS_SOURCE_DIR@/Modules/Platform/']
@@ -69,11 +70,11 @@ packages:
         - '@THIS_SOURCE_DIR@/bootstrap'
         - '--prefix=/usr'
         - '--system-libs'
-        - '--mandir=/share/man'
+        - '--mandir=/usr/share/man'
+        - '--datadir=/usr/share/cmake-3.19'
         - '--no-system-jsoncpp'
         - '--no-system-librhash'
-        - '--no-system-zstd'
-        - '--docdir=/usr/share/doc/cmake-3.18.0'
+        - '--docdir=/usr/share/doc/cmake-3.19.5'
         - '--parallel=@PARALLELISM@'
         - '--'
         - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -27,6 +27,7 @@ packages:
       - diffutils
       - xz-utils
       - findutils
+      - util-linux
     configure: []
     build: []
 

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -274,8 +274,8 @@ packages:
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/man-db.git'
-      tag: '2.9.1'
-      version: '2.9.1'
+      tag: '2.9.4'
+      version: '2.9.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -301,7 +301,7 @@ packages:
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
         - '--disable-nls'
-        - '--docdir=/usr/share/doc/man-db-2.9.1'
+        - '--docdir=/usr/share/doc/man-db-2.9.4'
         - '--sysconfdir=/etc'
         - '--disable-setuid'
         - '--with-systemdtmpfilesdir='

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -390,8 +390,8 @@ packages:
     source:
       subdir: ports
       git: 'https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git'
-      tag: 'v2.36.1'
-      version: '2.36.1'
+      tag: 'v2.36.2'
+      version: '2.36.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -408,12 +408,16 @@ packages:
       - zlib
       - libiconv
       - file
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
+        - '--exec-prefix=/usr'
+        - '--libdir=/usr/lib'
+        - '--bindir=/usr/bin'
+        - '--sbindir=/usr/sbin'
+        - '--with-udev'
         - '--disable-nls'
         - '--disable-static'
         - '--without-python'

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -101,8 +101,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config.git'
-      tag: 'xkeyboard-config-2.30'
-      version: '2.30'
+      tag: 'xkeyboard-config-2.32'
+      version: '2.32'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -677,8 +677,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/gentoo/eudev.git'
-      tag: 'v3.2.2'
-      version: '3.2.2'
+      tag: 'v3.2.10'
+      version: '3.2.10'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.11
@@ -699,7 +699,7 @@ packages:
         - '--disable-kmod'
         - '--disable-mtd-probe'
         - '--disable-rule-generator'
-        - '--disable-manpages'
+        - '--enable-introspection=no'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/patches/util-linux/0002-Revamp-the-configure-script.patch
+++ b/patches/util-linux/0002-Revamp-the-configure-script.patch
@@ -1,18 +1,16 @@
-From 0a00d26a55188907036ab4c1b260de3952416f16 Mon Sep 17 00:00:00 2001
+From b07e4d05bb062d95ebc17e1a98b63dc31b82723f Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
-Date: Sat, 23 Jan 2021 00:06:46 +0100
-Subject: [PATCH 2/2] Revamp the configure script.
-
-Revamp the configure script to allow for more fine-grained control over the programs build.
-Make configure think that managarm is Linux.
+Date: Tue, 16 Feb 2021 10:21:13 +0100
+Subject: [PATCH 2/2] Revamp the configure script to allow for more fine-grained
+ control over the programs build. Make configure think that Managarm is Linux.
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- configure.ac | 268 ++++++++++++++++++++++++++++++++++++++++++---------
- 1 file changed, 223 insertions(+), 45 deletions(-)
+ configure.ac | 258 ++++++++++++++++++++++++++++++++++++++++++---------
+ 1 file changed, 216 insertions(+), 42 deletions(-)
 
 diff --git a/configure.ac b/configure.ac
-index 4117969c6..b756ef7f1 100644
+index 2ac4c2bdf..345a3d319 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -212,6 +212,8 @@ bsd_os=no
@@ -48,13 +46,12 @@ index 4117969c6..b756ef7f1 100644
 +UL_BUILD_INIT([mkfs])
  AM_CONDITIONAL([BUILD_MKFS], [test "x$build_mkfs" = xyes])
  
--UL_BUILD_INIT([isosize], [yes])
-+
 +AC_ARG_ENABLE([isosize],
 +  AS_HELP_STRING([--disable-isosize], [do not build isosize]),
 +  [], [UL_DEFAULT_ENABLE([isosize], [yes])]
 +)
 +UL_BUILD_INIT([isosize])
+ UL_BUILD_INIT([isosize], [yes])
  AM_CONDITIONAL([BUILD_ISOSIZE], [test "x$build_isosize" = xyes])
  
  
@@ -104,15 +101,6 @@ index 4117969c6..b756ef7f1 100644
  UL_REQUIRES_LINUX([lscpu])
  UL_REQUIRES_BUILD([lscpu], [libsmartcols])
  UL_REQUIRES_HAVE([lscpu], [cpu_set_t], [cpu_set_t type])
-@@ -1565,7 +1595,7 @@ AM_CONDITIONAL([BUILD_LSCPU], [test "x$build_lscpu" = xyes])
- 
- AC_ARG_ENABLE([lslogins],
-   AS_HELP_STRING([--disable-lslogins], [do not build lslogins]),
--  [], [UL_DEFAULT_ENABLE([lslogins], [check])]
-+  [], [UL_DEFAULT_ENABLE([lslogins], [yes])]
- )
- UL_BUILD_INIT([lslogins])
- UL_REQUIRES_BUILD([lslogins], [libsmartcols])
 @@ -1575,7 +1605,11 @@ UL_REQUIRES_HAVE([lslogins], [gnu_utmpx], [GNU utmpx functions])
  AM_CONDITIONAL([BUILD_LSLOGINS], [test "x$build_lslogins" = xyes])
  
@@ -147,7 +135,7 @@ index 4117969c6..b756ef7f1 100644
 +)
 +UL_BUILD_INIT([mkswap])
  AM_CONDITIONAL([BUILD_MKSWAP], [test "x$build_mkswap" = xyes])
- AS_IF([test "x$build_mkswap" = xyes -a "x$build_libuuid" != xyes], [
+ AS_IF([test "x$build_mkswap" = xyes && test "x$build_libuuid" != xyes], [
    AC_MSG_WARN([uuid library is not found; mkswap(8) will not generate UUIDs])
 @@ -1618,13 +1660,25 @@ AC_ARG_ENABLE([logger],
  UL_BUILD_INIT([logger])
@@ -178,16 +166,8 @@ index 4117969c6..b756ef7f1 100644
  AM_CONDITIONAL([BUILD_NAMEI], [test "x$build_namei" = xyes])
  
  matriplet="$($CC -print-multiarch 2>/dev/null || true)"
-@@ -1632,19 +1686,35 @@ if test "x$matriplet" != "x"; then
-   AC_DEFINE_UNQUOTED([MULTIARCHTRIPLET], ["$matriplet"],
-   ["Multi-arch triplet for whereis library search path"])
- fi
--UL_BUILD_INIT([whereis], [yes])
-+AC_ARG_ENABLE([whereis],
-+  AS_HELP_STRING([--disable-whereis], [do not build whereis]),
-+  [], [UL_DEFAULT_ENABLE([whereis], [yes])]
-+)
-+UL_BUILD_INIT([whereis])
+@@ -1635,16 +1689,28 @@ fi
+ UL_BUILD_INIT([whereis], [yes])
  AM_CONDITIONAL([BUILD_WHEREIS], [test "x$build_whereis" = xyes])
  
 -UL_BUILD_INIT([getopt], [yes])
@@ -218,7 +198,7 @@ index 4117969c6..b756ef7f1 100644
  UL_REQUIRES_LINUX([prlimit])
  UL_REQUIRES_BUILD([prlimit], [libsmartcols])
  UL_REQUIRES_SYSCALL_CHECK([prlimit], [UL_CHECK_SYSCALL([prlimit64])], [prlimit64])
-@@ -1654,7 +1724,11 @@ AS_IF([test "x$build_prlimit" = xyes], [
+@@ -1654,7 +1720,11 @@ AS_IF([test "x$build_prlimit" = xyes], [
  ])
  
  
@@ -231,7 +211,7 @@ index 4117969c6..b756ef7f1 100644
  UL_REQUIRES_LINUX([lslocks])
  UL_REQUIRES_BUILD([lslocks], [libmount])
  UL_REQUIRES_BUILD([lslocks], [libsmartcols])
-@@ -1682,7 +1756,11 @@ UL_REQUIRES_SYSCALL_CHECK([pivot_root], [UL_CHECK_SYSCALL([pivot_root])])
+@@ -1682,7 +1752,11 @@ UL_REQUIRES_SYSCALL_CHECK([pivot_root], [UL_CHECK_SYSCALL([pivot_root])])
  AM_CONDITIONAL([BUILD_PIVOT_ROOT], [test "x$build_pivot_root" = xyes])
  
  
@@ -244,7 +224,7 @@ index 4117969c6..b756ef7f1 100644
  UL_REQUIRES_HAVE([flock], [timer], [timer_create/setitimer function])
  AM_CONDITIONAL([BUILD_FLOCK], [test "x$build_flock" = xyes])
  
-@@ -1705,7 +1783,11 @@ UL_BUILD_INIT([chmem])
+@@ -1705,7 +1779,11 @@ UL_BUILD_INIT([chmem])
  UL_REQUIRES_LINUX([chmem])
  AM_CONDITIONAL([BUILD_CHMEM], [test "x$build_chmem" = xyes])
  
@@ -257,7 +237,7 @@ index 4117969c6..b756ef7f1 100644
  AM_CONDITIONAL([BUILD_IPCMK], [test "x$build_ipcmk" = xyes])
  
  
-@@ -1745,22 +1827,38 @@ UL_REQUIRES_BUILD([lsirq], [libsmartcols])
+@@ -1745,22 +1823,38 @@ UL_REQUIRES_BUILD([lsirq], [libsmartcols])
  AM_CONDITIONAL([BUILD_LSIRQ], [test "x$build_lsirq" = xyes])
  
  
@@ -300,7 +280,7 @@ index 4117969c6..b756ef7f1 100644
  AM_CONDITIONAL([BUILD_RENICE], [test "x$build_renice" = xyes])
  
  
-@@ -1774,18 +1872,34 @@ UL_REQUIRES_BUILD([rfkill], [libsmartcols])
+@@ -1774,18 +1868,34 @@ UL_REQUIRES_BUILD([rfkill], [libsmartcols])
  AM_CONDITIONAL([BUILD_RFKILL], [test "x$build_rfkill" = xyes])
  
  
@@ -339,7 +319,7 @@ index 4117969c6..b756ef7f1 100644
  UL_REQUIRES_LINUX([ctrlaltdel])
  dnl we assume reboot() to be the 1-argument variant, because even considering
  dnl widely used alternative C libraries like uclibc, dietlibc and musl,
-@@ -1794,64 +1908,128 @@ dnl earlier than 2.x.
+@@ -1794,64 +1904,128 @@ dnl earlier than 2.x.
  UL_REQUIRES_HAVE([ctrlaltdel], [reboot], [reboot function])
  AM_CONDITIONAL([BUILD_CTRLALTDEL], [test "x$build_ctrlaltdel" = xyes])
  


### PR DESCRIPTION
This PR updates the following packages:

- `util-linux`, update from version 2.36.1 to 2.36.2 and install all programs in `/usr`,
- `glib`, update from version 2.66.6 to 2.66.7,
- `libuv`, update from version 1.39.0 to 1.41.0,
- `cmake`, update from version 3.18.0 to 3.19.5 (this includes an update for `host-cmake`),
- `xkeyboard-config`, update from version 2.30 to 2.32,
- `eudev`, update from version 3.2.2 to 3.2.10,
- `nettle`, update from version 3.6 to 3.7.1,
- `man-db`, update from version 2.9.1 to 2.9.4.

This PR is blocked on managarm/mlibc#233