### PR TITLE
rust: Port `cargo`, `ripgrep` and `exa`

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -30,6 +30,13 @@ sources:
     tag: '0.2.93'
     version: '0.2.93'
 
+  - name: host-bootstrap-cargo
+    subdir: 'ports'
+    url: 'https://static.rust-lang.org/dist/2021-05-08/cargo-nightly-x86_64-unknown-linux-gnu.tar.xz'
+    format: 'tar.xz'
+    extract_path: 'cargo-nightly-x86_64-unknown-linux-gnu'
+    version: '0.53.0'
+
 tools:
   - name: host-python
     from_source: python
@@ -57,7 +64,8 @@ tools:
             targets = "X86"
 
             [build]
-            target = ["x86_64-unknown-managarm-system"]
+            target = ["x86_64-unknown-managarm-system", "x86_64-unknown-linux-gnu"]
+            build-dir = "@THIS_BUILD_DIR@"
             docs = false
 
             [install]
@@ -73,8 +81,35 @@ tools:
             llvm-config = "@BUILD_ROOT@/tools/host-llvm-toolchain/bin/llvm-config"
             EOF
       - args: ['@THIS_SOURCE_DIR@/x.py', 'build', '--stage', '2', '-j', '@PARALLELISM@']
+        cargo_home: false
     install:
       - args: ['@THIS_SOURCE_DIR@/x.py', 'install', '-j', '@PARALLELISM@']
+        cargo_home: false
+
+  - name: host-cargo
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/rust-lang/cargo.git'
+      tag: '0.53.0'
+      version: '0.53.0'
+    tools_required:
+      - host-rust
+    sources_required:
+      - rust-libc
+      - host-bootstrap-cargo # Cargo requires cargo to build, so we download a binary that we can use temporarily
+    compile:
+      - args:
+        - '@THIS_SOURCE_DIR@/../host-bootstrap-cargo/cargo/bin/cargo'
+        - 'install'
+        - '--target'
+        - 'x86_64-unknown-linux-gnu'
+        - '--target-dir'
+        - '@THIS_BUILD_DIR@'
+        - '--path'
+        - '@THIS_SOURCE_DIR@'
+        - '-j@PARALLELISM@'
+        - '--root'
+        - '@PREFIX@'
 
 packages:
   - name: nasm

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -217,6 +217,63 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: ripgrep
+    source:
+      subdir: ports
+      git: 'https://github.com/BurntSushi/ripgrep.git'
+      tag: '12.1.1'
+      version: '12.1.1'
+    tools_required:
+      - host-cargo
+    sources_required:
+      - rust-libc
+      - rust-num-cpus
+    configure:
+      - args: ['cargo', 'update', '--manifest-path', '@THIS_SOURCE_DIR@/Cargo.toml', '-p', 'libc', '--precise', '0.2.93']
+    build:
+      - args:
+        - 'cargo'
+        - 'install'
+        - '--locked'
+        - '--target-dir'
+        - '@THIS_BUILD_DIR@'
+        - '--path'
+        - '@THIS_SOURCE_DIR@'
+        - '--root'
+        - '@THIS_COLLECT_DIR@'
+        - '-j@PARALLELISM@'
+
+  - name: exa
+    source:
+      subdir: ports
+      git: 'https://github.com/ogham/exa.git'
+      commit: 'b18e93d283d388ee42d8f0b73f36e546111324ce'
+      branch: 'master'
+      version: '0.10.1-master'
+    tools_required:
+      - host-cargo
+      - system-gcc # Required to build libgit2
+    sources_required:
+      - rust-libc
+      - rust-num-cpus
+      - rust-users
+    configure:
+      - args: ['cargo', 'update', '--manifest-path', '@THIS_SOURCE_DIR@/Cargo.toml', '-p', 'libc', '--precise', '0.2.93']
+    build:
+      - args:
+        - 'cargo'
+        - 'install'
+        - '--locked'
+        - '--target-dir'
+        - '@THIS_BUILD_DIR@'
+        - '--path'
+        - '@THIS_SOURCE_DIR@'
+        - '--root'
+        - '@THIS_COLLECT_DIR@'
+        - '-j@PARALLELISM@'
+        environ:
+          CC: x86_64-managarm-gcc
+
   - name: groff
     source:
       subdir: ports

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -229,7 +229,7 @@ packages:
       - rust-libc
       - rust-num-cpus
     configure:
-      - args: ['cargo', 'update', '--manifest-path', '@THIS_SOURCE_DIR@/Cargo.toml', '-p', 'libc', '--precise', '0.2.93']
+      - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
       - args:
         - 'cargo'
@@ -258,7 +258,7 @@ packages:
       - rust-num-cpus
       - rust-users
     configure:
-      - args: ['cargo', 'update', '--manifest-path', '@THIS_SOURCE_DIR@/Cargo.toml', '-p', 'libc', '--precise', '0.2.93']
+      - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
       - args:
         - 'cargo'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -1,3 +1,16 @@
+sources:
+  - name: rust-num-cpus
+    subdir: 'ports'
+    git: 'https://github.com/seanmonstar/num_cpus.git'
+    tag: 'v1.13.0'
+    version: '1.13.0'
+
+  - name: rust-users
+    subdir: 'ports'
+    git: 'https://github.com/ogham/rust-users.git'
+    tag: 'v0.11.0'
+    version: '0.11.0'
+
 packages:
   - name: gdbm
     source:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -29,6 +29,8 @@ general:
     patch_author: The Managarm Project
     patch_email: info@managarm.org
     everything_by_default: false
+    cargo:
+        config_toml: 'extrafiles/config.toml'
 
 repository:
     url: 'https://pkgs.managarm.org/nightly'

--- a/extrafiles/config.toml
+++ b/extrafiles/config.toml
@@ -1,0 +1,14 @@
+[unstable]
+patch-in-config = true
+
+[build]
+rustc = "@BUILD_ROOT@/tools/host-rust/bin/rustc"
+target = "x86_64-unknown-managarm-system"
+
+[target.x86_64-unknown-managarm-system]
+linker = "@BUILD_ROOT@/tools/system-gcc/bin/x86_64-managarm-gcc"
+
+[patch.crates-io]
+libc = { path = "@SOURCE_ROOT@/ports/rust-libc" }
+num_cpus = { path = "@SOURCE_ROOT@/ports/rust-num-cpus" }
+users = { path = "@SOURCE_ROOT@/ports/rust-users" }

--- a/patches/rust-libc/0001-managarm-initial-port.patch
+++ b/patches/rust-libc/0001-managarm-initial-port.patch
@@ -1,7 +1,7 @@
-From f5c66b35e9082f36d8b3647e1de996cf11d0e997 Mon Sep 17 00:00:00 2001
+From 6946817a03e47b6f14449041f29670c344ac4e5f Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Thu, 8 Apr 2021 22:08:55 +0100
-Subject: [PATCH] managarm: initial port
+Subject: [PATCH 1/2] managarm: initial port
 
 ---
  src/unix/mlibc/mod.rs | 547 ++++++++++++++++++++++++++++++++++++++++++
@@ -11,7 +11,7 @@ Subject: [PATCH] managarm: initial port
 
 diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
 new file mode 100644
-index 000000000..51b9ee91d
+index 0000000..51b9ee9
 --- /dev/null
 +++ b/src/unix/mlibc/mod.rs
 @@ -0,0 +1,547 @@
@@ -563,7 +563,7 @@ index 000000000..51b9ee91d
 +    pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
 +}
 diff --git a/src/unix/mod.rs b/src/unix/mod.rs
-index be7b6e73e..b7c67bb39 100644
+index be7b6e7..b7c67bb 100644
 --- a/src/unix/mod.rs
 +++ b/src/unix/mod.rs
 @@ -1459,6 +1459,9 @@ cfg_if! {

--- a/patches/rust-libc/0002-managarm-Add-missing-glue-for-memmap-num_cpus-and-us.patch
+++ b/patches/rust-libc/0002-managarm-Add-missing-glue-for-memmap-num_cpus-and-us.patch
@@ -1,0 +1,204 @@
+From 07284dd588cf5dfa11ea03ac384c457bb0261126 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Sat, 8 May 2021 19:33:53 +0100
+Subject: [PATCH 2/2] managarm: Add missing glue for memmap, num_cpus and users
+
+---
+ src/unix/mlibc/mod.rs | 110 +++++++++++++++++++++++++++++++-----------
+ 1 file changed, 81 insertions(+), 29 deletions(-)
+
+diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
+index 51b9ee9..f374aa1 100644
+--- a/src/unix/mlibc/mod.rs
++++ b/src/unix/mlibc/mod.rs
+@@ -19,6 +19,19 @@ pub type socklen_t = ::c_ulong;
+ // options/internal/include/bits/off_t.h
+ pub type off_t = ::c_long;
+ 
++// abis/mlibc/vm-flags.h 
++pub const MAP_ANON: ::c_int = 8;
++pub const MAP_PRIVATE: ::c_int = 1;
++pub const MAP_SHARED: ::c_int = 2;
++pub const PROT_EXEC: ::c_int = 4;
++pub const PROT_READ: ::c_int = 1;
++pub const PROT_WRITE: ::c_int = 2;
++
++// options/posix/include/sys/mman.h
++pub const MAP_FAILED: *mut ::c_void = usize::MAX as *mut ::c_void;
++pub const MS_ASYNC: ::c_int = 1;
++pub const MS_SYNC: ::c_int = 2;
++
+ // options/ansi/include/time.h
+ pub const CLOCK_MONOTONIC: clockid_t = 1;
+ pub const CLOCK_REALTIME: clockid_t = 0;
+@@ -48,12 +61,6 @@ pub type time_t = ::c_long;
+ // options/posix/include/bits/posix/suseconds_t.h
+ pub type suseconds_t = ::c_long;
+ 
+-// abis/mlibc/uid_t.h
+-pub type uid_t = ::c_int;
+-
+-// abis/mlibc/gid_t.h
+-pub type gid_t = ::c_int;
+-
+ // abis/mlibc/dev_t.h
+ pub type dev_t = ::c_ulong;
+ 
+@@ -73,8 +80,8 @@ s! {
+         pub si_signo: ::c_int,
+         pub si_code: ::c_int,
+         pub si_errno: ::c_int,
+-        pub si_pid: pid_t,
+-        pub si_uid: uid_t,
++        pub si_pid: ::pid_t,
++        pub si_uid: ::uid_t,
+         pub si_addr: *mut ::c_void,
+         pub si_status: ::c_int,
+         pub si_value: sigval,
+@@ -110,6 +117,9 @@ s! {
+     }
+ }
+ 
++// options/posix/include/termios.h
++pub const TIOCGWINSZ: ::c_ulong = 0x5413;
++
+ // abis/mlibc/ino_t.h
+ pub type ino_t = ::c_long;
+ 
+@@ -122,9 +132,6 @@ pub type blkcnt_t = ::c_long;
+ // abis/mlibc/nlink_t.h
+ pub type nlink_t = ::c_int;
+ 
+-// abis/mlibc/pid_t.h
+-pub type pid_t = ::c_int;
+-
+ // options/posix/include/bits/posix/in_addr_t.h
+ pub type in_addr_t = u32;
+ 
+@@ -151,6 +158,7 @@ pub const STDERR_FILENO: ::c_int = 2;
+ pub const STDIN_FILENO: ::c_int = 0;
+ pub const STDOUT_FILENO: ::c_int = 1;
+ pub const _SC_GETPW_R_SIZE_MAX: ::c_int = 1;
++pub const _SC_NPROCESSORS_ONLN: ::c_int = 6;
+ pub const _SC_PAGESIZE: ::c_int = _SC_PAGE_SIZE;
+ pub const _SC_PAGE_SIZE: ::c_int = 3;
+ 
+@@ -237,24 +245,36 @@ pub const S_IFLNK: mode_t = 0xA000;
+ pub const S_IFMT: mode_t = 0xF000;
+ pub const S_IFREG: mode_t = 0x8000;
+ pub const S_IFSOCK: mode_t = 0xC000;
++pub const S_IRGRP: mode_t = 0o40;
++pub const S_IROTH: mode_t = 0o4;
++pub const S_IRUSR: mode_t = 0o400;
++pub const S_IRWXG: mode_t = 0o70;
++pub const S_IRWXO: mode_t = 0o7;
++pub const S_IRWXU: mode_t = 0o700;
++pub const S_IWGRP: mode_t = 0o20;
++pub const S_IWOTH: mode_t = 0o2;
++pub const S_IWUSR: mode_t = 0o200;
++pub const S_IXGRP: mode_t = 0o10;
++pub const S_IXOTH: mode_t = 0o1;
++pub const S_IXUSR: mode_t = 0o100;
+ s! {
+     pub struct stat {
+-        pub st_dev: dev_t,
+-        pub st_ino: ino_t,
+-        pub st_mode: mode_t,
+-        pub st_nlink: nlink_t,
+-        pub st_uid: uid_t,
+-        pub st_gid: gid_t,
+-        pub st_rdev: dev_t,
+-        pub st_size: off_t,
+-        pub st_atime: time_t,
+-        pub st_atime_nsec: c_long,
+-        pub st_mtime: time_t,
+-        pub st_mtime_nsec: c_long,
+-        pub st_ctime: time_t,
+-        pub st_ctime_nsec: c_long,
+-        pub st_blksize: blksize_t,
+-        pub st_blocks: blkcnt_t,
++        pub st_dev: ::dev_t,
++        pub st_ino: ::ino_t,
++        pub st_mode: ::mode_t,
++        pub st_nlink: ::nlink_t,
++        pub st_uid: ::uid_t,
++        pub st_gid: ::gid_t,
++        pub st_rdev: ::dev_t,
++        pub st_size: ::off_t,
++        pub st_atime: ::time_t,
++        pub st_atime_nsec: ::c_long,
++        pub st_mtime: ::time_t,
++        pub st_mtime_nsec: ::c_long,
++        pub st_ctime: ::time_t,
++        pub st_ctime_nsec: ::c_long,
++        pub st_blksize: ::blksize_t,
++        pub st_blocks: ::blkcnt_t,
+     }
+ }
+ 
+@@ -308,8 +328,8 @@ s! {
+     pub struct passwd {
+         pub pw_name: *mut ::c_char,
+         pub pw_passwd: *mut ::c_char,
+-        pub pw_uid: uid_t,
+-        pub pw_gid: gid_t,
++        pub pw_uid: ::uid_t,
++        pub pw_gid: ::gid_t,
+         pub pw_gecos: *mut ::c_char,
+         pub pw_dir: *mut ::c_char,
+         pub pw_shell: *mut ::c_char,
+@@ -513,6 +533,35 @@ extern "C" {
+     pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
+     pub fn clock_gettime(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
+     pub fn clock_settime(clk_id: clockid_t, tp: *const ::timespec) -> ::c_int;
++    pub fn endpwent();
++    pub fn getpwent() -> *mut passwd;
++    pub fn getgrgid_r(
++        gid: ::gid_t,
++        grp: *mut ::group,
++        buf: *mut ::c_char,
++        buflen: ::size_t,
++        result: *mut *mut ::group,
++    ) -> ::c_int;
++    pub fn getgrnam_r(
++        name: *const ::c_char,
++        grp: *mut ::group,
++        buf: *mut ::c_char,
++        buflen: ::size_t,
++        result: *mut *mut ::group,
++    ) -> ::c_int;
++    pub fn getgrouplist(
++        user: *const ::c_char,
++        group: ::gid_t,
++        groups: *mut ::gid_t,
++        ngroups: *mut ::c_int,
++    ) -> ::c_int;
++    pub fn getpwnam_r(
++        name: *const ::c_char,
++        pwd: *mut passwd,
++        buf: *mut ::c_char,
++        buflen: ::size_t,
++        result: *mut *mut passwd,
++    ) -> ::c_int;
+     pub fn getpwuid_r(
+         uid: ::uid_t,
+         pwd: *mut passwd,
+@@ -521,6 +570,8 @@ extern "C" {
+         result: *mut *mut passwd,
+     ) -> ::c_int;
+     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
++    pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
++    pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
+     pub fn pthread_condattr_setclock(
+         attr: *mut pthread_condattr_t,
+         clock_id: ::clockid_t,
+@@ -543,5 +594,6 @@ extern "C" {
+         addrlen: *mut ::socklen_t,
+     ) -> ::ssize_t;
+     pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
++    pub fn setpwent();
+     pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
+ }
+-- 
+2.31.1
+

--- a/patches/rust-num-cpus/0001-managarm-Initial-port.patch
+++ b/patches/rust-num-cpus/0001-managarm-Initial-port.patch
@@ -1,0 +1,34 @@
+From 9f16707dd860306cd501cb7ffdc11d7d27a4b8fe Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Fri, 7 May 2021 19:16:06 +0100
+Subject: [PATCH] managarm: Initial port
+
+---
+ src/lib.rs | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/lib.rs b/src/lib.rs
+index 6c8280f..8ae23f7 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -331,7 +331,8 @@ fn get_num_physical_cpus() -> usize {
+     target_os = "android",
+     target_os = "solaris",
+     target_os = "illumos",
+-    target_os = "fuchsia")
++    target_os = "fuchsia",
++    target_os = "managarm")
+ )]
+ fn get_num_cpus() -> usize {
+     // On ARM targets, processors could be turned off to save power.
+@@ -420,6 +421,7 @@ fn get_num_cpus() -> usize {
+     target_os = "netbsd",
+     target_os = "haiku",
+     target_os = "hermit",
++    target_os = "managarm",
+     windows,
+ )))]
+ fn get_num_cpus() -> usize {
+-- 
+2.31.1
+

--- a/patches/rust-users/0001-managarm-Initial-port.patch
+++ b/patches/rust-users/0001-managarm-Initial-port.patch
@@ -1,0 +1,39 @@
+From f19c2082b16c5a378be27097079518f6acca074c Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Sun, 9 May 2021 18:16:40 +0100
+Subject: [PATCH] managarm: Initial port
+
+---
+ src/base.rs | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/base.rs b/src/base.rs
+index ece499a..7cc5794 100644
+--- a/src/base.rs
++++ b/src/base.rs
+@@ -923,7 +923,7 @@ pub mod os {
+     /// Although the `passwd` struct is common among Unix systems, its actual
+     /// format can vary. See the definitions in the `base` module to check which
+     /// fields are actually present.
+-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
++    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris", target_os = "managarm"))]
+     pub mod unix {
+         use std::ffi::{OsStr, OsString};
+         use std::path::{Path, PathBuf};
+@@ -1176,11 +1176,11 @@ pub mod os {
+     pub type UserExtras = bsd::UserExtras;
+ 
+     /// Any extra fields on a `User` specific to the current platform.
+-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris"))]
++    #[cfg(any(target_os = "linux", target_os = "android", target_os = "solaris", target_os = "managarm"))]
+     pub type UserExtras = unix::UserExtras;
+ 
+     /// Any extra fields on a `Group` specific to the current platform.
+-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris"))]
++    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "freebsd", target_os = "dragonfly", target_os = "openbsd", target_os = "netbsd", target_os = "solaris", target_os = "managarm"))]
+     pub type GroupExtras = unix::GroupExtras;
+ }
+ 
+-- 
+2.31.1
+

--- a/scripts/cargo-inject-patches.py
+++ b/scripts/cargo-inject-patches.py
@@ -12,6 +12,12 @@ parser = argparse.ArgumentParser(description='Inject patched Rust libraries into
 parser.add_argument('manifest', type=pathlib.Path, help='path to Cargo.toml')
 manifest = parser.parse_args().manifest
 
+# First, delete the existing lockfile to work around https://github.com/rust-lang/cargo/issues/9470
+lockfile = os.path.join(os.path.dirname(manifest), 'Cargo.lock')
+if os.path.exists(lockfile):
+    print('cargo-inject-patches: workaround cargo bug by removing existing lockfile...')
+    os.remove(lockfile)
+
 for lib, version in patched_libs.items():
 	cmd = [
 		'cargo',

--- a/scripts/cargo-inject-patches.py
+++ b/scripts/cargo-inject-patches.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import argparse, os, subprocess, pathlib
+
+patched_libs = {
+	'libc': '0.2.93',
+	'num_cpus': '1.13.0',
+	'users': '0.11.0',
+}
+
+parser = argparse.ArgumentParser(description='Inject patched Rust libraries into Cargo lockfiles')
+parser.add_argument('manifest', type=pathlib.Path, help='path to Cargo.toml')
+manifest = parser.parse_args().manifest
+
+for lib, version in patched_libs.items():
+	cmd = [
+		'cargo',
+		'update',
+		'--manifest-path', manifest,
+		'--package', lib,
+		'--precise', version
+	]
+
+	output = subprocess.run(cmd, capture_output=True)
+	if 'did not match any packages' in str(output.stderr):
+		print(f'cargo-inject-patches: Injecting {lib} v{version} failed, patch not used')
+	else:
+		print(f'cargo-inject-patches: Injected {lib} v{version}')


### PR DESCRIPTION
This PR implements support for `cargo` builds. We also port `ripgrep` and `exa`, implementing the necessary patches for them to build.

In order to test this PR, you must have managarm/xbstrap#48 merged locally, and then run `xbstrap init ../src` from your `build` directory.