### PR TITLE
Implicit package removal

### DIFF
--- a/bootstrap.d/app-admin.yml
+++ b/bootstrap.d/app-admin.yml
@@ -14,6 +14,8 @@ packages:
         - args: ['./autogen.sh']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -9,6 +9,8 @@ packages:
       version: '1.0.8'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       # Remove the test directory from the Makefile, as it tries to run (and fail on) the tests
@@ -41,6 +43,8 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -64,6 +68,7 @@ packages:
       - host-cmake
       - system-gcc
     pkgs_required:
+      - mlibc
       - openssl
       - zlib
       - xz-utils
@@ -95,6 +100,8 @@ packages:
     tools_required:
       - host-cmake
       - system-gcc
+    pkgs_required:
+      - mlibc
     revision: 2
     configure:
       - args:
@@ -126,6 +133,8 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -160,6 +169,7 @@ packages:
       - host-libtool
       - system-gcc
     pkgs_required:
+      - mlibc
       - zlib
     configure:
       - args:
@@ -184,6 +194,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - zlib
       - xz-utils
     configure:

--- a/bootstrap.d/app-crypt.yml
+++ b/bootstrap.d/app-crypt.yml
@@ -18,6 +18,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libffi
       - libtasn
     configure:

--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -24,6 +24,7 @@ packages:
       - host-pkg-config
       - system-gcc
     pkgs_required:
+      - mlibc
       - file
       - ncurses
       - libintl
@@ -65,6 +66,7 @@ packages:
       - host-pkg-config
       - host-automake-v1.15
     pkgs_required:
+      - mlibc
       - ncurses
       - libiconv
     configure:

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -40,6 +40,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - ncurses
     revision: 2
     configure:

--- a/bootstrap.d/app-shells.yml
+++ b/bootstrap.d/app-shells.yml
@@ -21,6 +21,7 @@ packages:
       - host-automake-v1.15
       - system-gcc
     pkgs_required:
+      - mlibc
       - ncurses
       - readline
       - libiconv

--- a/bootstrap.d/dev-db.yml
+++ b/bootstrap.d/dev-db.yml
@@ -16,6 +16,7 @@ packages:
       - system-gcc
       - host-libtool
     pkgs_required:
+      - mlibc
       - readline
       - zlib
     configure:

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -120,6 +120,8 @@ packages:
       version: '2.14.02'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -143,6 +145,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - zlib
       - bzip2
     configure:
@@ -184,6 +187,7 @@ packages:
       - host-python
       - system-gcc
     pkgs_required:
+      - mlibc
       - zlib
       - libexpat
       - libffi
@@ -240,6 +244,8 @@ packages:
         - args: ['make', '-C', '@THIS_SOURCE_DIR@', 'distclean']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -63,6 +63,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - glib
     configure:
       - args:
@@ -95,6 +96,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - gmp
     configure:
       - args:
@@ -132,6 +134,8 @@ packages:
       - system-gcc
       - host-autoconf-v2.69
       - host-automake-v1.15
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -152,6 +156,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - pcre
       - libffi
       - zlib
@@ -195,6 +200,8 @@ packages:
             '@THIS_SOURCE_DIR@/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -215,6 +222,8 @@ packages:
     tools_required:
       - system-gcc
       - host-icu
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['cp',
           '@THIS_SOURCE_DIR@/icu4c/source/config/mh-linux',
@@ -240,6 +249,8 @@ packages:
     tools_required:
       - system-gcc
       - host-cmake
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - 'cmake'
@@ -271,6 +282,8 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     revision: 2
     configure:
       - args:
@@ -304,6 +317,8 @@ packages:
       - host-automake-v1.15
       - host-libtool
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/expat/configure'
@@ -337,6 +352,8 @@ packages:
             '@THIS_SOURCE_DIR@/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -369,6 +386,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libgpg-error
     configure:
       - args:
@@ -404,6 +422,8 @@ packages:
         - args: ['autoreconf', '-f', '-v', '-i']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       # libgpg-error does not know about managarm, teach it
       - args: ['cp', '-v', '@THIS_SOURCE_DIR@/src/syscfg/lock-obj-pub.x86_64-unknown-linux-gnu.h',
@@ -470,6 +490,8 @@ packages:
     tools_required:
       - system-gcc
       - host-libtool
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -499,6 +521,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - eudev
       - libevdev
       - mtdev
@@ -539,6 +562,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libiconv
     configure:
       - args:
@@ -591,6 +615,7 @@ packages:
       - system-gcc
       - host-autoconf-v2.69
     pkgs_required:
+      - mlibc
       - freetype
     revision: 2
     configure:
@@ -625,6 +650,8 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -655,6 +682,8 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -683,6 +712,8 @@ packages:
         - args: ['./autogen.sh']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -714,6 +745,7 @@ packages:
       - system-gcc
       - host-python
     pkgs_required:
+      - mlibc
       - zlib
       - python
       - libiconv
@@ -748,6 +780,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - gmp
       - mpfr
     configure:
@@ -782,6 +815,7 @@ packages:
       - system-gcc
       - host-libtool
     pkgs_required:
+      - mlibc
       - gmp
     configure:
       - args:
@@ -824,6 +858,7 @@ packages:
       - host-autoconf-v2.69
       - host-automake-v1.15
     pkgs_required:
+      - mlibc
       - gmp
     configure:
       - args:
@@ -849,6 +884,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - zlib
     revision: 2
     configure:
@@ -896,6 +932,8 @@ packages:
       - system-gcc
       - host-autoconf-v2.69
       - host-automake-v1.15
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -929,6 +967,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libiconv
     configure:
       - args:
@@ -997,6 +1036,7 @@ packages:
       - system-gcc
       - wayland-scanner
     pkgs_required:
+      - mlibc
       - cairo
       - libinput
       - libxkbcommon
@@ -1034,6 +1074,8 @@ packages:
       version: '0.8.0'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/dev-util.yml
+++ b/bootstrap.d/dev-util.yml
@@ -56,6 +56,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - curl
       - libarchive
       - libexpat
@@ -108,6 +109,7 @@ packages:
       - host-libtool
       - host-pkg-config
     pkgs_required:
+      - mlibc
       - glib
     configure:
       - args:
@@ -151,6 +153,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - glib
     configure:
       - args:

--- a/bootstrap.d/games-board.yml
+++ b/bootstrap.d/games-board.yml
@@ -20,6 +20,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libice
       - libpng
       - libx11

--- a/bootstrap.d/games-misc.yml
+++ b/bootstrap.d/games-misc.yml
@@ -10,6 +10,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - gtk+-2
       - gdk-pixbuf
       - pango
@@ -66,6 +67,8 @@ packages:
       version: '1.5.2'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/media-fonts.yml
+++ b/bootstrap.d/media-fonts.yml
@@ -58,6 +58,8 @@ packages:
     from_source: xorg-font-util
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/media-gfx.yml
+++ b/bootstrap.d/media-gfx.yml
@@ -10,7 +10,8 @@ packages:
       - host-python
       - host-cmake
     pkgs_required:
-      - gcc
+      - mlibc
+      - gcc # Actually requires libstdc++.so in the system root, otherwise it links against the host libstdc++.so.6
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -18,6 +18,7 @@ packages:
         # Make sure we regenerate this file
         - args: ['rm', '-f', 'src/fcobjshash.h']
     pkgs_required:
+      - mlibc
       - freetype
       - libxml
       - libiconv
@@ -56,6 +57,7 @@ packages:
       - host-cmake
       - system-gcc
     pkgs_required:
+      - mlibc
       - libxi
       - mesa
       - glu
@@ -98,6 +100,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - bzip2
       - libpng
       - zlib
@@ -125,6 +128,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - glu
       - mesa
     configure:
@@ -162,7 +166,8 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
-      - gcc
+      - mlibc
+      - gcc # Actually requires libstdc++.so in the system root, otherwise it links against the host libstdc++.so.6
       - mesa
     configure:
       - args:
@@ -198,6 +203,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - graphite2
       - glib
       - zlib
@@ -244,6 +250,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - mesa
       - xorg-proto
       - libx11
@@ -273,6 +280,8 @@ packages:
       - host-cmake
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - 'cmake'
@@ -309,6 +318,8 @@ packages:
         - args: ['autoreconf', '-fvi']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -337,6 +348,8 @@ packages:
             NOCONFIGURE: '1'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -366,6 +379,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - zlib
     configure:
       - args:
@@ -396,6 +410,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libogg
       - libvorbis
     configure:
@@ -436,6 +451,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libogg
     configure:
       - args:
@@ -468,6 +484,7 @@ packages:
       - virtual: pkgconfig-for-host
         program_name: host-pkg-config
     pkgs_required:
+      - mlibc
       - libdrm
       - llvm
       - wayland

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -4,6 +4,7 @@ packages:
     labels: [aarch64]
     from_source: managarm
     pkgs_required:
+      - mlibc
       - core-files
       - tzdata
       - ca-certificates

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -18,6 +18,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - openssl
     configure:
       - args:
@@ -76,6 +77,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     revision: 2
     pkgs_required:
+      - mlibc
       - lz4
       - openssl
       - libiconv
@@ -129,6 +131,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - ncurses
       - readline
       - openssl
@@ -174,6 +177,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - pcre
       - openssl
     revision: 2

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -48,6 +48,8 @@ packages:
       # Bison 3.7 broke gnulib, work around it by building an older bison
       - host-bison
       - system-gcc
+    pkgs_required:
+      - mlibc
     revision: 2
     configure:
       # Huge hack: coreutils does not compile the build-machine binary make-prime-list
@@ -91,6 +93,8 @@ packages:
       - system-gcc
       - host-autoconf-v2.69
       - host-automake-v1.15
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -117,6 +121,8 @@ packages:
       - system-gcc
     sources_required:
       - rust-patched-libs
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
@@ -141,6 +147,7 @@ packages:
       - system-gcc
       - host-file
     pkgs_required:
+      - mlibc
       - zlib
     configure:
       - args:
@@ -175,6 +182,8 @@ packages:
     tools_required:
       - system-gcc
       - host-python
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -210,6 +219,8 @@ packages:
       - system-gcc
       - host-autoconf-v2.69
       - host-automake-v1.15
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -241,6 +252,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - pcre
     configure:
       - args:
@@ -273,6 +285,8 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -306,6 +320,7 @@ packages:
       - host-automake-v1.15
       - host-libtool
     pkgs_required:
+      - mlibc
       - ncurses
     revision: 2
     configure:
@@ -337,6 +352,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libpipeline
       - gdbm
       - groff
@@ -389,6 +405,8 @@ packages:
         - args: ['wget', '-O', '@THIS_SOURCE_DIR@/pci.ids', 'https://raw.githubusercontent.com/pciutils/pciids/master/pci.ids']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - 'meson'
@@ -437,6 +455,8 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -459,6 +479,8 @@ packages:
       - host-cargo
     sources_required:
       - rust-patched-libs
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
@@ -491,6 +513,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - eudev
       - readline
       - ncurses
@@ -584,6 +607,8 @@ packages:
       version: '2.21'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -607,6 +632,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libarchive
       - openssl
       - zlib

--- a/bootstrap.d/sys-boot.yml
+++ b/bootstrap.d/sys-boot.yml
@@ -19,9 +19,10 @@ packages:
       git: 'https://github.com/limine-bootloader/limine.git'
       tag: 'v2.23'
       version: '2.23'
-    revision: 1
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['cp', '-rv', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -76,6 +76,8 @@ packages:
       version: '3.2.4'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args: ['./configure.sh', '-G', '-O3']
@@ -97,6 +99,8 @@ packages:
       - system-gcc
       - host-autoconf-v2.69
       - host-automake-v1.15
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -125,6 +129,8 @@ packages:
         - args: ['./autogen.sh']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -149,6 +155,8 @@ packages:
       - system-gcc
       - host-autoconf-v2.69
       - host-automake-v1.15
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -191,6 +199,8 @@ packages:
             '@THIS_SOURCE_DIR@/build-aux/']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     revision: 2
     configure:
       - args:
@@ -228,6 +238,8 @@ packages:
       - system-gcc
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -264,6 +276,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - diffutils
     revision: 2
     configure:

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -45,6 +45,8 @@ packages:
       - host-autoconf-v2.69
       - host-automake-v1.15
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -78,6 +80,8 @@ packages:
       - host-autoconf-v2.69
       - host-automake-v1.15
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -98,9 +102,11 @@ packages:
       git: 'https://github.com/ThomasDickey/ncurses-snapshots.git'
       tag: 'v6_2'
       version: '6.2'
-    revision: 2
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -142,6 +148,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - ncurses
     configure:
       - args:

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -17,6 +17,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - freeglut
       - freetype
       - glew
@@ -65,6 +66,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - libx11
       - libxmu
       - libxaw
@@ -107,6 +109,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - xcb-proto
@@ -149,6 +152,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - mesa
       - xorg-util-macros
       - libx11
@@ -185,6 +189,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - libx11
       - libxkbfile
@@ -220,6 +225,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - libx11
       - libxmu
@@ -256,6 +262,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - libxcb
     configure:
@@ -290,6 +297,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - libx11
     configure:
@@ -324,6 +332,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - libxmu
       - libx11
@@ -362,6 +371,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - libx11
       - xcb-util

--- a/bootstrap.d/x11-base.yml
+++ b/bootstrap.d/x11-base.yml
@@ -91,6 +91,7 @@ packages:
       - virtual: pkgconfig-for-host
         program_name: host-pkg-config
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xcb-proto
       - xorg-proto

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -53,6 +53,7 @@ packages:
       - host-libtool
       - host-pkg-config
     pkgs_required:
+      - mlibc
       - freetype
       - fontconfig
       - libpng
@@ -99,6 +100,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - glib
       - libjpeg-turbo
       - libpng
@@ -141,6 +143,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - atk
       - cairo
       - glib
@@ -187,6 +190,8 @@ packages:
           triple: "@OPTION:arch-triple@"
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - 'meson'
@@ -237,6 +242,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -278,6 +284,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -317,6 +324,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -357,6 +365,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libxcb
@@ -398,6 +407,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
     configure:
@@ -433,6 +443,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -475,6 +486,7 @@ packages:
       - system-gcc
       - host-python
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libxau
@@ -518,6 +530,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -558,6 +571,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -597,6 +611,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libxau
@@ -635,6 +650,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -675,6 +691,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -718,6 +735,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -764,6 +782,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -805,6 +824,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -842,6 +862,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - wayland
       - wayland-protocols
       - libxcb
@@ -887,6 +908,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -925,6 +947,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -964,6 +987,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -1004,6 +1028,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -1046,6 +1071,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -1086,6 +1112,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -1124,6 +1151,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -1189,6 +1217,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -1230,6 +1259,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -1271,6 +1301,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
@@ -1304,6 +1335,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - glib
       - fontconfig
       - freetype
@@ -1353,6 +1385,7 @@ packages:
       - host-pkg-config
       - system-gcc
     pkgs_required:
+      - mlibc
       - libpng
     configure:
       - args:
@@ -1388,6 +1421,7 @@ packages:
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -48,6 +48,7 @@ packages:
       - system-gcc
       - host-python
     pkgs_required:
+      - mlibc
       - glib
       - libxml
       - itstool

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -587,6 +587,8 @@ packages:
     from_source: binutils
     tools_required:
       - tool: system-gcc
+    pkgs_required:
+      - mlibc
     revision: 2
     configure:
       - args:
@@ -716,6 +718,7 @@ packages:
       - tool: system-gcc
       - host-automake-v1.15
     pkgs_required:
+      - mlibc
       - gmp
       - mpfr
       - mpc
@@ -762,6 +765,8 @@ packages:
         - args: ['./autogen.sh']
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -791,6 +796,8 @@ packages:
       branch: 'master'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - 'meson'
@@ -845,6 +852,8 @@ packages:
     tools_required:
       - host-cmake
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - 'cmake'
@@ -894,6 +903,7 @@ packages:
       - host-cmake
       - system-gcc
     pkgs_required:
+      - mlibc
       - zlib
     configure:
       - args:
@@ -941,6 +951,7 @@ packages:
       - host-pkg-config
       - system-gcc
     pkgs_required:
+      - mlibc
       - mesa
     configure:
       - args:
@@ -1002,6 +1013,7 @@ packages:
       - host-protoc
       - system-gcc
     pkgs_required:
+      - mlibc
       - eudev
       - fafnir
       # This should not be necessary (due to the source dep),
@@ -1094,6 +1106,8 @@ packages:
     tools_required:
       - system-gcc
       - host-protoc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1119,6 +1133,7 @@ packages:
       - system-gcc
       - wayland-scanner
     pkgs_required:
+      - mlibc
       - libexpat
       - libffi
     configure:
@@ -1149,6 +1164,8 @@ packages:
       version: '1.2.11'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1185,6 +1202,7 @@ packages:
       - host-pkg-config
       - system-gcc
     pkgs_required:
+      - mlibc
       - libxkbcommon
     configure:
       - args:
@@ -1222,6 +1240,7 @@ packages:
       - host-autoconf-v2.69
       - host-automake-v1.15
     pkgs_required:
+      - mlibc
       - libxkbcommon
       - libdrm
       - libtsm
@@ -1258,6 +1277,7 @@ packages:
       - host-pkg-config
       - wayland-scanner
     pkgs_required:
+      - mlibc
       - libdrm
       - eudev
       - mesa
@@ -1327,6 +1347,7 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - mlibc
       - sdl2
     configure:
       - args:
@@ -1353,6 +1374,8 @@ packages:
       version: '5.3.5'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -1391,6 +1414,7 @@ packages:
       - host-autoconf-v2.69
       - host-automake-v1.15
     pkgs_required:
+      - mlibc
       - sdl2
     configure:
       - args:
@@ -1418,6 +1442,8 @@ packages:
       version: '2.1.2'
     tools_required:
       - system-gcc
+    pkgs_required:
+      - mlibc
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args: 'echo @OPTION:arch-triple@-gcc -O2 -Wall > @THIS_BUILD_DIR@/src/conf-cc'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1052,7 +1052,6 @@ packages:
     tools_required:
       - host-managarm-tools
       - host-protoc
-    implict_package: true
     configure:
       - args:
         - 'meson'
@@ -1077,7 +1076,6 @@ packages:
       - host-managarm-tools
       - bootstrap-system-gcc
       - host-protoc
-    implict_package: true
     pkgs_required:
       - mlibc-headers
     configure:


### PR DESCRIPTION
This PR removes the implicit package definition from `mlibc` and `mlibc-headers`, and adds a dependency on `mlibc` to all packages that require it.