### PR TITLE
Add metadata to various packages

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -2,6 +2,13 @@ packages:
   - name: bzip2
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: A high-quality data compressor
+      description: This package contains programs for compressing and decompressing files.
+      spdx: 'bzip2-1.0.6'
+      website: 'https://gitlab.com/federicomenaquintero/bzip2'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-arch']
     source:
       subdir: ports
       url: 'https://www.sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz'
@@ -30,6 +37,13 @@ packages:
   - name: gzip
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: The standard GNU compressor
+      description: This package provides the standard GNU file compression utilities.
+      spdx: 'GPL-3.0-only'
+      website: 'https://www.gnu.org/software/gzip/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-arch']
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gzip.git'
@@ -64,6 +78,13 @@ packages:
   - name: libarchive
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: Multi-format archive and compression library
+      description: This package provides a common library to interface with the most used file compression standards.
+      spdx: 'BSD-2-Clause'
+      website: 'https://www.libarchive.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-arch']
     source:
       subdir: 'ports'
       git: 'https://github.com/libarchive/libarchive.git'
@@ -97,6 +118,13 @@ packages:
         quiet: true
 
   - name: lz4
+    metadata:
+      summary: Extremely Fast Compression algorithm
+      description: This package provides tools to compress and decompress files in .lz4 format.
+      spdx: 'BSD-2-Clause'
+      website: 'https://github.com/lz4/lz4'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-arch']
     source:
       subdir: 'ports'
       git: 'https://github.com/lz4/lz4.git'
@@ -124,6 +152,13 @@ packages:
   - name: tar
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: The best way to make a tarball
+      description: This package provides the GNU tar program, commonly used to distribute files or make backups.
+      spdx: 'GPL-3.0-or-later'
+      website: 'https://www.gnu.org/software/tar/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-arch']
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/tar.git'
@@ -158,6 +193,13 @@ packages:
   - name: xz-utils
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: Utilities for managing LZMA compressed files
+      description: This package provides the programs to compress and decompress lzma and xz compressed files.
+      spdx: 'no-spdx: Public Domain'
+      website: 'https://tukaani.org/xz/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-arch']
     source:
       subdir: ports
       git: 'https://git.tukaani.org/xz.git'
@@ -194,6 +236,13 @@ packages:
   - name: zstd
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: zstd fast compression library
+      description: This package provides the programs to interact with Zstandard compressed files.
+      spdx: 'BSD-3-Clause'
+      website: 'https://facebook.github.io/zstd/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-arch']
     source:
       subdir: ports
       git: 'https://github.com/facebook/zstd.git'

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -1,5 +1,12 @@
 packages:
   - name: ca-certificates
+    metadata:
+      summary: Common CA certificates PEM files
+      description: This package provides the standard set of Certificate Authorities as chosen by Mozilla in their NSS project  It also includes a script to (re)generate the certificate files.
+      spdx: 'MPL-2.0'
+      website: 'https://packages.debian.org/sid/ca-certificates'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-misc']
     labels: [aarch64]
     architecture: noarch
     source:

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -38,6 +38,13 @@ packages:
       - args: ['chmod', '0755', '@THIS_COLLECT_DIR@/etc/ssl/certs/.']
 
   - name: sl
+    metadata:
+      summary: Never type 'ls' wrong again!
+      description: This package provides a fun way to correct the all too common typo of 'sl' when 'ls' was meant.
+      spdx: 'no-spdx: Toyoda license'
+      website: 'https://github.com/mtoyoda/sl/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-misc']
     source:
       subdir: ports
       git: 'https://github.com/mtoyoda/sl.git'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -54,6 +54,13 @@ tools:
 
 packages:
   - name: atk
+    metadata:
+      summary: GTK+ & GNOME Accessibility Toolkit
+      description: This package provides a set of accessibility interfaces used extensively througout GTK and GNOME.
+      spdx: 'LGPL-2.0-or-later'
+      website: 'https://wiki.gnome.org/Accessibility'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: 'ports'
       git: 'https://gitlab.gnome.org/GNOME/atk.git'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -91,6 +91,13 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: d0-blind-id
+    metadata:
+      summary: Blind-ID library for user identification using RSA blind signatures
+      description: This package provides a library for user identification using RSA blind signatures.
+      spdx: 'BSD-3-Clause'
+      website: 'https://git.xonotic.org/?p=xonotic/d0_blind_id.git'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: 'ports'
       git: 'https://github.com/divVerent/d0_blind_id.git'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -131,6 +131,13 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: fribidi
+    metadata:
+      summary: A free implementation of the unicode bidirectional algorithm
+      description: This package provides a library with an implementation of the Unicode Bidirectional Algorithm (BIDI). This is used for supporting Arabic and Hebrew alphabets in other packages.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://fribidi.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: 'ports'
       git: 'https://github.com/fribidi/fribidi.git'

--- a/bootstrap.d/media-fonts.yml
+++ b/bootstrap.d/media-fonts.yml
@@ -63,6 +63,13 @@ packages:
           - args: ['fc-cache']
 
   - name: xorg-font-util
+    metadata:
+      summary: X.Org font utilities
+      description: This package provides various X.Org font utilities.
+      spdx: 'MIT'
+      website: 'https://gitlab.freedesktop.org/xorg/font/util'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['media-fonts']
     labels: [aarch64]
     architecture: '@OPTION:arch@'
     from_source: xorg-font-util

--- a/bootstrap.d/media-fonts.yml
+++ b/bootstrap.d/media-fonts.yml
@@ -32,7 +32,13 @@ tools:
 
 packages:
   - name: dejavu
-    revision: 2
+    metadata:
+      summary: Dejavu fonts
+      description: This package provides the Dejavu fonts, commonly found on Linux systems.
+      spdx: 'no-spdx: BitstreamVera license'
+      website: 'https://dejavu-fonts.github.io/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['media-fonts']
     labels: [aarch64]
     architecture: noarch
     source:
@@ -44,6 +50,7 @@ packages:
     pkgs_required:
       - freetype
       - fontconfig
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/ttf', '@THIS_SOURCE_DIR@/dejavu']
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/', '@THIS_BUILD_DIR@']

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -6,6 +6,13 @@ packages:
     source:
       subdir: meta-sources
       version: '1.0'
+    metadata:
+      summary: Minimum meta-package to provide a useful environment
+      description: This meta-package provides a useful terminal only environment with various common unix tools and the xbps package manager.
+      spdx: 'MIT'
+      website: 'https://managarm.org'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['meta-pkgs']
     revision: 2
     pkgs_required:
       - mlibc
@@ -45,6 +52,13 @@ packages:
     source:
       subdir: meta-sources
       version: '1.0'
+    metadata:
+      summary: Meta-package to provide common development utilities
+      description: This meta-package provides a set of commonly used development utilities, including the gcc compiler and GNU Make.
+      spdx: 'MIT'
+      website: 'https://managarm.org'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['meta-pkgs']
     pkgs_required:
       - base
       - binutils
@@ -66,6 +80,13 @@ packages:
     source:
       subdir: meta-sources
       version: '1.0'
+    metadata:
+      summary: Meta-package to provide a useful GUI environment (Weston)
+      description: This meta-package provides a GUI environment based on the Weston compositor and various small X based utilities.
+      spdx: 'MIT'
+      website: 'https://managarm.org'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['meta-pkgs']
     pkgs_required:
       - base
       - weston

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1236,6 +1236,13 @@ packages:
         quiet: true
 
   - name: zlib
+    metadata:
+      summary: Standard (de)compression library
+      description: This package provides some common compression and decompression functions used by various programs.
+      spdx: 'Zlib'
+      website: 'https://zlib.net'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-libs']
     labels: [aarch64]
     architecture: '@OPTION:arch@'
     source:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -598,6 +598,13 @@ tools:
 
 packages:
   - name: binutils
+    metadata:
+      summary: Tools necessary to build programs
+      description: This package provides various tools commonly used during package development, including the GNU linker and the GNU assembler. This package also includes libbfd and libopcodes.
+      spdx: 'GPL-3.0-or-later'
+      website: 'https://www.gnu.org/software/binutils/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-devel']
     from_source: binutils
     tools_required:
       - tool: system-gcc
@@ -625,6 +632,13 @@ packages:
         quiet: true
 
   - name: boost
+    metadata:
+      summary: Boost development headers
+      description: This package provides the Boost headers for C++.
+      spdx: 'BSL-1.0'
+      website: 'https://boost.org'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     labels: [aarch64]
     architecture: noarch
     source:
@@ -647,6 +661,13 @@ packages:
             '@THIS_COLLECT_DIR@/usr/include']
 
   - name: core-files
+    metadata:
+      summary: Managarm base filesystem layout
+      description: This package provides the base filesystem layout that Managarm uses, includes various directories, essential files and symlinks.
+      spdx: 'MIT'
+      website: 'https://managarm.org'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-apps']
     labels: [aarch64]
     architecture: noarch
     default: true

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1270,6 +1270,13 @@ packages:
   - name: libtsm
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: Terminal emulator state machine
+      description: LibTSM provides a state machine for DEC VT100-VT520 compatible terminal emulators.
+      spdx: 'MIT'
+      website: 'https://github.com/Aetf/libtsm'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: 'ports'
       git: 'https://github.com/managarm/libtsm-mirror.git'
@@ -1310,6 +1317,13 @@ packages:
     labels: [aarch64]
     architecture: '@OPTION:arch@'
     default: true
+    metadata:
+      summary: Terminal emulator based on KMS/DRM
+      description: Kmscon is a simle KMS/DRM based terminal emulator.
+      spdx: 'MIT'
+      website: 'https://github.com/Aetf/kmscon'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-apps']
     source:
       subdir: 'ports'
       git: 'https://github.com/dvdhrm/kmscon.git'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -995,6 +995,13 @@ packages:
         quiet: true
 
   - name: managarm-kernel
+    metadata:
+      summary: The Managarm kernel
+      description: This package provides the Managarm kernel.
+      spdx: 'MIT'
+      website: 'https://managarm.org'
+      maintainer: "Alexander van der Grinten <avdgrinten@managarm.org>"
+      categories: ['sys-kernel']
     labels: [aarch64]
     architecture: '@OPTION:arch@'
     default: true
@@ -1030,6 +1037,13 @@ packages:
         quiet: true
 
   - name: managarm-system
+    metadata:
+      summary: The Managarm userspace
+      description: This package provides the Managarm userspace components, various drivers and the POSIX emulation layer.
+      spdx: 'MIT'
+      website: 'https://managarm.org'
+      maintainer: "Alexander van der Grinten <avdgrinten@managarm.org>"
+      categories: ['sys-kernel']
     labels: [aarch64]
     architecture: '@OPTION:arch@'
     default: true
@@ -1075,6 +1089,13 @@ packages:
         quiet: true
 
   - name: mlibc-headers
+    metadata:
+      summary: Managarm libc headers
+      description: This package provides the headers for the C standard library that Managarm uses.
+      spdx: 'MIT'
+      website: 'https://managarm.org'
+      maintainer: "Alexander van der Grinten <avdgrinten@managarm.org>"
+      categories: ['sys-libs']
     labels: [aarch64]
     architecture: '@OPTION:arch@'
     from_source: mlibc
@@ -1099,6 +1120,13 @@ packages:
         quiet: true
 
   - name: mlibc
+    metadata:
+      summary: Managarm libc C library
+      description: This package provides the C standard library that Managarm uses, this includes the dynamic loader and various utility libraries.
+      spdx: 'MIT'
+      website: 'https://managarm.org'
+      maintainer: "Alexander van der Grinten <avdgrinten@managarm.org>"
+      categories: ['sys-libs']
     labels: [aarch64]
     architecture: '@OPTION:arch@'
     from_source: mlibc


### PR DESCRIPTION
This PR adds metadata to several packages. The plan is to add this to all packages so `xbps` can display this to the end user.

Currently, the following packages have metadata applied to them:
- `managarm-kernel`,
- `managarm-system`,
- `mlibc-headers`,
- `mlibc`,
- `binutils`,
- `boost`,
- `core-files,`
- `base`,
- `base-devel`,
- `weston-desktop`,
- `zlib`,
- `ca-certificates`,
- `sl`,
- `dejavu`,
- `xorg-font-util`,
- `atk`,
- `d0-blind-id`,
- `fribidi`,
- `libtsm`,
- `kmscon`,
- `bzip2`,
- `gzip`,
- `libarchive`,
- `lz4`,
- `tar`,
- `xz-utils`,
- `zstd`.

As data sources for the metadata (descriptions, websites and licensing), I've aggregated information from https://packages.gentoo.org, https://linuxfromscratch.org (both LFS and BLFS) and the information provided by `aptitude show` on debian sid.