### PR TITLE
Add a port of hexchat

### DIFF
--- a/bootstrap.d/net-irc.yml
+++ b/bootstrap.d/net-irc.yml
@@ -1,0 +1,58 @@
+packages:
+  - name: hexchat
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Graphical IRC client based on XChat
+      description: This package HexChat, an IRC program. It allows you to join multiple IRC channels at the same time where you can talk publicly, have private one-to-one communications among other things.
+      spdx: 'GPL-2.0'
+      website: 'https://hexchat.github.io/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-irc']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/hexchat/hexchat.git'
+      tag: 'v2.16.1'
+      version: '2.16.1'
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+      - gdk-pixbuf
+      - gtk+-2
+      - pango
+      - libx11
+      - openssl
+    configure:
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        - '--buildtype=debugoptimized'
+        - '-Dgtk-frontend=true'
+        - '-Dtext-frontend=false'
+        - '-Dtls=enabled'
+        - '-Dplugin=true'
+        - '-Ddbus=disabled'
+        - '-Dlibcanberra=disabled'
+        - '-Dtheme-manager=false'
+        - '-Ddbus-service-use-appid=false'
+        - '-Dwith-checksum=false'
+        - '-Dwith-fishlim=false'
+        - '-Dwith-lua=false'
+        - '-Dwith-perl=false'
+        - '-Dwith-python=false'
+        - '-Dwith-sysinfo=false'
+        - '-Dinstall-appdata=false'
+        - '-Dinstall-plugin-metainfo=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -24,6 +24,7 @@ imports:
   - file: bootstrap.d/media-libs.yml
   - file: bootstrap.d/meta-pkgs.yml
   - file: bootstrap.d/net-dns.yml
+  - file: bootstrap.d/net-irc.yml
   - file: bootstrap.d/net-libs.yml
   - file: bootstrap.d/net-misc.yml
   - file: bootstrap.d/net-print.yml

--- a/patches/hexchat/0001-Add-missing-includes.patch
+++ b/patches/hexchat/0001-Add-missing-includes.patch
@@ -1,0 +1,38 @@
+From bd7f2f64a6c9b484fcd563a69272c75f44fb14a6 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 12 Oct 2022 03:19:59 +0200
+Subject: [PATCH] Add missing includes
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ src/common/proto-irc.c | 1 +
+ src/fe-gtk/fkeys.c     | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/common/proto-irc.c b/src/common/proto-irc.c
+index a8d997b..1a97f9d 100644
+--- a/src/common/proto-irc.c
++++ b/src/common/proto-irc.c
+@@ -19,6 +19,7 @@
+ /* IRC RFC1459(+commonly used extensions) protocol implementation */
+ 
+ #include <string.h>
++#include <strings.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <ctype.h>
+diff --git a/src/fe-gtk/fkeys.c b/src/fe-gtk/fkeys.c
+index dc4b41b..8b7c9a2 100644
+--- a/src/fe-gtk/fkeys.c
++++ b/src/fe-gtk/fkeys.c
+@@ -21,6 +21,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <string.h>
++#include <strings.h>
+ #include <fcntl.h>
+ #include <ctype.h>
+ 
+-- 
+2.37.2
+


### PR DESCRIPTION
This PR adds a port of `hexchat`, the `gtk+-2` based IRC client. After way too much time, I finally tried to repair this long forgotten beauty that was left to rot, and after more than one year of sitting here waiting I have finally finished restoring it. It remains blocked on a couple of error handling PRs listed below but once all of those are merged I see no blockers to finally merging this `hexchat` PR.

- [x] Blocked on managarm/managarm#336
- [x] Blocked on managarm/mlibc#273
- [x] Blocked on managarm/managarm#489
- [x] Blocked on managarm/mlibc#750
- [x] Blocked on managarm/mlibc#751
- [x] Blocked on managarm/mlibc#752
- [x] Blocked on managarm/mlibc#753
- [x] Blocked on managarm/mlibc#758
- [x] Blocked on managarm/mlibc#755