### PR TITLE
gcc: Update from version 10.3.0 to 11.1.0

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -104,8 +104,8 @@ sources:
   - name: gcc
     subdir: 'ports'
     git: 'git://gcc.gnu.org/git/gcc.git'
-    tag: 'releases/gcc-10.3.0'
-    version: '10.3.0'
+    tag: 'releases/gcc-11.1.0'
+    version: '11.1.0'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.11
@@ -720,7 +720,6 @@ packages:
       - mpfr
       - mpc
       - zlib
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/patches/gcc/0001-Managarm-target.patch
+++ b/patches/gcc/0001-Managarm-target.patch
@@ -1,4 +1,4 @@
-From 1a7918abf523d88f7aa7532d5fb2ec5c90123ab1 Mon Sep 17 00:00:00 2001
+From d1c00b3751c8238828318187b002d30a0954e8ac Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Tue, 13 Apr 2021 21:20:52 +0200
 Subject: [PATCH] Managarm target
@@ -7,20 +7,22 @@ TODO: Use libtoolize instead of modifying in-tree libtool?
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- config.sub                            |  8 +++-
- fixincludes/mkfixinc.sh               |  2 +
- gcc/config.gcc                        | 59 +++++++++++++++++++++++++++
- gcc/config/aarch64/aarch64-managarm.h | 45 ++++++++++++++++++++
- gcc/config/aarch64/t-aarch64-managarm |  8 ++++
- gcc/config/i386/i386-managarm.h       | 11 +++++
- gcc/config/i386/t-managarm64          |  4 ++
- gcc/config/managarm-kernel.h          |  9 ++++
- gcc/config/managarm-system.h          |  3 ++
- gcc/config/managarm.h                 | 13 ++++++
- libgcc/config.host                    | 16 ++++++++
- libstdc++-v3/crossconfig.m4           | 11 +++++
- libtool.m4                            | 14 +++++++
- 13 files changed, 201 insertions(+), 2 deletions(-)
+ config.sub                                  | 11 +++-
+ fixincludes/mkfixinc.sh                     |  2 +
+ gcc/config.gcc                              | 59 +++++++++++++++++++++
+ gcc/config/aarch64/aarch64-managarm.h       | 45 ++++++++++++++++
+ gcc/config/aarch64/t-aarch64-managarm       |  8 +++
+ gcc/config/i386/i386-managarm.h             | 11 ++++
+ gcc/config/i386/t-managarm64                |  4 ++
+ gcc/config/managarm-kernel.h                |  9 ++++
+ gcc/config/managarm-system.h                |  3 ++
+ gcc/config/managarm.h                       | 13 +++++
+ libgcc/config.host                          | 16 ++++++
+ libgcc/libgcov.h                            |  1 +
+ libstdc++-v3/crossconfig.m4                 | 11 ++++
+ libstdc++-v3/include/c_compatibility/fenv.h | 10 ++--
+ libtool.m4                                  | 14 +++++
+ 15 files changed, 210 insertions(+), 7 deletions(-)
  create mode 100644 gcc/config/aarch64/aarch64-managarm.h
  create mode 100644 gcc/config/aarch64/t-aarch64-managarm
  create mode 100644 gcc/config/i386/i386-managarm.h
@@ -30,40 +32,50 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  create mode 100644 gcc/config/managarm.h
 
 diff --git a/config.sub b/config.sub
-index a318a4686..a9324e4b0 100755
+index 63c1f1c8b5e..033763b58cc 100755
 --- a/config.sub
 +++ b/config.sub
-@@ -133,7 +133,8 @@ case $1 in
+@@ -132,7 +132,8 @@ case $1 in
+ 		maybe_os=$field2-$field3
  		case $maybe_os in
- 			nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc \
- 			| linux-newlib* | linux-musl* | linux-uclibc* | uclinux-uclibc* \
+ 			nto-qnx* | linux-* | uclinux-uclibc* \
 -			| uclinux-gnu* | kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* \
 +			| uclinux-gnu* | managarm-kernel* | managarm-system* \
 +			| kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* \
  			| netbsd*-eabi* | kopensolaris*-gnu* | cloudabi*-eabi* \
  			| storm-chaos* | os2-emx* | rtmk-nova*)
  				basic_machine=$field1
-@@ -1366,7 +1367,7 @@ case $os in
+@@ -1313,6 +1314,10 @@ EOF
+ 		kernel=linux
+ 		os=$(echo $basic_os | sed -e 's|linux|gnu|')
+ 		;;
++	managarm*)
++		kernel=managarm
++		os=$(echo $basic_os | sed -e 's|managarm|system|')
++		;;
+ 	*)
+ 		kernel=
+ 		os=$basic_os
+@@ -1725,7 +1730,7 @@ case $os in
  	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
  	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
  	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
--	     | nsk* | powerunix)
-+	     | nsk* | powerunix* | managarm-kernel* | managarm-system*)
- 	# Remember, each alternative MUST END IN *, to match a version number.
+-	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx*)
++	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | kernel* | system*)
  		;;
- 	qnx*)
-@@ -1408,6 +1409,9 @@ case $os in
- 	mac*)
- 		os=`echo "$os" | sed -e 's|mac|macos|'`
+ 	# This one is extra strict with allowed versions
+ 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
+@@ -1744,6 +1749,8 @@ esac
+ case $kernel-$os in
+ 	linux-gnu* | linux-dietlibc* | linux-android* | linux-newlib* | linux-musl* | linux-uclibc* )
  		;;
-+	managarm*)
-+		os=`echo $os | sed -e 's|managarm|managarm-system|'`
++	managarm-kernel* | managarm-system* )
 +		;;
- 	opened*)
- 		os=openedition
+ 	uclinux-uclibc* )
  		;;
+ 	-dietlibc* | -newlib* | -musl* | -uclibc* )
 diff --git a/fixincludes/mkfixinc.sh b/fixincludes/mkfixinc.sh
-index df90720b7..f79010d07 100755
+index df90720b716..f79010d078e 100755
 --- a/fixincludes/mkfixinc.sh
 +++ b/fixincludes/mkfixinc.sh
 @@ -12,6 +12,8 @@ target=fixinc.sh
@@ -76,10 +88,10 @@ index df90720b7..f79010d07 100755
      x86_64-*-mingw32* | \
      powerpc-*-eabisim* | \
 diff --git a/gcc/config.gcc b/gcc/config.gcc
-index 6fcdd771d..ca1cccc78 100644
+index 357b0bed067..1cb66ac6563 100644
 --- a/gcc/config.gcc
 +++ b/gcc/config.gcc
-@@ -866,6 +866,29 @@ case ${target} in
+@@ -885,6 +885,29 @@ case ${target} in
    target_has_targetcm=yes
    target_has_targetdm=yes
    ;;
@@ -109,7 +121,7 @@ index 6fcdd771d..ca1cccc78 100644
  *-*-netbsd*)
    tm_p_file="${tm_p_file} netbsd-protos.h"
    tmake_file="t-netbsd t-slibgcc"
-@@ -1141,6 +1164,24 @@ aarch64*-*-linux*)
+@@ -1162,6 +1185,24 @@ aarch64*-*-linux*)
  	done
  	TM_MULTILIB_CONFIG=`echo $TM_MULTILIB_CONFIG | sed 's/^,//'`
  	;;
@@ -134,7 +146,7 @@ index 6fcdd771d..ca1cccc78 100644
  aarch64*-wrs-vxworks*)
          tm_file="${tm_file} elfos.h aarch64/aarch64-elf.h"
          tm_file="${tm_file} vx-common.h vxworks.h aarch64/aarch64-vxworks.h"
-@@ -2040,6 +2081,24 @@ x86_64-*-linux* | x86_64-*-kfreebsd*-gnu)
+@@ -2041,6 +2082,24 @@ x86_64-*-linux* | x86_64-*-kfreebsd*-gnu)
  	done
  	TM_MULTILIB_CONFIG=`echo $TM_MULTILIB_CONFIG | sed 's/^,//'`
  	;;
@@ -161,7 +173,7 @@ index 6fcdd771d..ca1cccc78 100644
  	tm_file="dbxcoff.h ${tm_file} i386/unix.h i386/bsd.h i386/gas.h i386/djgpp.h i386/djgpp-stdint.h"
 diff --git a/gcc/config/aarch64/aarch64-managarm.h b/gcc/config/aarch64/aarch64-managarm.h
 new file mode 100644
-index 000000000..9143fa673
+index 00000000000..9143fa67301
 --- /dev/null
 +++ b/gcc/config/aarch64/aarch64-managarm.h
 @@ -0,0 +1,45 @@
@@ -212,7 +224,7 @@ index 000000000..9143fa673
 +  GNU_USER_TARGET_ENDFILE_SPEC
 diff --git a/gcc/config/aarch64/t-aarch64-managarm b/gcc/config/aarch64/t-aarch64-managarm
 new file mode 100644
-index 000000000..eb6bd808f
+index 00000000000..eb6bd808f0a
 --- /dev/null
 +++ b/gcc/config/aarch64/t-aarch64-managarm
 @@ -0,0 +1,8 @@
@@ -226,7 +238,7 @@ index 000000000..eb6bd808f
 +MULTILIB_OSDIRNAMES += mabi.ilp32=../libilp32$(call if_multiarch,:aarch64-managarm_ilp32)
 diff --git a/gcc/config/i386/i386-managarm.h b/gcc/config/i386/i386-managarm.h
 new file mode 100644
-index 000000000..eeba4ba00
+index 00000000000..eeba4ba008e
 --- /dev/null
 +++ b/gcc/config/i386/i386-managarm.h
 @@ -0,0 +1,11 @@
@@ -243,7 +255,7 @@ index 000000000..eeba4ba00
 +#define GNU_USER_DYNAMIC_LINKERX32 "/lib/x86_64-managarm-x32/ld.so"
 diff --git a/gcc/config/i386/t-managarm64 b/gcc/config/i386/t-managarm64
 new file mode 100644
-index 000000000..dfd959f5d
+index 00000000000..dfd959f5d1b
 --- /dev/null
 +++ b/gcc/config/i386/t-managarm64
 @@ -0,0 +1,4 @@
@@ -253,7 +265,7 @@ index 000000000..dfd959f5d
 +MULTILIB_OSDIRNAMES = m64=../lib64:x86_64-managarm m32=../lib32:i386-managarm
 diff --git a/gcc/config/managarm-kernel.h b/gcc/config/managarm-kernel.h
 new file mode 100644
-index 000000000..6b1c85a76
+index 00000000000..6b1c85a7670
 --- /dev/null
 +++ b/gcc/config/managarm-kernel.h
 @@ -0,0 +1,9 @@
@@ -268,7 +280,7 @@ index 000000000..6b1c85a76
 +#define ENDFILE_SPEC "%{shared:crtendS.o%s;:crtend.o%s} crtn.o%s"
 diff --git a/gcc/config/managarm-system.h b/gcc/config/managarm-system.h
 new file mode 100644
-index 000000000..ba41561d1
+index 00000000000..ba41561d127
 --- /dev/null
 +++ b/gcc/config/managarm-system.h
 @@ -0,0 +1,3 @@
@@ -277,7 +289,7 @@ index 000000000..ba41561d1
 +#define LIB_SPEC "-lc"
 diff --git a/gcc/config/managarm.h b/gcc/config/managarm.h
 new file mode 100644
-index 000000000..c3d1d9fc2
+index 00000000000..c3d1d9fc2bc
 --- /dev/null
 +++ b/gcc/config/managarm.h
 @@ -0,0 +1,13 @@
@@ -295,10 +307,10 @@ index 000000000..c3d1d9fc2
 +		builtin_assert ("system=posix");   \
 +	} while(0);
 diff --git a/libgcc/config.host b/libgcc/config.host
-index c529cc40f..2bf8599ae 100644
+index f808b61be70..d5c47fab03e 100644
 --- a/libgcc/config.host
 +++ b/libgcc/config.host
-@@ -255,6 +255,11 @@ case ${host} in
+@@ -252,6 +252,11 @@ case ${host} in
      extra_parts="$extra_parts vtv_start.o vtv_end.o vtv_start_preinit.o vtv_end_preinit.o"
    fi
    ;;
@@ -310,7 +322,7 @@ index c529cc40f..2bf8599ae 100644
  *-*-lynxos*)
    tmake_file="$tmake_file t-lynx $cpu_type/t-crtstuff t-crtstuff-pic t-libgcc-pic"
    extra_parts="crtbegin.o crtbeginS.o crtend.o crtendS.o"
-@@ -392,6 +397,13 @@ aarch64*-*-linux*)
+@@ -389,6 +394,13 @@ aarch64*-*-linux*)
  	tmake_file="${tmake_file} ${cpu_type}/t-lse t-slibgcc-libgcc"
  	tmake_file="${tmake_file} ${cpu_type}/t-softfp t-softfp t-crtfm"
  	;;
@@ -324,7 +336,7 @@ index c529cc40f..2bf8599ae 100644
  aarch64*-*-vxworks7*)
  	extra_parts="$extra_parts crtfastmath.o"
  	md_unwind_header=aarch64/aarch64-unwind.h
-@@ -743,6 +755,10 @@ i[34567]86-*-linux*)
+@@ -735,6 +747,10 @@ i[34567]86-*-linux*)
  	tm_file="${tm_file} i386/elf-lib.h"
  	md_unwind_header=i386/linux-unwind.h
  	;;
@@ -335,12 +347,24 @@ index c529cc40f..2bf8599ae 100644
  i[34567]86-*-kfreebsd*-gnu | i[34567]86-*-kopensolaris*-gnu)
  	extra_parts="$extra_parts crtprec32.o crtprec64.o crtprec80.o crtfastmath.o"
  	tmake_file="${tmake_file} i386/t-crtpc t-crtfm i386/t-crtstuff t-dfprules"
+diff --git a/libgcc/libgcov.h b/libgcc/libgcov.h
+index 7b0d367ec52..f72762cb36d 100644
+--- a/libgcc/libgcov.h
++++ b/libgcc/libgcov.h
+@@ -183,6 +183,7 @@ extern struct gcov_info *gcov_list;
+ #endif
+ 
+ #include "gcov-io.h"
++#include <stdint.h>
+ 
+ /* Structures embedded in coveraged program.  The structures generated
+    by write_profile must match these.  */
 diff --git a/libstdc++-v3/crossconfig.m4 b/libstdc++-v3/crossconfig.m4
-index fe1828835..552740077 100644
+index ff44d5ae019..aa74dc3aa4f 100644
 --- a/libstdc++-v3/crossconfig.m4
 +++ b/libstdc++-v3/crossconfig.m4
-@@ -192,6 +192,17 @@ case "${host}" in
-     AC_CHECK_FUNCS(sockatmark)
+@@ -198,6 +198,17 @@ case "${host}" in
+     AC_CHECK_FUNCS(uselocale)
      AM_ICONV
      ;;
 +  *-managarm*)
@@ -357,11 +381,37 @@ index fe1828835..552740077 100644
    *-mingw32*)
      GLIBCXX_CHECK_LINKER_FEATURES
      GLIBCXX_CHECK_MATH_SUPPORT
+diff --git a/libstdc++-v3/include/c_compatibility/fenv.h b/libstdc++-v3/include/c_compatibility/fenv.h
+index 0413e3b7c25..3937be9f856 100644
+--- a/libstdc++-v3/include/c_compatibility/fenv.h
++++ b/libstdc++-v3/include/c_compatibility/fenv.h
+@@ -26,16 +26,16 @@
+  *  This is a Standard C++ Library header.
+  */
+ 
+-#ifndef _GLIBCXX_FENV_H
+-#define _GLIBCXX_FENV_H 1
+-
+-#pragma GCC system_header
+-
+ #include <bits/c++config.h>
+ #if _GLIBCXX_HAVE_FENV_H
+ # include_next <fenv.h>
+ #endif
+ 
++#ifndef _GLIBCXX_FENV_H
++#define _GLIBCXX_FENV_H 1
++
++#pragma GCC system_header
++
+ #if __cplusplus >= 201103L
+ 
+ #if _GLIBCXX_USE_C99_FENV_TR1
 diff --git a/libtool.m4 b/libtool.m4
-index 00206549f..23497087e 100644
+index 17f8e5f3074..a934226d3a3 100644
 --- a/libtool.m4
 +++ b/libtool.m4
-@@ -2501,6 +2501,16 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | uclinuxfdpiceabi)
+@@ -2491,6 +2491,16 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu* | uclinuxfdpiceabi)
    dynamic_linker='GNU/Linux ld.so'
    ;;
  
@@ -378,7 +428,7 @@ index 00206549f..23497087e 100644
  netbsd*)
    version_type=sunos
    need_lib_prefix=no
-@@ -3100,6 +3110,10 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | uclinuxfdpiceabi)
+@@ -3090,6 +3100,10 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | uclinuxfdpiceabi)
    lt_cv_deplibs_check_method=pass_all
    ;;
  
@@ -390,5 +440,5 @@ index 00206549f..23497087e 100644
    if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
      lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|_pic\.a)$'
 -- 
-2.31.1
+2.32.0
 


### PR DESCRIPTION
This PR updates `gcc` and the toolchain to version 11.1.0.

This PR is blocked on managarm/managarm#369 and managarm/frigg#10