### PR TITLE
Add certificates

### DIFF
--- a/bootstrap.d/app-crypt.yml
+++ b/bootstrap.d/app-crypt.yml
@@ -1,5 +1,6 @@
 packages:
   - name: p11-kit
+    labels: [aarch64]
     source:
       subdir: ports
       git: 'https://github.com/p11-glue/p11-kit.git'

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -1,4 +1,38 @@
 packages:
+  - name: ca-certificates
+    labels: [aarch64]
+    source:
+      subdir: ports
+      git: 'https://github.com/djlucas/make-ca.git'
+      tag: 'v1.7'
+      # While unusual, version will be the date of the last bump + the NSS version used.
+      # If needed, we can always fetch a set NSS commit past the last release to fix critical bugs.
+      version: '20210605.3.66'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - openssl
+      - p11-kit
+    sources_required:
+      - nss
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+      - args: ['cp', '@THIS_SOURCE_DIR@/../nss/lib/ckfw/builtins/certdata.txt', '@THIS_SOURCE_DIR@']
+    build:
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      # We need to run this script, mark it as runnable.
+      - args: ['chmod', '0755', '@THIS_BUILD_DIR@/make-ca']
+      # Run it, -f forces it, -C points to our certdata.txt -D sets the destination.
+      - args: ['@THIS_BUILD_DIR@/make-ca', '-f', '-C', '@THIS_SOURCE_DIR@/certdata.txt', '-D', '@THIS_COLLECT_DIR@']
+      # BLFS installs this directory for any local certificates a system administrator may have.
+      - args: ['install', '-dm755', '@THIS_COLLECT_DIR@/etc/ssl/local']
+      # We don't have systemd, but it's installed if the host has it, remove it.
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib/systemd/']
+      # Fix a small permission issue during installation
+      - args: ['chmod', '0755', '@THIS_COLLECT_DIR@/etc/ssl/certs/.']
+
   - name: sl
     source:
       subdir: ports

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -19,6 +19,12 @@ sources:
           '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
           '@THIS_SOURCE_DIR@/icu4c/source']
 
+  - name: nss
+    subdir: 'ports'
+    git: 'https://github.com/nss-dev/nss.git'
+    tag: 'NSS_3_66_RTM'
+    version: 'NSS_3_66_RTM'
+
 tools:
   - name: host-glib
     exports_aclocal: true
@@ -631,6 +637,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: libtasn
+    labels: [aarch64]
     source:
       subdir: ports
       git: 'https://gitlab.com/gnutls/libtasn1.git'

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -6,6 +6,7 @@ packages:
     pkgs_required:
       - core-files
       - tzdata
+      - ca-certificates
       - managarm-kernel
       - managarm-system
       - kmscon


### PR DESCRIPTION
This PR adds a port of `make-ca`, which is a script that BLFS uses to generate the certificates used by `OpenSSL`. As the package that holds the certificates is often times called `ca-certificates`, I opted to use the same name. This package has also been added to the `base` metapackage and all dependencies of `ca-certificates` and `ca-certificates` itself received a label marking them ready to build on AArch64.

A small note regarding the version number used on `ca-certificates`, as is common with the `ca-certificates` package, at least on Debian based systems, I have chosen to use the date of package creation / update as a version number. This way, it is clear on which day the certificates have been generated.