### PR TITLE
rust: Add cross-compiler port

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -18,6 +18,18 @@ sources:
     regenerate:
       - args: ['autoreconf', '-f', '-i']
 
+  - name: rust
+    subdir: 'ports'
+    git: 'https://github.com/rust-lang/rust.git'
+    tag: '1.51.0'
+    version: '1.51.0'
+
+  - name: rust-libc
+    subdir: 'ports'
+    git: 'https://github.com/rust-lang/libc.git'
+    tag: '0.2.93'
+    version: '0.2.93'
+
 tools:
   - name: host-python
     from_source: python
@@ -29,6 +41,40 @@ tools:
       - args: ['make', '-j@PARALLELISM@']
     install:
       - args: ['make', 'install']
+
+  - name: host-rust
+    from_source: rust
+    sources_required:
+      - rust-libc
+    tools_required:
+      - host-llvm-toolchain
+    compile:
+      - args: |
+            cat << EOF > config.toml
+            changelog-seen = 2
+
+            [llvm]
+            targets = "X86"
+
+            [build]
+            target = ["x86_64-unknown-managarm-system"]
+            docs = false
+
+            [install]
+            prefix = "@PREFIX@"
+
+            [rust]
+            codegen-tests = false
+
+            [target.x86_64-unknown-linux-gnu]
+            llvm-config = "@BUILD_ROOT@/tools/host-llvm-toolchain/bin/llvm-config"
+
+            [target.x86_64-managarm-system]
+            llvm-config = "@BUILD_ROOT@/tools/host-llvm-toolchain/bin/llvm-config"
+            EOF
+      - args: ['@THIS_SOURCE_DIR@/x.py', 'build', '--stage', '2', '-j', '@PARALLELISM@']
+    install:
+      - args: ['@THIS_SOURCE_DIR@/x.py', 'install', '-j', '@PARALLELISM@']
 
 packages:
   - name: nasm

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -69,7 +69,7 @@ tools:
             [target.x86_64-unknown-linux-gnu]
             llvm-config = "@BUILD_ROOT@/tools/host-llvm-toolchain/bin/llvm-config"
 
-            [target.x86_64-managarm-system]
+            [target.x86_64-unknown-managarm-system]
             llvm-config = "@BUILD_ROOT@/tools/host-llvm-toolchain/bin/llvm-config"
             EOF
       - args: ['@THIS_SOURCE_DIR@/x.py', 'build', '--stage', '2', '-j', '@PARALLELISM@']

--- a/patches/rust-libc/0001-managarm-initial-port.patch
+++ b/patches/rust-libc/0001-managarm-initial-port.patch
@@ -1,27 +1,28 @@
-From 9de522a27f50ee54f4e8ebb8dd689323ffa0706e Mon Sep 17 00:00:00 2001
+From f5c66b35e9082f36d8b3647e1de996cf11d0e997 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Thu, 8 Apr 2021 22:08:55 +0100
 Subject: [PATCH] managarm: initial port
 
 ---
- src/unix/mlibc/mod.rs | 550 ++++++++++++++++++++++++++++++++++++++++++
+ src/unix/mlibc/mod.rs | 547 ++++++++++++++++++++++++++++++++++++++++++
  src/unix/mod.rs       |   3 +
- 2 files changed, 553 insertions(+)
+ 2 files changed, 550 insertions(+)
  create mode 100644 src/unix/mlibc/mod.rs
 
 diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
 new file mode 100644
-index 000000000..409ac74f5
+index 000000000..51b9ee91d
 --- /dev/null
 +++ b/src/unix/mlibc/mod.rs
-@@ -0,0 +1,550 @@
-+// TODO: Should padding be public?
+@@ -0,0 +1,547 @@
++#[cfg(not(target_pointer_width = "64"))]
++compile_error!("Managarm target is not ported to this architecture");
 +
 +// Basic data types
 +pub type c_char = i8;
-+pub type c_long = i64; // TODO ?
-+pub type c_ulong = u64; // TODO ?
-+pub type wchar_t = ::c_int; // TODO ?
++pub type c_long = i64;
++pub type c_ulong = u64;
++pub type wchar_t = ::c_int;
 +
 +// options/posix/include/sys/resource.h
 +pub type rlim_t = ::c_ulong;
@@ -193,7 +194,7 @@ index 000000000..409ac74f5
 +s! {
 +    pub struct sockaddr_storage {
 +        pub ss_family: sa_family_t,
-+        pub __padding: [c_char; 128 - ::mem::size_of::<sa_family_t>()],
++        __padding: [u8; 128 - ::mem::size_of::<sa_family_t>()],
 +    }
 +}
 +
@@ -263,10 +264,6 @@ index 000000000..409ac74f5
 +        pub st_gid: gid_t,
 +        pub st_rdev: dev_t,
 +        pub st_size: off_t,
-+        // TODO: Should we use timespec here? Don't think we can
-+        // pub st_atime: timespec,
-+        // pub st_mtime: timespec,
-+        // pub st_ctime: timespec,
 +        pub st_atime: time_t,
 +        pub st_atime_nsec: c_long,
 +        pub st_mtime: time_t,
@@ -385,7 +382,7 @@ index 000000000..409ac74f5
 +    pub struct pthread_rwlock_t {
 +        pub __mlibc_m: ::c_uint,
 +        pub __mlibc_rc: ::c_uint,
-+        pub __mlibc_padding: ::c_uint,
++        __mlibc_padding: ::c_uint,
 +    }
 +    pub struct pthread_rwlockattr_t {
 +        pub __mlibc_align: ::c_int,
@@ -510,7 +507,7 @@ index 000000000..409ac74f5
 +        pub sin_family: sa_family_t,
 +        pub sin_port: in_port_t,
 +        pub sin_addr: in_addr,
-+        pub pad: [u8; 8],
++        pub __padding: [u8; 8], // std relies on this being public
 +    }
 +    pub struct sockaddr_in6 {
 +        pub sin6_family: sa_family_t,

--- a/patches/rust-libc/0001-managarm-initial-port.patch
+++ b/patches/rust-libc/0001-managarm-initial-port.patch
@@ -1,0 +1,584 @@
+From 9de522a27f50ee54f4e8ebb8dd689323ffa0706e Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Thu, 8 Apr 2021 22:08:55 +0100
+Subject: [PATCH] managarm: initial port
+
+---
+ src/unix/mlibc/mod.rs | 550 ++++++++++++++++++++++++++++++++++++++++++
+ src/unix/mod.rs       |   3 +
+ 2 files changed, 553 insertions(+)
+ create mode 100644 src/unix/mlibc/mod.rs
+
+diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
+new file mode 100644
+index 000000000..409ac74f5
+--- /dev/null
++++ b/src/unix/mlibc/mod.rs
+@@ -0,0 +1,550 @@
++// TODO: Should padding be public?
++
++// Basic data types
++pub type c_char = i8;
++pub type c_long = i64; // TODO ?
++pub type c_ulong = u64; // TODO ?
++pub type wchar_t = ::c_int; // TODO ?
++
++// options/posix/include/sys/resource.h
++pub type rlim_t = ::c_ulong;
++
++// abis/mlibc/mode_t.h
++pub type mode_t = ::c_int;
++
++// options/posix/include/bits/posix/socklen_t.h
++pub type socklen_t = ::c_ulong;
++
++// options/internal/include/bits/off_t.h
++pub type off_t = ::c_long;
++
++// options/ansi/include/time.h
++pub const CLOCK_MONOTONIC: clockid_t = 1;
++pub const CLOCK_REALTIME: clockid_t = 0;
++pub type clock_t = ::c_ulong;
++s! {
++    pub struct tm {
++        pub tm_sec: ::c_int,
++        pub tm_min: ::c_int,
++        pub tm_hour: ::c_int,
++        pub tm_mday: ::c_int,
++        pub tm_mon: ::c_int,
++        pub tm_year: ::c_int,
++        pub tm_wday: ::c_int,
++        pub tm_yday: ::c_int,
++        pub tm_isdst: ::c_int,
++        pub tm_gmtoff: ::c_long,
++        pub tm_zone: *const ::c_char,
++    }
++}
++
++// options/ansi/include/bits/ansi/clockid_t.h
++pub type clockid_t = ::c_long;
++
++// options/ansi/include/bits/ansi/time_t.h
++pub type time_t = ::c_long;
++
++// options/posix/include/bits/posix/suseconds_t.h
++pub type suseconds_t = ::c_long;
++
++// abis/mlibc/uid_t.h
++pub type uid_t = ::c_int;
++
++// abis/mlibc/gid_t.h
++pub type gid_t = ::c_int;
++
++// abis/mlibc/dev_t.h
++pub type dev_t = ::c_ulong;
++
++// options/posix/include/bits/posix/fsblkcnt_t.h
++pub type fsblkcnt_t = ::c_uint;
++
++// options/posix/include/bits/posix/fsfilcnt_t.h
++pub type fsfilcnt_t = ::c_uint;
++
++// abis/mlibc/signal.h
++pub const SIGKILL: ::c_int = 9;
++pub const SIGPIPE: ::c_int = 13;
++pub const SIG_SETMASK: ::c_int = 3;
++pub type sigset_t = ::c_long;
++s! {
++    pub struct siginfo_t {
++        pub si_signo: ::c_int,
++        pub si_code: ::c_int,
++        pub si_errno: ::c_int,
++        pub si_pid: pid_t,
++        pub si_uid: uid_t,
++        pub si_addr: *mut ::c_void,
++        pub si_status: ::c_int,
++        pub si_value: sigval,
++    }
++    pub struct sigaction {
++        pub sa_handler: ::Option<extern fn(::c_int)>,
++        pub sa_mask: sigset_t,
++        pub sa_flags: ::c_int,
++        pub sa_sigaction: ::Option<extern fn(::c_int, *mut siginfo_t, *mut ::c_void)>,
++    }
++}
++s_no_extra_traits! {
++    pub union sigval {
++        pub sival_int: ::c_int,
++        pub sival_ptr: *mut ::c_void,
++    }
++}
++
++// abis/mlibc/termios.h
++pub const NCCS: usize = 11;
++pub type cc_t = ::c_uint;
++pub type speed_t = ::c_uint;
++pub type tcflag_t = ::c_uint;
++s! {
++    pub struct termios {
++        pub c_iflag: tcflag_t,
++        pub c_oflag: tcflag_t,
++        pub c_cflag: tcflag_t,
++        pub c_lflag: tcflag_t,
++        pub c_cc: [cc_t; NCCS],
++        pub ibaud: speed_t,
++        pub obaud: speed_t,
++    }
++}
++
++// abis/mlibc/ino_t.h
++pub type ino_t = ::c_long;
++
++// abis/mlibc/blksize_t.h
++pub type blksize_t = ::c_long;
++
++// abis/mlibc/blkcnt_t.h
++pub type blkcnt_t = ::c_long;
++
++// abis/mlibc/nlink_t.h
++pub type nlink_t = ::c_int;
++
++// abis/mlibc/pid_t.h
++pub type pid_t = ::c_int;
++
++// options/posix/include/bits/posix/in_addr_t.h
++pub type in_addr_t = u32;
++
++// options/posix/include/bits/posix/in_port_t.h
++pub type in_port_t = u16;
++
++// options/ansi/include/stdlib.h
++pub const EXIT_FAILURE: ::c_int = 1;
++pub const EXIT_SUCCESS: ::c_int = 0;
++
++// options/posix/include/dlfcn.h
++pub const RTLD_DEFAULT: *mut ::c_void = 0 as *mut ::c_void;
++s! {
++    pub struct Dl_info {
++        pub dli_fname: *const ::c_char,
++        pub dli_fbase: *mut ::c_void,
++        pub dli_sname: *const ::c_char,
++        pub dli_saddr: *mut ::c_void,
++    }
++}
++
++// options/posix/include/unistd.h
++pub const STDERR_FILENO: ::c_int = 2;
++pub const STDIN_FILENO: ::c_int = 0;
++pub const STDOUT_FILENO: ::c_int = 1;
++pub const _SC_GETPW_R_SIZE_MAX: ::c_int = 1;
++pub const _SC_PAGESIZE: ::c_int = _SC_PAGE_SIZE;
++pub const _SC_PAGE_SIZE: ::c_int = 3;
++
++// abis/mlibc/socket.h
++pub const AF_INET6: ::c_int = PF_INET6;
++pub const AF_INET: ::c_int = PF_INET;
++pub const AF_UNIX: ::c_int = 3;
++pub const MSG_PEEK: ::c_int = 0x20;
++pub const PF_INET6: ::c_int = 2;
++pub const PF_INET: ::c_int = 1;
++pub const PF_UNIX: ::c_int = 3;
++pub const SHUT_RD: ::c_int = 1;
++pub const SHUT_RDWR: ::c_int = 2;
++pub const SHUT_WR: ::c_int = 3;
++pub const SOCK_DGRAM: ::c_int = 1;
++pub const SOCK_STREAM: ::c_int = 4;
++pub const SOL_SOCKET: ::c_int = 1;
++pub const SO_BROADCAST: ::c_int = 6;
++pub const SO_ERROR: ::c_int = 5;
++pub const SO_RCVTIMEO: ::c_int = 11;
++pub const SO_REUSEADDR: ::c_int = 12;
++pub const SO_SNDTIMEO: ::c_int = 15;
++pub type sa_family_t = ::c_uint;
++s! {
++    pub struct sockaddr_storage {
++        pub ss_family: sa_family_t,
++        pub __padding: [c_char; 128 - ::mem::size_of::<sa_family_t>()],
++    }
++}
++
++// abis/mlibc/errno.h
++pub const EACCES: ::c_int = 1002;
++pub const EADDRINUSE: ::c_int = 1003;
++pub const EADDRNOTAVAIL: ::c_int = 1004;
++pub const EAGAIN: ::c_int = 1006;
++pub const EBADF: ::c_int = 1008;
++pub const ECONNABORTED: ::c_int = 1013;
++pub const ECONNREFUSED: ::c_int = 1014;
++pub const ECONNRESET: ::c_int = 1015;
++pub const EDEADLK: ::c_int = 1016;
++pub const EEXIST: ::c_int = 1019;
++pub const EINPROGRESS: ::c_int = 1024;
++pub const EINTR: ::c_int = 1025;
++pub const EINVAL: ::c_int = 1026;
++pub const ENOENT: ::c_int = 1043;
++pub const ENOSYS: ::c_int = 1051;
++pub const ENOTCONN: ::c_int = 1052;
++pub const EPERM: ::c_int = 1063;
++pub const EPIPE: ::c_int = 1064;
++pub const ERANGE: ::c_int = 3;
++pub const ETIMEDOUT: ::c_int = 1072;
++pub const EWOULDBLOCK: ::c_int = EAGAIN;
++
++// options/posix/include/fcntl.h
++pub const AT_FDCWD: ::c_int = -100;
++pub const F_DUPFD_CLOEXEC: ::c_int = 2;
++pub const F_GETFL: ::c_int = 5;
++pub const F_SETFL: ::c_int = 6;
++pub const O_ACCMODE: ::c_int = 7;
++pub const O_APPEND: ::c_int = 8;
++pub const O_CLOEXEC: ::c_int = 0x4000;
++pub const O_CREAT: ::c_int = 0x10;
++pub const O_EXCL: ::c_int = 0x40;
++pub const O_NONBLOCK: ::c_int = 0x400;
++pub const O_RDONLY: ::c_int = 2;
++pub const O_RDWR: ::c_int = 3;
++pub const O_TRUNC: ::c_int = 0x200;
++pub const O_WRONLY: ::c_int = 5;
++
++// options/mlibc/seek-whence.h
++pub const SEEK_CUR: ::c_int = 1;
++pub const SEEK_END: ::c_int = 2;
++pub const SEEK_SET: ::c_int = 3;
++
++// options/posix/include/netinet/tcp.h
++pub const TCP_NODELAY: ::c_int = 1;
++
++// abis/mlibc/stat.h
++pub const S_IFBLK: mode_t = 0x6000;
++pub const S_IFCHR: mode_t = 0x2000;
++pub const S_IFDIR: mode_t = 0x4000;
++pub const S_IFIFO: mode_t = 0x1000;
++pub const S_IFLNK: mode_t = 0xA000;
++pub const S_IFMT: mode_t = 0xF000;
++pub const S_IFREG: mode_t = 0x8000;
++pub const S_IFSOCK: mode_t = 0xC000;
++s! {
++    pub struct stat {
++        pub st_dev: dev_t,
++        pub st_ino: ino_t,
++        pub st_mode: mode_t,
++        pub st_nlink: nlink_t,
++        pub st_uid: uid_t,
++        pub st_gid: gid_t,
++        pub st_rdev: dev_t,
++        pub st_size: off_t,
++        // TODO: Should we use timespec here? Don't think we can
++        // pub st_atime: timespec,
++        // pub st_mtime: timespec,
++        // pub st_ctime: timespec,
++        pub st_atime: time_t,
++        pub st_atime_nsec: c_long,
++        pub st_mtime: time_t,
++        pub st_mtime_nsec: c_long,
++        pub st_ctime: time_t,
++        pub st_ctime_nsec: c_long,
++        pub st_blksize: blksize_t,
++        pub st_blocks: blkcnt_t,
++    }
++}
++
++// options/posix/include/sys/wait.h
++pub const WCOREFLAG: ::c_int = 0x80;
++pub const WNOHANG: ::c_int = 2;
++safe_f! {
++    pub {const} fn WCOREDUMP(x: ::c_int) -> bool {
++        x & WCOREFLAG != 0
++    }
++    pub {const} fn WEXITSTATUS(x: ::c_int) -> ::c_int {
++        x & 0xFF
++    }
++    pub {const} fn WIFCONTINUED(x: ::c_int) -> bool {
++        x & 0x100 != 0
++    }
++    pub {const} fn WIFEXITED(x: ::c_int) -> bool {
++        x & 0x200 != 0
++    }
++    pub {const} fn WIFSIGNALED(x: ::c_int) -> bool {
++        x & 0x400 != 0
++    }
++    pub {const} fn WIFSTOPPED(x: ::c_int) -> bool {
++        x & 0x800 != 0
++    }
++    pub {const} fn WSTOPSIG(x: ::c_int) -> ::c_int {
++        (x & 0xFF_0000) >> 16
++    }
++    pub {const} fn WTERMSIG(x: ::c_int) -> ::c_int {
++        (x & 0xFF00_0000) >> 24
++    }
++}
++
++// options/linux/include/sys/poll.h
++// TODO: Port epoll!
++pub const POLLHUP: ::c_short = 8;
++pub const POLLIN: ::c_short = 1;
++pub const POLLNVAL: ::c_short = 0x40;
++pub const POLLOUT: ::c_short = 2;
++pub type nfds_t = ::size_t;
++
++// options/glibc/include/sys/ioctl.h
++pub const FIOCLEX: ::c_ulong = 0x5451;
++pub const FIONBIO: ::c_ulong = 0x5421;
++
++// options/ansi/include/limits.h
++pub const PTHREAD_STACK_MIN: ::size_t = 16384;
++
++// options/posix/include/pwd.h
++s! {
++    pub struct passwd {
++        pub pw_name: *mut ::c_char,
++        pub pw_passwd: *mut ::c_char,
++        pub pw_uid: uid_t,
++        pub pw_gid: gid_t,
++        pub pw_gecos: *mut ::c_char,
++        pub pw_dir: *mut ::c_char,
++        pub pw_shell: *mut ::c_char,
++    }
++}
++
++// options/posix/include/sys/socket.h
++s! {
++    pub struct sockaddr {
++        pub sa_family: sa_family_t,
++        pub sa_data: [::c_char; 14],
++    }
++}
++
++// options/posix/include/bits/posix/pthread_t.h
++pub type pthread_t = *mut __mlibc_thread_data;
++s! {
++    pub struct __mlibc_thread_data {}
++}
++
++// options/posix/include/bits/posix/pthread.h
++pub const PTHREAD_COND_INITIALIZER: pthread_cond_t = pthread_cond_t { __mlibc_seq: 0 };
++pub const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = pthread_mutex_t {
++    __mlibc_state: 0,
++    __mlibc_recursion: 0,
++    __mlibc_flags: 0,
++};
++pub const PTHREAD_MUTEX_NORMAL: ::c_int = 0;
++pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 2;
++pub const PTHREAD_RWLOCK_INITIALIZER: pthread_rwlock_t = pthread_rwlock_t {
++    __mlibc_m: 0,
++    __mlibc_rc: 0,
++    __mlibc_padding: 0,
++};
++pub type pthread_key_t = usize; // TODO: This is a big hack
++s! {
++    pub struct pthread_attr_t {
++        pub __mlibc_deatchstate: ::c_int,
++    }
++    pub struct pthread_cond_t {
++        pub __mlibc_seq: ::c_uint,
++    }
++    pub struct pthread_condattr_t {}
++    pub struct pthread_mutex_t {
++        pub __mlibc_state: ::c_uint,
++        pub __mlibc_recursion: ::c_uint,
++        pub __mlibc_flags: ::c_uint,
++    }
++    pub struct pthread_mutexattr_t {
++        pub __mlibc_type: ::c_int,
++        pub __mlibc_robust: ::c_int,
++    }
++    pub struct pthread_rwlock_t {
++        pub __mlibc_m: ::c_uint,
++        pub __mlibc_rc: ::c_uint,
++        pub __mlibc_padding: ::c_uint,
++    }
++    pub struct pthread_rwlockattr_t {
++        pub __mlibc_align: ::c_int,
++    }
++}
++
++// options/posix/include/netdb.h
++pub const EAI_SYSTEM: ::c_int = 9;
++s! {
++    pub struct addrinfo {
++        pub ai_flags: ::c_int,
++        pub ai_family: ::c_int,
++        pub ai_socktype: ::c_int,
++        pub ai_protocol: ::c_int,
++        pub ai_addrlen: ::socklen_t,
++        pub ai_addr: *mut sockaddr,
++        pub ai_canonname: *mut ::c_char,
++        pub ai_next: *mut addrinfo,
++    }
++}
++
++// options/ansi/include/locale.h
++s! {
++    pub struct lconv {
++        pub decimal_point: *mut ::c_char,
++        pub thousands_sep: *mut ::c_char,
++        pub grouping: *mut ::c_char,
++        pub mon_decimal_point: *mut ::c_char,
++        pub mon_thousands_sep: *mut ::c_char,
++        pub mon_grouping: *mut ::c_char,
++        pub positive_sign: *mut ::c_char,
++        pub negative_sign: *mut ::c_char,
++        pub currency_symbol: *mut ::c_char,
++        pub frac_digits: ::c_char,
++        pub p_cs_precedes: ::c_char,
++        pub n_cs_precedes: ::c_char,
++        pub p_sep_by_space: ::c_char,
++        pub n_sep_by_space: ::c_char,
++        pub p_sign_posn: ::c_char,
++        pub n_sign_posn: ::c_char,
++        pub int_curr_symbol: *mut ::c_char,
++        pub int_frac_digits: ::c_char,
++        pub int_p_cs_precedes: ::c_char,
++        pub int_n_cs_precedes: ::c_char,
++        pub int_p_sep_by_space: ::c_char,
++        pub int_n_sep_by_space: ::c_char,
++        pub int_p_sign_posn: ::c_char,
++        pub int_n_sign_posn: ::c_char,
++    }
++}
++
++// options/posix/include/semaphore.h
++s! {
++    pub struct sem_t {
++        pub __mlibc_count: ::c_uint,
++    }
++}
++
++// options/posix/include/sys/statvfs.h
++s! {
++    pub struct statvfs {
++        pub f_bsize: ::c_ulong,
++        pub f_frsize: ::c_ulong,
++        pub f_blocks: fsblkcnt_t,
++        pub f_bfree: fsblkcnt_t,
++        pub f_bavail: fsblkcnt_t,
++        pub f_files: fsfilcnt_t,
++        pub f_ffree: fsfilcnt_t,
++        pub f_favail: fsfilcnt_t,
++        pub f_fsid: ::c_ulong,
++        pub f_flag: ::c_ulong,
++        pub f_namemax: ::c_ulong,
++    }
++}
++
++// options/posix/include/dirent.h
++s! {
++    pub struct dirent {
++        pub d_ino: ino_t,
++        pub d_off: off_t,
++        pub d_reclen: ::c_ushort,
++        pub d_type: ::c_uchar,
++        pub d_name: [::c_char; 1024],
++    }
++}
++
++// options/ansi/include/bits/ansi/timespec.h
++s! {
++    pub struct timespec {
++        pub tv_sec: time_t,
++        pub tv_nsec: ::c_long,
++    }
++}
++
++// options/posix/include/sys/un.h
++s! {
++    pub struct sockaddr_un {
++        pub sun_family: sa_family_t,
++        pub sun_path: [::c_char; 108],
++    }
++}
++
++// abis/mlibc/in.h
++pub const IPV6_ADD_MEMBERSHIP: ::c_int = 1;
++pub const IPV6_DROP_MEMBERSHIP: ::c_int = 2;
++pub const IPV6_MULTICAST_LOOP: ::c_int = 5;
++pub const IPV6_V6ONLY: ::c_int = 7;
++pub const IP_ADD_MEMBERSHIP: ::c_int = 35;
++pub const IP_DROP_MEMBERSHIP: ::c_int = 36;
++pub const IP_MULTICAST_LOOP: ::c_int = 34;
++pub const IP_MULTICAST_TTL: ::c_int = 33;
++pub const IP_TTL: ::c_int = 2;
++s! {
++    pub struct in_addr {
++        pub s_addr: in_addr_t,
++    }
++    pub struct ip_mreq {
++        pub imr_multiaddr: in_addr,
++        pub imr_interface: in_addr,
++    }
++    pub struct sockaddr_in {
++        pub sin_family: sa_family_t,
++        pub sin_port: in_port_t,
++        pub sin_addr: in_addr,
++        pub pad: [u8; 8],
++    }
++    pub struct sockaddr_in6 {
++        pub sin6_family: sa_family_t,
++        pub sin6_port: in_port_t,
++        pub sin6_flowinfo: u32,
++        pub sin6_addr: ::in6_addr,
++        pub sin6_scope_id: u32,
++    }
++}
++
++// options/posix/include/bits/posix/fd_set.h
++s_no_extra_traits! {
++    pub union fd_set {
++        pub __mlibc_elems: [c_char; 128],
++        pub fds_bits: [c_char; 128],
++    }
++}
++
++extern "C" {
++    pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
++    pub fn clock_gettime(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
++    pub fn clock_settime(clk_id: clockid_t, tp: *const ::timespec) -> ::c_int;
++    pub fn getpwuid_r(
++        uid: ::uid_t,
++        pwd: *mut passwd,
++        buf: *mut ::c_char,
++        buflen: ::size_t,
++        result: *mut *mut passwd,
++    ) -> ::c_int;
++    pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
++    pub fn pthread_condattr_setclock(
++        attr: *mut pthread_condattr_t,
++        clock_id: ::clockid_t,
++    ) -> ::c_int;
++    pub fn pthread_create(
++        thread: *mut ::pthread_t,
++        attr: *const ::pthread_attr_t,
++        f: extern "C" fn(*mut ::c_void) -> *mut ::c_void,
++        value: *mut ::c_void,
++    ) -> ::c_int;
++    pub fn pthread_setname_np(t: ::pthread_t, name: *const ::c_char) -> ::c_int;
++    pub fn pthread_sigmask(how: ::c_int, set: *const sigset_t, oldset: *mut sigset_t) -> ::c_int;
++    pub fn readv(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
++    pub fn recvfrom(
++        socket: ::c_int,
++        buf: *mut ::c_void,
++        len: ::size_t,
++        flags: ::c_int,
++        addr: *mut ::sockaddr,
++        addrlen: *mut ::socklen_t,
++    ) -> ::ssize_t;
++    pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
++    pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
++}
+diff --git a/src/unix/mod.rs b/src/unix/mod.rs
+index be7b6e73e..b7c67bb39 100644
+--- a/src/unix/mod.rs
++++ b/src/unix/mod.rs
+@@ -1459,6 +1459,9 @@ cfg_if! {
+     } else if #[cfg(target_os = "redox")] {
+         mod redox;
+         pub use self::redox::*;
++    } else if #[cfg(target_os = "managarm")] {
++        mod mlibc;
++        pub use self::mlibc::*;
+     } else {
+         // Unknown target_os
+     }
+-- 
+2.31.1
+

--- a/patches/rust/0001-managarm-initial-port.patch
+++ b/patches/rust/0001-managarm-initial-port.patch
@@ -1,4 +1,4 @@
-From 67654aea797ac07cc28fec23d771b82a60f16fa9 Mon Sep 17 00:00:00 2001
+From 73d9fe6abca8e17d7919e41bb2ccbe202b557129 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Sat, 10 Apr 2021 17:53:24 +0100
 Subject: [PATCH] managarm: initial port
@@ -567,7 +567,7 @@ index cda17eb4bd2..fa977f5755c 100644
      pub fn set_name(name: &CStr) {
          use crate::ffi::CString;
 diff --git a/library/std/src/sys/unix/thread_local_dtor.rs b/library/std/src/sys/unix/thread_local_dtor.rs
-index c3275eb6f0e..8fe5def3ed7 100644
+index c3275eb6f0e..7ffeaea3c14 100644
 --- a/library/std/src/sys/unix/thread_local_dtor.rs
 +++ b/library/std/src/sys/unix/thread_local_dtor.rs
 @@ -15,7 +15,8 @@
@@ -576,7 +576,7 @@ index c3275eb6f0e..8fe5def3ed7 100644
      target_os = "redox",
 -    target_os = "emscripten"
 +    target_os = "emscripten",
-+    target_os = "managarm" // TODO: Is this right?
++    target_os = "managarm"
  ))]
  pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
      use crate::mem;

--- a/patches/rust/0001-managarm-initial-port.patch
+++ b/patches/rust/0001-managarm-initial-port.patch
@@ -1,0 +1,616 @@
+From 67654aea797ac07cc28fec23d771b82a60f16fa9 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Sat, 10 Apr 2021 17:53:24 +0100
+Subject: [PATCH] managarm: initial port
+
+---
+ Cargo.lock                                    |   4 +-
+ Cargo.toml                                    |   1 +
+ .../src/spec/managarm_system_base.rs          |  35 +++++
+ compiler/rustc_target/src/spec/mod.rs         |   3 +
+ .../spec/x86_64_unknown_managarm_system.rs    |  19 +++
+ library/std/build.rs                          |   1 +
+ library/std/src/os/managarm/fs.rs             | 148 ++++++++++++++++++
+ library/std/src/os/managarm/mod.rs            |   6 +
+ library/std/src/os/managarm/raw.rs            |  66 ++++++++
+ library/std/src/os/mod.rs                     |   2 +
+ library/std/src/sys/unix/args.rs              |   3 +-
+ library/std/src/sys/unix/env.rs               |  11 ++
+ library/std/src/sys/unix/fs.rs                |   6 +-
+ library/std/src/sys/unix/mod.rs               |   2 +
+ library/std/src/sys/unix/os.rs                |  34 +++-
+ library/std/src/sys/unix/thread.rs            |   7 +
+ library/std/src/sys/unix/thread_local_dtor.rs |   3 +-
+ library/std/src/sys/unix/time.rs              |   7 +-
+ library/unwind/build.rs                       |   2 +
+ 19 files changed, 344 insertions(+), 16 deletions(-)
+ create mode 100644 compiler/rustc_target/src/spec/managarm_system_base.rs
+ create mode 100644 compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
+ create mode 100644 library/std/src/os/managarm/fs.rs
+ create mode 100644 library/std/src/os/managarm/mod.rs
+ create mode 100644 library/std/src/os/managarm/raw.rs
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 2b68f725816..4eaf3ca4ce7 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1839,9 +1839,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.85"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
++version = "0.2.93"
+ dependencies = [
+  "rustc-std-workspace-core",
+ ]
+diff --git a/Cargo.toml b/Cargo.toml
+index f961d3e9b97..9b7a31f9385 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -105,6 +105,7 @@ rustc-workspace-hack = { path = 'src/tools/rustc-workspace-hack' }
+ rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
+ rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
+ rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
++libc = { path = '../rust-libc' }
+ 
+ [patch."https://github.com/rust-lang/rust-clippy"]
+ clippy_lints = { path = "src/tools/clippy/clippy_lints" }
+diff --git a/compiler/rustc_target/src/spec/managarm_system_base.rs b/compiler/rustc_target/src/spec/managarm_system_base.rs
+new file mode 100644
+index 00000000000..08b7d8a8c73
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/managarm_system_base.rs
+@@ -0,0 +1,35 @@
++use crate::spec::{LinkArgs, LinkerFlavor, RelroLevel, TargetOptions};
++
++pub fn opts() -> TargetOptions {
++    let mut args = LinkArgs::new();
++    args.insert(
++        LinkerFlavor::Gcc,
++        vec![
++            // We want to be able to strip as much executable code as possible
++            // from the linker command line, and this flag indicates to the
++            // linker that it can avoid linking in dynamic libraries that don't
++            // actually satisfy any symbols up to that point (as with many other
++            // resolutions the linker does). This option only applies to all
++            // following libraries so we're sure to pass it as one of the first
++            // arguments.
++            "-Wl,--as-needed".to_string(),
++            // Always enable NX protection when it is available
++            "-Wl,-z,noexecstack".to_string(),
++        ],
++    );
++
++    TargetOptions {
++        os: "managarm".to_string(),
++        dynamic_linking: true,
++        executables: true,
++        os_family: Some("unix".to_string()),
++        linker_is_gnu: true,
++        has_rpath: true,
++        pre_link_args: args,
++        position_independent_executables: true,
++        relro_level: RelroLevel::Full,
++        has_elf_tls: true,
++        crt_static_respected: true,
++        ..Default::default()
++    }
++}
+diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
+index 7a93bac72ca..75e38b625ec 100644
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -60,6 +60,7 @@
+ mod freebsd_base;
+ mod fuchsia_base;
+ mod haiku_base;
++mod managarm_system_base;
+ mod hermit_base;
+ mod hermit_kernel_base;
+ mod illumos_base;
+@@ -706,6 +707,8 @@ fn to_json(&self) -> Json {
+     ("i686-unknown-haiku", i686_unknown_haiku),
+     ("x86_64-unknown-haiku", x86_64_unknown_haiku),
+ 
++    ("x86_64-unknown-managarm-system", x86_64_unknown_managarm_system),
++
+     ("aarch64-apple-darwin", aarch64_apple_darwin),
+     ("x86_64-apple-darwin", x86_64_apple_darwin),
+     ("i686-apple-darwin", i686_apple_darwin),
+diff --git a/compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs b/compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
+new file mode 100644
+index 00000000000..7c16ed9b2a5
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
+@@ -0,0 +1,19 @@
++use crate::spec::{LinkerFlavor, StackProbeType, Target};
++
++pub fn target() -> Target {
++    let mut base = super::managarm_system_base::opts();
++    base.cpu = "x86-64".to_string();
++    base.max_atomic_width = Some(64);
++    base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
++    // don't use probe-stack=inline-asm until rust-lang/rust#83139 is resolved.
++    base.stack_probes = StackProbeType::Call;
++
++    Target {
++        llvm_target: "x86_64-unknown-managarm-system".to_string(),
++        pointer_width: 64,
++        data_layout: "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
++            .to_string(),
++        arch: "x86_64".to_string(),
++        options: base,
++    }
++}
+diff --git a/library/std/build.rs b/library/std/build.rs
+index a14ac63c7a8..de7f9fc4a1f 100644
+--- a/library/std/build.rs
++++ b/library/std/build.rs
+@@ -23,6 +23,7 @@ fn main() {
+         || target.contains("l4re")
+         || target.contains("redox")
+         || target.contains("haiku")
++        || target.contains("managarm")
+         || target.contains("vxworks")
+         || target.contains("wasm32")
+         || target.contains("asmjs")
+diff --git a/library/std/src/os/managarm/fs.rs b/library/std/src/os/managarm/fs.rs
+new file mode 100644
+index 00000000000..efd774d2415
+--- /dev/null
++++ b/library/std/src/os/managarm/fs.rs
+@@ -0,0 +1,148 @@
++#![stable(feature = "raw_ext", since = "1.1.0")]
++
++use crate::fs::Metadata;
++use crate::sys_common::AsInner;
++
++#[allow(deprecated)]
++use crate::os::managarm::raw;
++
++/// OS-specific extensions to [`fs::Metadata`].
++///
++/// [`fs::Metadata`]: crate::fs::Metadata
++#[stable(feature = "metadata_ext", since = "1.1.0")]
++pub trait MetadataExt {
++    /// Gain a reference to the underlying `stat` structure which contains
++    /// the raw information returned by the OS.
++    ///
++    /// The contents of the returned `stat` are **not** consistent across
++    /// Unix platforms. The `os::unix::fs::MetadataExt` trait contains the
++    /// cross-Unix abstractions contained within the raw stat.
++    #[stable(feature = "metadata_ext", since = "1.1.0")]
++    #[rustc_deprecated(
++        since = "1.8.0",
++        reason = "deprecated in favor of the accessor \
++                  methods of this trait"
++    )]
++    #[allow(deprecated)]
++    fn as_raw_stat(&self) -> &raw::stat;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_dev(&self) -> u64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_ino(&self) -> u64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_mode(&self) -> u32;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_nlink(&self) -> u64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_uid(&self) -> u32;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_gid(&self) -> u32;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_rdev(&self) -> u64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_size(&self) -> u64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_atime(&self) -> i64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_atime_nsec(&self) -> i64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_mtime(&self) -> i64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_mtime_nsec(&self) -> i64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_ctime(&self) -> i64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_ctime_nsec(&self) -> i64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_blksize(&self) -> u64;
++
++    #[stable(feature = "metadata_ext2", since = "1.8.0")]
++    fn st_blocks(&self) -> u64;
++}
++
++#[stable(feature = "metadata_ext", since = "1.1.0")]
++impl MetadataExt for Metadata {
++    #[allow(deprecated)]
++    fn as_raw_stat(&self) -> &raw::stat {
++        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
++    }
++
++    fn st_dev(&self) -> u64 {
++        self.as_inner().as_inner().st_dev as u64
++    }
++
++    fn st_ino(&self) -> u64 {
++        self.as_inner().as_inner().st_ino as u64
++    }
++
++    fn st_mode(&self) -> u32 {
++        self.as_inner().as_inner().st_mode as u32
++    }
++
++    fn st_nlink(&self) -> u64 {
++        self.as_inner().as_inner().st_nlink as u64
++    }
++
++    fn st_uid(&self) -> u32 {
++        self.as_inner().as_inner().st_uid as u32
++    }
++
++    fn st_gid(&self) -> u32 {
++        self.as_inner().as_inner().st_gid as u32
++    }
++
++    fn st_rdev(&self) -> u64 {
++        self.as_inner().as_inner().st_rdev as u64
++    }
++
++    fn st_size(&self) -> u64 {
++        self.as_inner().as_inner().st_size as u64
++    }
++
++    fn st_atime(&self) -> i64 {
++        self.as_inner().as_inner().st_atime as i64
++    }
++
++    fn st_atime_nsec(&self) -> i64 {
++        self.as_inner().as_inner().st_atime_nsec as i64
++    }
++
++    fn st_mtime(&self) -> i64 {
++        self.as_inner().as_inner().st_mtime as i64
++    }
++
++    fn st_mtime_nsec(&self) -> i64 {
++        self.as_inner().as_inner().st_mtime_nsec as i64
++    }
++
++    fn st_ctime(&self) -> i64 {
++        self.as_inner().as_inner().st_ctime as i64
++    }
++
++    fn st_ctime_nsec(&self) -> i64 {
++        self.as_inner().as_inner().st_ctime_nsec as i64
++    }
++
++    fn st_blksize(&self) -> u64 {
++        self.as_inner().as_inner().st_blksize as u64
++    }
++
++    fn st_blocks(&self) -> u64 {
++        self.as_inner().as_inner().st_blocks as u64
++    }
++}
+diff --git a/library/std/src/os/managarm/mod.rs b/library/std/src/os/managarm/mod.rs
+new file mode 100644
+index 00000000000..869966bb054
+--- /dev/null
++++ b/library/std/src/os/managarm/mod.rs
+@@ -0,0 +1,6 @@
++//! Managarm-specific definitions
++
++#![stable(feature = "raw_ext", since = "1.1.0")]
++
++pub mod fs;
++pub mod raw;
+diff --git a/library/std/src/os/managarm/raw.rs b/library/std/src/os/managarm/raw.rs
+new file mode 100644
+index 00000000000..5124020d939
+--- /dev/null
++++ b/library/std/src/os/managarm/raw.rs
+@@ -0,0 +1,66 @@
++#![stable(feature = "raw_ext", since = "1.1.0")]
++
++#[stable(feature = "pthread_t", since = "1.8.0")]
++pub type pthread_t = usize; // TODO: This is completely wrong tbh
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type dev_t = libc::dev_t;
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type ino_t = libc::ino_t;
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type mode_t = libc::mode_t;
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type nlink_t = libc::nlink_t;
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type off_t = libc::off_t;
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type time_t = libc::time_t;
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type blkcnt_t = libc::blkcnt_t;
++
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub type blksize_t = libc::blksize_t;
++
++#[repr(C)]
++#[derive(Clone)]
++#[stable(feature = "raw_ext", since = "1.1.0")]
++pub struct stat {
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_dev: libc::dev_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_ino: libc::ino_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_mode: libc::mode_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_nlink: libc::nlink_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_uid: libc::uid_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_gid: libc::gid_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_rdev: libc::dev_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_size: libc::off_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_atime: libc::time_t,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_atime_nsec: libc::c_long,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_mtime: libc::time_t,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_mtime_nsec: libc::c_long,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_ctime: libc::time_t,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_ctime_nsec: libc::c_long,
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_blksize: libc::blksize_t, 
++    #[stable(feature = "raw_ext", since = "1.1.0")]
++    pub st_blocks: libc::blkcnt_t, 
++}
+diff --git a/library/std/src/os/mod.rs b/library/std/src/os/mod.rs
+index fd6ee088e96..d6adf1d9662 100644
+--- a/library/std/src/os/mod.rs
++++ b/library/std/src/os/mod.rs
+@@ -58,6 +58,8 @@
+ pub mod ios;
+ #[cfg(target_os = "macos")]
+ pub mod macos;
++#[cfg(target_os = "managarm")]
++pub mod managarm;
+ #[cfg(target_os = "netbsd")]
+ pub mod netbsd;
+ #[cfg(target_os = "openbsd")]
+diff --git a/library/std/src/sys/unix/args.rs b/library/std/src/sys/unix/args.rs
+index 69676472493..898aa0e3368 100644
+--- a/library/std/src/sys/unix/args.rs
++++ b/library/std/src/sys/unix/args.rs
+@@ -71,7 +71,8 @@ fn next_back(&mut self) -> Option<OsString> {
+     target_os = "l4re",
+     target_os = "fuchsia",
+     target_os = "redox",
+-    target_os = "vxworks"
++    target_os = "vxworks",
++    target_os = "managarm"
+ ))]
+ mod imp {
+     use super::Args;
+diff --git a/library/std/src/sys/unix/env.rs b/library/std/src/sys/unix/env.rs
+index 7f5e9b04dba..dd976565b3e 100644
+--- a/library/std/src/sys/unix/env.rs
++++ b/library/std/src/sys/unix/env.rs
+@@ -173,3 +173,14 @@ pub mod os {
+     pub const EXE_SUFFIX: &str = "";
+     pub const EXE_EXTENSION: &str = "";
+ }
++
++#[cfg(target_os = "managarm")]
++pub mod os {
++    pub const FAMILY: &str = "unix";
++    pub const OS: &str = "managarm";
++    pub const DLL_PREFIX: &str = "lib";
++    pub const DLL_SUFFIX: &str = ".so";
++    pub const DLL_EXTENSION: &str = "so";
++    pub const EXE_SUFFIX: &str = "";
++    pub const EXE_EXTENSION: &str = "";
++}
+diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
+index d1b0ad9e5f8..a9ba3a30123 100644
+--- a/library/std/src/sys/unix/fs.rs
++++ b/library/std/src/sys/unix/fs.rs
+@@ -594,7 +594,8 @@ pub fn file_type(&self) -> io::Result<FileType> {
+         target_os = "l4re",
+         target_os = "fuchsia",
+         target_os = "redox",
+-        target_os = "vxworks"
++        target_os = "vxworks",
++        target_os = "managarm"
+     ))]
+     pub fn ino(&self) -> u64 {
+         self.entry.d_ino as u64
+@@ -633,7 +634,8 @@ fn name_bytes(&self) -> &[u8] {
+         target_os = "emscripten",
+         target_os = "l4re",
+         target_os = "haiku",
+-        target_os = "vxworks"
++        target_os = "vxworks",
++        target_os = "managarm"
+     ))]
+     fn name_bytes(&self) -> &[u8] {
+         unsafe { CStr::from_ptr(self.entry.d_name.as_ptr()).to_bytes() }
+diff --git a/library/std/src/sys/unix/mod.rs b/library/std/src/sys/unix/mod.rs
+index f8a5ee89969..b48ef8126ab 100644
+--- a/library/std/src/sys/unix/mod.rs
++++ b/library/std/src/sys/unix/mod.rs
+@@ -25,6 +25,8 @@
+ pub use crate::os::linux as platform;
+ #[cfg(all(not(doc), target_os = "macos"))]
+ pub use crate::os::macos as platform;
++#[cfg(all(not(doc), target_os = "managarm"))]
++pub use crate::os::managarm as platform;
+ #[cfg(all(not(doc), target_os = "netbsd"))]
+ pub use crate::os::netbsd as platform;
+ #[cfg(all(not(doc), target_os = "openbsd"))]
+diff --git a/library/std/src/sys/unix/os.rs b/library/std/src/sys/unix/os.rs
+index d5e14bec765..a3f4f5c0f81 100644
+--- a/library/std/src/sys/unix/os.rs
++++ b/library/std/src/sys/unix/os.rs
+@@ -37,7 +37,7 @@
+ }
+ 
+ extern "C" {
+-    #[cfg(not(any(target_os = "dragonfly", target_os = "vxworks")))]
++    #[cfg(not(any(target_os = "dragonfly", target_os = "vxworks", target_os = "managarm")))]
+     #[cfg_attr(
+         any(
+             target_os = "linux",
+@@ -67,13 +67,13 @@
+ }
+ 
+ /// Returns the platform-specific value of errno
+-#[cfg(not(any(target_os = "dragonfly", target_os = "vxworks")))]
++#[cfg(not(any(target_os = "dragonfly", target_os = "vxworks", target_os = "managarm")))]
+ pub fn errno() -> i32 {
+     unsafe { (*errno_location()) as i32 }
+ }
+ 
+ /// Sets the platform-specific value of errno
+-#[cfg(all(not(target_os = "linux"), not(target_os = "dragonfly"), not(target_os = "vxworks")))] // needed for readdir and syscall!
++#[cfg(all(not(target_os = "linux"), not(target_os = "dragonfly"), not(target_os = "vxworks"), not(target_os = "managarm")))] // needed for readdir and syscall!
+ #[allow(dead_code)] // but not all target cfgs actually end up using it
+ pub fn set_errno(e: i32) {
+     unsafe { *errno_location() = e as c_int }
+@@ -111,6 +111,29 @@ pub fn set_errno(e: i32) {
+     }
+ }
+ 
++#[cfg(target_os = "managarm")]
++pub fn errno() -> i32 {
++    extern "C" {
++        #[thread_local]
++        static __mlibc_errno: c_int;
++    }
++
++    unsafe { __mlibc_errno as i32 }
++}
++
++#[cfg(target_os = "managarm")]
++#[allow(dead_code)]
++pub fn set_errno(e: i32) {
++    extern "C" {
++        #[thread_local]
++        static mut __mlibc_errno: c_int;
++    }
++
++    unsafe {
++        __mlibc_errno = e;
++    }
++}
++
+ /// Gets a detailed string description for the given error number.
+ pub fn error_string(errno: i32) -> String {
+     extern "C" {
+@@ -350,6 +373,11 @@ pub fn current_exe() -> io::Result<PathBuf> {
+     }
+ }
+ 
++#[cfg(target_os = "managarm")]
++pub fn current_exe() -> io::Result<PathBuf> {
++    unimplemented!()
++}
++
+ #[cfg(any(target_os = "macos", target_os = "ios"))]
+ pub fn current_exe() -> io::Result<PathBuf> {
+     extern "C" {
+diff --git a/library/std/src/sys/unix/thread.rs b/library/std/src/sys/unix/thread.rs
+index cda17eb4bd2..fa977f5755c 100644
+--- a/library/std/src/sys/unix/thread.rs
++++ b/library/std/src/sys/unix/thread.rs
+@@ -103,6 +103,13 @@ pub fn set_name(name: &CStr) {
+         }
+     }
+ 
++    #[cfg(target_os = "managarm")]
++    pub fn set_name(name: &CStr) {
++        unsafe {
++            libc::pthread_setname_np(libc::pthread_self(), name.as_ptr());
++        }
++    }
++
+     #[cfg(target_os = "netbsd")]
+     pub fn set_name(name: &CStr) {
+         use crate::ffi::CString;
+diff --git a/library/std/src/sys/unix/thread_local_dtor.rs b/library/std/src/sys/unix/thread_local_dtor.rs
+index c3275eb6f0e..8fe5def3ed7 100644
+--- a/library/std/src/sys/unix/thread_local_dtor.rs
++++ b/library/std/src/sys/unix/thread_local_dtor.rs
+@@ -15,7 +15,8 @@
+     target_os = "linux",
+     target_os = "fuchsia",
+     target_os = "redox",
+-    target_os = "emscripten"
++    target_os = "emscripten",
++    target_os = "managarm" // TODO: Is this right?
+ ))]
+ pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
+     use crate::mem;
+diff --git a/library/std/src/sys/unix/time.rs b/library/std/src/sys/unix/time.rs
+index 23a5c81c005..4170857d80d 100644
+--- a/library/std/src/sys/unix/time.rs
++++ b/library/std/src/sys/unix/time.rs
+@@ -361,12 +361,7 @@ fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+         }
+     }
+ 
+-    #[cfg(not(target_os = "dragonfly"))]
+-    pub type clock_t = libc::c_int;
+-    #[cfg(target_os = "dragonfly")]
+-    pub type clock_t = libc::c_ulong;
+-
+-    fn now(clock: clock_t) -> Timespec {
++    fn now(clock: libc::clockid_t) -> Timespec {
+         let mut t = Timespec { t: libc::timespec { tv_sec: 0, tv_nsec: 0 } };
+         cvt(unsafe { libc::clock_gettime(clock, &mut t.t) }).unwrap();
+         t
+diff --git a/library/unwind/build.rs b/library/unwind/build.rs
+index 694e6b98c82..8ab01ff67ad 100644
+--- a/library/unwind/build.rs
++++ b/library/unwind/build.rs
+@@ -48,6 +48,8 @@ fn main() {
+         println!("cargo:rustc-link-lib=gcc_s");
+     } else if target.contains("redox") {
+         // redox is handled in lib.rs
++    } else if target.contains("managarm") {
++        println!("cargo:rustc-link-lib=gcc_s");
+     }
+ }
+ 
+-- 
+2.31.1
+


### PR DESCRIPTION
This PR adds patches for Rust's `std` and `libc` crates and allows us to cross-compile basic Rust programs for managarm.

The full install takes ~1h20 on my machine (4 core low spec laptop), as we compile both stage1 and stage2. This may not be strictly necessary, but is a good idea to avoid ABI issues in future (e.g with procedural macros).

Partially addresses managarm/managarm#91.