### PR TITLE
rust: Use rust-patched-libs source group

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -90,8 +90,7 @@ tools:
     sources_required:
       # This cargo runs on the host, so we don't actually need any patches here. We just
       # add the sources used by cargo so that the dependency resolver doesn't complain.
-      - name: rust-patched-libs
-        recursive: true
+      - rust-patched-libs
       # Cargo requires cargo to build, so we download a binary that we can use temporarily
       - host-bootstrap-cargo
     compile:

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -24,12 +24,6 @@ sources:
     tag: '1.51.0'
     version: '1.51.0'
 
-  - name: rust-libc
-    subdir: 'ports'
-    git: 'https://github.com/rust-lang/libc.git'
-    tag: '0.2.93'
-    version: '0.2.93'
-
   - name: host-bootstrap-cargo
     subdir: 'ports'
     url: 'https://static.rust-lang.org/dist/2021-05-08/cargo-nightly-x86_64-unknown-linux-gnu.tar.xz'
@@ -96,8 +90,8 @@ tools:
     sources_required:
       # This cargo runs on the host, so we don't actually need any patches here. We just
       # add the sources used by cargo so that the dependency resolver doesn't complain.
-      - rust-num-cpus
-      - rust-libc
+      - name: rust-patched-libs
+        recursive: true
       # Cargo requires cargo to build, so we download a binary that we can use temporarily
       - host-bootstrap-cargo
     compile:

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -105,6 +105,36 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: exa
+    source:
+      subdir: ports
+      git: 'https://github.com/ogham/exa.git'
+      commit: 'b18e93d283d388ee42d8f0b73f36e546111324ce'
+      branch: 'master'
+      version: '0.10.1-master'
+    tools_required:
+      - host-cargo
+      - system-gcc # Required to build libgit2
+    sources_required:
+      - name: rust-patched-libs
+        recursive: true
+    configure:
+      - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
+    build:
+      - args:
+        - 'cargo'
+        - 'install'
+        - '--locked'
+        - '--target-dir'
+        - '@THIS_BUILD_DIR@'
+        - '--path'
+        - '@THIS_SOURCE_DIR@'
+        - '--root'
+        - '@THIS_COLLECT_DIR@'
+        - '-j@PARALLELISM@'
+        environ:
+          CC: x86_64-managarm-gcc
+
   - name: file
     labels: [aarch64]
     from_source: file
@@ -225,63 +255,6 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
-
-  - name: ripgrep
-    source:
-      subdir: ports
-      git: 'https://github.com/BurntSushi/ripgrep.git'
-      tag: '12.1.1'
-      version: '12.1.1'
-    tools_required:
-      - host-cargo
-    sources_required:
-      - rust-libc
-      - rust-num-cpus
-    configure:
-      - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
-    build:
-      - args:
-        - 'cargo'
-        - 'install'
-        - '--locked'
-        - '--target-dir'
-        - '@THIS_BUILD_DIR@'
-        - '--path'
-        - '@THIS_SOURCE_DIR@'
-        - '--root'
-        - '@THIS_COLLECT_DIR@'
-        - '-j@PARALLELISM@'
-
-  - name: exa
-    source:
-      subdir: ports
-      git: 'https://github.com/ogham/exa.git'
-      commit: 'b18e93d283d388ee42d8f0b73f36e546111324ce'
-      branch: 'master'
-      version: '0.10.1-master'
-    tools_required:
-      - host-cargo
-      - system-gcc # Required to build libgit2
-    sources_required:
-      - rust-libc
-      - rust-num-cpus
-      - rust-users
-    configure:
-      - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
-    build:
-      - args:
-        - 'cargo'
-        - 'install'
-        - '--locked'
-        - '--target-dir'
-        - '@THIS_BUILD_DIR@'
-        - '--path'
-        - '@THIS_SOURCE_DIR@'
-        - '--root'
-        - '@THIS_COLLECT_DIR@'
-        - '-j@PARALLELISM@'
-        environ:
-          CC: x86_64-managarm-gcc
 
   - name: groff
     source:
@@ -476,6 +449,32 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: ripgrep
+    source:
+      subdir: ports
+      git: 'https://github.com/BurntSushi/ripgrep.git'
+      tag: '12.1.1'
+      version: '12.1.1'
+    tools_required:
+      - host-cargo
+    sources_required:
+      - name: rust-patched-libs
+        recursive: true
+    configure:
+      - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
+    build:
+      - args:
+        - 'cargo'
+        - 'install'
+        - '--locked'
+        - '--target-dir'
+        - '@THIS_BUILD_DIR@'
+        - '--path'
+        - '@THIS_SOURCE_DIR@'
+        - '--root'
+        - '@THIS_COLLECT_DIR@'
+        - '-j@PARALLELISM@'
 
   - name: util-linux
     labels: [aarch64]

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -116,8 +116,7 @@ packages:
       - host-cargo
       - system-gcc # Required to build libgit2
     sources_required:
-      - name: rust-patched-libs
-        recursive: true
+      - rust-patched-libs
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
@@ -459,8 +458,7 @@ packages:
     tools_required:
       - host-cargo
     sources_required:
-      - name: rust-patched-libs
-        recursive: true
+      - rust-patched-libs
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -1,4 +1,10 @@
 sources:
+  - name: rust-libc
+    subdir: 'ports'
+    git: 'https://github.com/rust-lang/libc.git'
+    tag: '0.2.93'
+    version: '0.2.93'
+
   - name: rust-num-cpus
     subdir: 'ports'
     git: 'https://github.com/seanmonstar/num_cpus.git'
@@ -10,6 +16,13 @@ sources:
     git: 'https://github.com/ogham/rust-users.git'
     tag: 'v0.11.0'
     version: '0.11.0'
+
+  - name: rust-patched-libs
+    subdir: 'ports'
+    sources_required:
+      - rust-libc
+      - rust-num-cpus
+      - rust-users
 
 packages:
   - name: gdbm

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -20,9 +20,12 @@ sources:
   - name: rust-patched-libs
     subdir: 'ports'
     sources_required:
-      - rust-libc
-      - rust-num-cpus
-      - rust-users
+      - name: rust-libc
+        recursive: true
+      - name: rust-num-cpus
+        recursive: true
+      - name: rust-users
+        recursive: true
 
 packages:
   - name: gdbm


### PR DESCRIPTION
Requires https://github.com/managarm/xbstrap/pull/49.

This should fix the rust-related CI build failures, finally.

We also move `ripgrep` and `exa` packages to be in alphabetical order.
