### PR TITLE
rust: Fix cargo target selection when setting CARGO_HOME

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -82,10 +82,8 @@ tools:
             llvm-config = "@BUILD_ROOT@/tools/host-llvm-toolchain/bin/llvm-config"
             EOF
       - args: ['@THIS_SOURCE_DIR@/x.py', 'build', '--stage', '2', '-j', '@PARALLELISM@']
-        cargo_home: false
     install:
       - args: ['@THIS_SOURCE_DIR@/x.py', 'install', '-j', '@PARALLELISM@']
-        cargo_home: false
 
   - name: host-cargo
     source:

--- a/patches/rust/0001-managarm-initial-port.patch
+++ b/patches/rust/0001-managarm-initial-port.patch
@@ -1,7 +1,7 @@
-From 73d9fe6abca8e17d7919e41bb2ccbe202b557129 Mon Sep 17 00:00:00 2001
+From 4036157782a6d630d1c0605925d9029b7372ee9f Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Sat, 10 Apr 2021 17:53:24 +0100
-Subject: [PATCH] managarm: initial port
+Subject: [PATCH 1/2] managarm: initial port
 
 ---
  Cargo.lock                                    |   4 +-
@@ -31,7 +31,7 @@ Subject: [PATCH] managarm: initial port
  create mode 100644 library/std/src/os/managarm/raw.rs
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 2b68f725816..4eaf3ca4ce7 100644
+index 2b68f725..4eaf3ca4 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
 @@ -1839,9 +1839,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
@@ -46,7 +46,7 @@ index 2b68f725816..4eaf3ca4ce7 100644
   "rustc-std-workspace-core",
  ]
 diff --git a/Cargo.toml b/Cargo.toml
-index f961d3e9b97..9b7a31f9385 100644
+index f961d3e9..9b7a31f9 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -105,6 +105,7 @@ rustc-workspace-hack = { path = 'src/tools/rustc-workspace-hack' }
@@ -59,7 +59,7 @@ index f961d3e9b97..9b7a31f9385 100644
  clippy_lints = { path = "src/tools/clippy/clippy_lints" }
 diff --git a/compiler/rustc_target/src/spec/managarm_system_base.rs b/compiler/rustc_target/src/spec/managarm_system_base.rs
 new file mode 100644
-index 00000000000..08b7d8a8c73
+index 00000000..08b7d8a8
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/managarm_system_base.rs
 @@ -0,0 +1,35 @@
@@ -99,7 +99,7 @@ index 00000000000..08b7d8a8c73
 +    }
 +}
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 7a93bac72ca..75e38b625ec 100644
+index 7a93bac7..75e38b62 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
 @@ -60,6 +60,7 @@
@@ -121,7 +121,7 @@ index 7a93bac72ca..75e38b625ec 100644
      ("i686-apple-darwin", i686_apple_darwin),
 diff --git a/compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs b/compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
 new file mode 100644
-index 00000000000..7c16ed9b2a5
+index 00000000..7c16ed9b
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
 @@ -0,0 +1,19 @@
@@ -145,7 +145,7 @@ index 00000000000..7c16ed9b2a5
 +    }
 +}
 diff --git a/library/std/build.rs b/library/std/build.rs
-index a14ac63c7a8..de7f9fc4a1f 100644
+index a14ac63c..de7f9fc4 100644
 --- a/library/std/build.rs
 +++ b/library/std/build.rs
 @@ -23,6 +23,7 @@ fn main() {
@@ -158,7 +158,7 @@ index a14ac63c7a8..de7f9fc4a1f 100644
          || target.contains("asmjs")
 diff --git a/library/std/src/os/managarm/fs.rs b/library/std/src/os/managarm/fs.rs
 new file mode 100644
-index 00000000000..efd774d2415
+index 00000000..efd774d2
 --- /dev/null
 +++ b/library/std/src/os/managarm/fs.rs
 @@ -0,0 +1,148 @@
@@ -312,7 +312,7 @@ index 00000000000..efd774d2415
 +}
 diff --git a/library/std/src/os/managarm/mod.rs b/library/std/src/os/managarm/mod.rs
 new file mode 100644
-index 00000000000..869966bb054
+index 00000000..869966bb
 --- /dev/null
 +++ b/library/std/src/os/managarm/mod.rs
 @@ -0,0 +1,6 @@
@@ -324,7 +324,7 @@ index 00000000000..869966bb054
 +pub mod raw;
 diff --git a/library/std/src/os/managarm/raw.rs b/library/std/src/os/managarm/raw.rs
 new file mode 100644
-index 00000000000..5124020d939
+index 00000000..5124020d
 --- /dev/null
 +++ b/library/std/src/os/managarm/raw.rs
 @@ -0,0 +1,66 @@
@@ -395,7 +395,7 @@ index 00000000000..5124020d939
 +    pub st_blocks: libc::blkcnt_t, 
 +}
 diff --git a/library/std/src/os/mod.rs b/library/std/src/os/mod.rs
-index fd6ee088e96..d6adf1d9662 100644
+index fd6ee088..d6adf1d9 100644
 --- a/library/std/src/os/mod.rs
 +++ b/library/std/src/os/mod.rs
 @@ -58,6 +58,8 @@
@@ -408,7 +408,7 @@ index fd6ee088e96..d6adf1d9662 100644
  pub mod netbsd;
  #[cfg(target_os = "openbsd")]
 diff --git a/library/std/src/sys/unix/args.rs b/library/std/src/sys/unix/args.rs
-index 69676472493..898aa0e3368 100644
+index 69676472..898aa0e3 100644
 --- a/library/std/src/sys/unix/args.rs
 +++ b/library/std/src/sys/unix/args.rs
 @@ -71,7 +71,8 @@ fn next_back(&mut self) -> Option<OsString> {
@@ -422,7 +422,7 @@ index 69676472493..898aa0e3368 100644
  mod imp {
      use super::Args;
 diff --git a/library/std/src/sys/unix/env.rs b/library/std/src/sys/unix/env.rs
-index 7f5e9b04dba..dd976565b3e 100644
+index 7f5e9b04..dd976565 100644
 --- a/library/std/src/sys/unix/env.rs
 +++ b/library/std/src/sys/unix/env.rs
 @@ -173,3 +173,14 @@ pub mod os {
@@ -441,7 +441,7 @@ index 7f5e9b04dba..dd976565b3e 100644
 +    pub const EXE_EXTENSION: &str = "";
 +}
 diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
-index d1b0ad9e5f8..a9ba3a30123 100644
+index d1b0ad9e..a9ba3a30 100644
 --- a/library/std/src/sys/unix/fs.rs
 +++ b/library/std/src/sys/unix/fs.rs
 @@ -594,7 +594,8 @@ pub fn file_type(&self) -> io::Result<FileType> {
@@ -465,7 +465,7 @@ index d1b0ad9e5f8..a9ba3a30123 100644
      fn name_bytes(&self) -> &[u8] {
          unsafe { CStr::from_ptr(self.entry.d_name.as_ptr()).to_bytes() }
 diff --git a/library/std/src/sys/unix/mod.rs b/library/std/src/sys/unix/mod.rs
-index f8a5ee89969..b48ef8126ab 100644
+index f8a5ee89..b48ef812 100644
 --- a/library/std/src/sys/unix/mod.rs
 +++ b/library/std/src/sys/unix/mod.rs
 @@ -25,6 +25,8 @@
@@ -478,7 +478,7 @@ index f8a5ee89969..b48ef8126ab 100644
  pub use crate::os::netbsd as platform;
  #[cfg(all(not(doc), target_os = "openbsd"))]
 diff --git a/library/std/src/sys/unix/os.rs b/library/std/src/sys/unix/os.rs
-index d5e14bec765..a3f4f5c0f81 100644
+index d5e14bec..a3f4f5c0 100644
 --- a/library/std/src/sys/unix/os.rs
 +++ b/library/std/src/sys/unix/os.rs
 @@ -37,7 +37,7 @@
@@ -549,7 +549,7 @@ index d5e14bec765..a3f4f5c0f81 100644
  pub fn current_exe() -> io::Result<PathBuf> {
      extern "C" {
 diff --git a/library/std/src/sys/unix/thread.rs b/library/std/src/sys/unix/thread.rs
-index cda17eb4bd2..fa977f5755c 100644
+index cda17eb4..fa977f57 100644
 --- a/library/std/src/sys/unix/thread.rs
 +++ b/library/std/src/sys/unix/thread.rs
 @@ -103,6 +103,13 @@ pub fn set_name(name: &CStr) {
@@ -567,7 +567,7 @@ index cda17eb4bd2..fa977f5755c 100644
      pub fn set_name(name: &CStr) {
          use crate::ffi::CString;
 diff --git a/library/std/src/sys/unix/thread_local_dtor.rs b/library/std/src/sys/unix/thread_local_dtor.rs
-index c3275eb6f0e..7ffeaea3c14 100644
+index c3275eb6..7ffeaea3 100644
 --- a/library/std/src/sys/unix/thread_local_dtor.rs
 +++ b/library/std/src/sys/unix/thread_local_dtor.rs
 @@ -15,7 +15,8 @@
@@ -581,7 +581,7 @@ index c3275eb6f0e..7ffeaea3c14 100644
  pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
      use crate::mem;
 diff --git a/library/std/src/sys/unix/time.rs b/library/std/src/sys/unix/time.rs
-index 23a5c81c005..4170857d80d 100644
+index 23a5c81c..4170857d 100644
 --- a/library/std/src/sys/unix/time.rs
 +++ b/library/std/src/sys/unix/time.rs
 @@ -361,12 +361,7 @@ fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -599,7 +599,7 @@ index 23a5c81c005..4170857d80d 100644
          cvt(unsafe { libc::clock_gettime(clock, &mut t.t) }).unwrap();
          t
 diff --git a/library/unwind/build.rs b/library/unwind/build.rs
-index 694e6b98c82..8ab01ff67ad 100644
+index 694e6b98..8ab01ff6 100644
 --- a/library/unwind/build.rs
 +++ b/library/unwind/build.rs
 @@ -48,6 +48,8 @@ fn main() {

--- a/patches/rust/0002-managarm-fix-build-target-in-x.py-and-bootstrap.patch
+++ b/patches/rust/0002-managarm-fix-build-target-in-x.py-and-bootstrap.patch
@@ -1,0 +1,77 @@
+From ba9081c05d5cca4ecbd732563fd7b448d64b233e Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 31 May 2021 21:19:44 +0100
+Subject: [PATCH 2/2] managarm: fix build target in x.py and bootstrap
+
+---
+ src/bootstrap/bootstrap.py | 8 ++++++--
+ src/bootstrap/builder.rs   | 6 ++++--
+ 2 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/src/bootstrap/bootstrap.py b/src/bootstrap/bootstrap.py
+index 6708b27b..0a8a5c49 100644
+--- a/src/bootstrap/bootstrap.py
++++ b/src/bootstrap/bootstrap.py
+@@ -796,7 +796,7 @@ class RustBuild(object):
+         ... "debug", "bootstrap")
+         True
+         """
+-        return os.path.join(self.build_dir, "bootstrap", "debug", "bootstrap")
++        return os.path.join(self.build_dir, "bootstrap", self.build, "debug", "bootstrap")
+ 
+     def build_bootstrap(self):
+         """Build bootstrap"""
+@@ -804,7 +804,7 @@ class RustBuild(object):
+         if self.clean and os.path.exists(build_dir):
+             shutil.rmtree(build_dir)
+         env = os.environ.copy()
+-        # `CARGO_BUILD_TARGET` breaks bootstrap build.
++        # `CARGO_BUILD_TARGET` and 'build.target' break bootstrap build.
+         # See also: <https://github.com/rust-lang/rust/issues/70208>.
+         if "CARGO_BUILD_TARGET" in env:
+             del env["CARGO_BUILD_TARGET"]
+@@ -852,6 +852,10 @@ class RustBuild(object):
+             args.append("--locked")
+         if self.use_vendored_sources:
+             args.append("--frozen")
++
++        args.append("--target")
++        args.append(self.build)
++
+         run(args, env=env, verbose=self.verbose)
+ 
+     def build_triple(self):
+diff --git a/src/bootstrap/builder.rs b/src/bootstrap/builder.rs
+index f1a16025..c00cf4cd 100644
+--- a/src/bootstrap/builder.rs
++++ b/src/bootstrap/builder.rs
+@@ -1023,6 +1023,8 @@ pub fn cargo(
+             self.clear_if_dirty(&out_dir, &self.rustc(compiler));
+         }
+ 
++        let artifact_dir = self.out.join("bootstrap/").join(self.build.build.triple).join("debug/");
++
+         // Customize the compiler we're running. Specify the compiler to cargo
+         // as our shim and then pass it some various options used to configure
+         // how the actual compiler itself is called.
+@@ -1035,7 +1037,7 @@ pub fn cargo(
+             .env("RUSTC_STAGE", stage.to_string())
+             .env("RUSTC_SYSROOT", &sysroot)
+             .env("RUSTC_LIBDIR", &libdir)
+-            .env("RUSTDOC", self.out.join("bootstrap/debug/rustdoc"))
++            .env("RUSTDOC", artifact_dir.join("rustdoc"))
+             .env(
+                 "RUSTDOC_REAL",
+                 if cmd == "doc" || cmd == "rustdoc" || (cmd == "test" && want_rustdoc) {
+@@ -1049,7 +1051,7 @@ pub fn cargo(
+         // Clippy support is a hack and uses the default `cargo-clippy` in path.
+         // Don't override RUSTC so that the `cargo-clippy` in path will be run.
+         if cmd != "clippy" {
+-            cargo.env("RUSTC", self.out.join("bootstrap/debug/rustc"));
++            cargo.env("RUSTC", artifact_dir.join("rustc"));
+         }
+ 
+         // Dealing with rpath here is a little special, so let's go into some
+-- 
+2.31.1
+


### PR DESCRIPTION
This PR fixes Rust builds for use with `cbuildrt`.

First, we allow `xbstrap` to set `CARGO_HOME` when building `rustc`. Then, we fix `rustc`'s build system so that it uses the right `--target` for bootstrapping.
