### PR TITLE
scripts/vm-util: Add disable-modern=on to the qemu command line

### DIFF
--- a/scripts/vm-util.py
+++ b/scripts/vm-util.py
@@ -106,7 +106,7 @@ def do_qemu(args):
 		qemu_args += ['-netdev', 'tap,id=net0']
 	else:
 		qemu_args += ['-netdev', 'user,id=net0']
-	qemu_args += ['-device', 'virtio-net,netdev=net0']
+	qemu_args += ['-device', 'virtio-net,disable-modern=on,netdev=net0']
 
 	# Add graphics output.
 	if args.gfx == 'default':


### PR DESCRIPTION
This PR adds `disable-modern=on` to the qemu command line. It seems that this argument was missed while converting the old `run-qemu` script to the new `vm-util.py` script.