### PR TITLE
Deprecate libressl and add OpenSSL

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -61,14 +61,14 @@ packages:
       - host-cmake
       - system-gcc
     pkgs_required:
-      - libressl
+      - openssl
       - zlib
       - xz-utils
       - libiconv
       - libexpat
       - libxml
       - zstd
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -109,10 +109,11 @@ packages:
       - ncurses
       - readline
       - bzip2
-      - libressl
+      - openssl
       - xz-utils
       - gdbm
-    revision: 3
+      - util-linux
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -823,6 +823,41 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: openssl
+    source:
+      subdir: ports
+      git: 'https://github.com/openssl/openssl.git'
+      tag: 'OpenSSL_1_1_1j'
+      version: '1.1.1j'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - zlib
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/config'
+        - '--prefix=/usr'
+        - '--openssldir=/etc/ssl'
+        - '--libdir=lib'
+        - 'shared'
+        - 'zlib-dynamic'
+        - 'no-afalgeng'
+        environ:
+          CC: 'x86_64-managarm-gcc'
+          CXX: 'x86_64-managarm-g++'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      # Disable installing static libraries
+      - args: ['sed', '-i', '/INSTALL_LIBS/s/libcrypto.a libssl.a//', '@THIS_BUILD_DIR@/Makefile']
+      # Suffix all man pages with ssl
+      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'MANSUFFIX=ssl', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      # Move the doc dir to a versioned directory
+      - args: ['mv', '@THIS_COLLECT_DIR@/usr/share/doc/openssl', '@THIS_COLLECT_DIR@/usr/share/doc/openssl-1.1.1j']
+      # Install more documentation
+      - args: ['cp', '-fr', '@THIS_SOURCE_DIR@/doc/.', '@THIS_COLLECT_DIR@/usr/share/doc/openssl-1.1.1j']
+
   - name: pcre
     source:
       subdir: ports

--- a/bootstrap.d/dev-util.yml
+++ b/bootstrap.d/dev-util.yml
@@ -57,12 +57,13 @@ packages:
       - curl
       - libarchive
       - libexpat
-      - libressl
+      - openssl
       - libuv
       - libxml
       - xz-utils
       - zlib
       - zstd
+    revision: 2
     configure:
       - args: ['sed', '-i', '/"lib64"/s/64//', '@THIS_SOURCE_DIR@/Modules/GNUInstallDirs.cmake']
       - args: ['cp', '-f', '@SOURCE_ROOT@/scripts/managarm.cmake', '@THIS_SOURCE_DIR@/Modules/Platform/']

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -18,7 +18,8 @@ packages:
       - virtual: pkgconfig-for-target
         triple: x86_64-managarm
     pkgs_required:
-      - libressl
+      - openssl
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -73,9 +74,10 @@ packages:
       - system-gcc
       - virtual: pkgconfig-for-target
         triple: x86_64-managarm
+    revision: 2
     pkgs_required:
       - lz4
-      - libressl
+      - openssl
       - libiconv
       - zlib
       - xxhash
@@ -129,7 +131,8 @@ packages:
     pkgs_required:
       - ncurses
       - readline
-      - libressl
+      - openssl
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -171,12 +174,14 @@ packages:
         triple: x86_64-managarm
     pkgs_required:
       - pcre
-      - libressl
+      - openssl
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=x86_64-managarm'
         - '--prefix=/usr'
+        - '--sysconfdir=/etc'
         - '--disable-nls'
         - '--with-ssl=openssl'
         - '--with-openssl'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -519,9 +519,9 @@ packages:
       - system-gcc
     pkgs_required:
       - libarchive
-      - libressl
+      - openssl
       - zlib
-    revision: 2
+    revision: 3
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -757,6 +757,7 @@ packages:
         - 'AS=x86_64-managarm-as'
         - 'install'
 
+  # Deprecated in favor of openssl
   - name: libressl
     source:
       subdir: 'ports'

--- a/patches/openssl/0001-Add-managarm-support.patch
+++ b/patches/openssl/0001-Add-managarm-support.patch
@@ -1,0 +1,69 @@
+From 02c4ded3f3aa33989212d34653abd71170c2ffe0 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 21 Feb 2021 13:22:15 +0100
+Subject: [PATCH] Add managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ Configure          | 15 +--------------
+ apps/speed.c       |  2 ++
+ test/rsa_complex.c |  4 +++-
+ 3 files changed, 6 insertions(+), 15 deletions(-)
+
+diff --git a/Configure b/Configure
+index b286dd0678..b9faa33921 100755
+--- a/Configure
++++ b/Configure
+@@ -1546,20 +1546,7 @@ unless ($disabled{"crypto-mdebug-backtrace"})
+ unless ($disabled{afalgeng}) {
+     $config{afalgeng}="";
+     if (grep { $_ eq 'afalgeng' } @{$target{enable}}) {
+-        my $minver = 4*10000 + 1*100 + 0;
+-        if ($config{CROSS_COMPILE} eq "") {
+-            my $verstr = `uname -r`;
+-            my ($ma, $mi1, $mi2) = split("\\.", $verstr);
+-            ($mi2) = $mi2 =~ /(\d+)/;
+-            my $ver = $ma*10000 + $mi1*100 + $mi2;
+-            if ($ver < $minver) {
+-                disable('too-old-kernel', 'afalgeng');
+-            } else {
+-                push @{$config{engdirs}}, "afalg";
+-            }
+-        } else {
+-            disable('cross-compiling', 'afalgeng');
+-        }
++        push @{$config{engdirs}}, "afalg";
+     } else {
+         disable('not-linux', 'afalgeng');
+     }
+diff --git a/apps/speed.c b/apps/speed.c
+index d4ae7ab7bf..db2db31bcd 100644
+--- a/apps/speed.c
++++ b/apps/speed.c
+@@ -113,6 +113,8 @@
+ # define NO_FORK
+ #endif
+ 
++#include <sys/select.h>
++
+ #define MAX_MISALIGNMENT 63
+ #define MAX_ECDH_SIZE   256
+ #define MISALIGN        64
+diff --git a/test/rsa_complex.c b/test/rsa_complex.c
+index fac581254a..109e613f67 100644
+--- a/test/rsa_complex.c
++++ b/test/rsa_complex.c
+@@ -14,7 +14,9 @@
+  */
+ #if defined(__STDC_VERSION__)
+ # if __STDC_VERSION__ >= 199901L
+-#  include <complex.h>
++#  if !defined(__managarm__)
++#   include <complex.h>
++#  endif
+ # endif
+ #endif
+ #include <openssl/rsa.h>
+-- 
+2.30.1
+


### PR DESCRIPTION
This PR makes the following changes to the ports listed below, all in preparation of removing `libressl`. This decision was made after gentoo announced that they are no longer supporting `libressl` installs because the work required to do so was increasing without the original benefits. We follow them in this decision to lighten the workload.

- `libressl`, deprecate in favor of `openssl`,
- `openssl`, add port,
- `libarchive`, depend on `openssl` instead of `libressl`,
- `python`, depend on `openssl` instead of `libressl` and add a dependency on `util-linux`,
- `cmake`, depend on `openssl` instead of `libressl`,
- `curl`, depend on `openssl` instead of `libressl`,
- `socat`, depend on `openssl` instead of `libressl`,
- `rsync`, depend on `openssl` instead of `libressl`,
- `wget`, depend on `openssl` instead of `libressl` and install config files in `/etc`,
- `xbps`, depend on `openssl` instead of `libressl`.