### PR TITLE
Various updates to xbps

### DIFF
--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -610,7 +610,7 @@ packages:
       - libarchive
       - openssl
       - zlib
-    revision: 3
+    revision: 4
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -623,4 +623,3 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/xbps.conf', '@THIS_COLLECT_DIR@/usr/share/xbps.d/']
-      - args: ['cp', '@SOURCE_ROOT@/extrafiles/00-repository-main.conf', '@THIS_COLLECT_DIR@/usr/share/xbps.d/']

--- a/extrafiles/00-repository-main.conf
+++ b/extrafiles/00-repository-main.conf
@@ -1,1 +1,0 @@
-repository=https://ci.managarm.org/repos/packages/managarm/rolling

--- a/patches/xbps/0001-Managarm-specific-changes.patch
+++ b/patches/xbps/0001-Managarm-specific-changes.patch
@@ -1,8 +1,9 @@
-From 68cec99ba767690ae25476807ff3950954e7c132 Mon Sep 17 00:00:00 2001
+From ab4e855c68f553ddc9c0e1ba72c6a28c2942aec0 Mon Sep 17 00:00:00 2001
 From: Alexander van der Grinten <alexander.vandergrinten@gmail.com>
 Date: Sat, 9 May 2020 18:46:34 +0200
-Subject: [PATCH] Managarm-specific changes
+Subject: [PATCH 1/3] Managarm-specific changes
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  bin/xbps-create/main.c                  | 1 +
  bin/xbps-install/util.c                 | 1 +
@@ -16,7 +17,7 @@ Subject: [PATCH] Managarm-specific changes
  9 files changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/bin/xbps-create/main.c b/bin/xbps-create/main.c
-index 373e744..1f594ad 100644
+index 373e7441..1f594ad6 100644
 --- a/bin/xbps-create/main.c
 +++ b/bin/xbps-create/main.c
 @@ -39,6 +39,7 @@
@@ -28,7 +29,7 @@ index 373e744..1f594ad 100644
  #include <dirent.h>
  
 diff --git a/bin/xbps-install/util.c b/bin/xbps-install/util.c
-index 7cabdd1..398b654 100644
+index 7cabdd16..398b654f 100644
 --- a/bin/xbps-install/util.c
 +++ b/bin/xbps-install/util.c
 @@ -31,6 +31,7 @@
@@ -40,7 +41,7 @@ index 7cabdd1..398b654 100644
  
  #include <xbps.h>
 diff --git a/bin/xbps-pkgdb/check_pkg_alternatives.c b/bin/xbps-pkgdb/check_pkg_alternatives.c
-index 90c4109..dc3f6d7 100644
+index 90c4109b..dc3f6d70 100644
 --- a/bin/xbps-pkgdb/check_pkg_alternatives.c
 +++ b/bin/xbps-pkgdb/check_pkg_alternatives.c
 @@ -32,6 +32,7 @@
@@ -52,7 +53,7 @@ index 90c4109..dc3f6d7 100644
  
  #include <xbps.h>
 diff --git a/bin/xbps-pkgdb/check_pkg_symlinks.c b/bin/xbps-pkgdb/check_pkg_symlinks.c
-index 851e677..782ed53 100644
+index 851e6777..782ed53e 100644
 --- a/bin/xbps-pkgdb/check_pkg_symlinks.c
 +++ b/bin/xbps-pkgdb/check_pkg_symlinks.c
 @@ -31,6 +31,7 @@
@@ -64,7 +65,7 @@ index 851e677..782ed53 100644
  
  #include <xbps.h>
 diff --git a/configure b/configure
-index da8ae75..2052b5b 100755
+index da8ae75f..2052b5b3 100755
 --- a/configure
 +++ b/configure
 @@ -275,7 +275,7 @@ fi
@@ -77,7 +78,7 @@ index da8ae75..2052b5b 100755
  	unsafe-loop-optimizations undef sign-compare \
  	missing-include-dirs old-style-definition \
 diff --git a/lib/compat/strcasestr.c b/lib/compat/strcasestr.c
-index e7861c2..5180af5 100644
+index e7861c27..5180af5e 100644
 --- a/lib/compat/strcasestr.c
 +++ b/lib/compat/strcasestr.c
 @@ -36,6 +36,7 @@
@@ -89,7 +90,7 @@ index e7861c2..5180af5 100644
  /*
   * Find the first occurrence of find in s, ignore case.
 diff --git a/lib/fetch/common.c b/lib/fetch/common.c
-index 7180c6e..86306cf 100644
+index 7180c6ef..86306cfc 100644
 --- a/lib/fetch/common.c
 +++ b/lib/fetch/common.c
 @@ -34,6 +34,7 @@
@@ -101,7 +102,7 @@ index 7180c6e..86306cf 100644
  #include <sys/time.h>
  #include <sys/uio.h>
 diff --git a/lib/fetch/ftp.c b/lib/fetch/ftp.c
-index 28296a0..0fac406 100644
+index 28296a00..0fac406e 100644
 --- a/lib/fetch/ftp.c
 +++ b/lib/fetch/ftp.c
 @@ -77,6 +77,7 @@
@@ -122,7 +123,7 @@ index 28296a0..0fac406 100644
  #endif
  }
 diff --git a/lib/fetch/http.c b/lib/fetch/http.c
-index fe98b1a..a50128c 100644
+index fe98b1a9..a50128ca 100644
 --- a/lib/fetch/http.c
 +++ b/lib/fetch/http.c
 @@ -76,6 +76,7 @@
@@ -134,5 +135,5 @@ index fe98b1a..a50128c 100644
  #include <unistd.h>
  
 -- 
-2.20.1
+2.32.0
 

--- a/patches/xbps/0002-Add-the-Managarm-amd64-repository-and-remove-the-Voi.patch
+++ b/patches/xbps/0002-Add-the-Managarm-amd64-repository-and-remove-the-Voi.patch
@@ -1,0 +1,61 @@
+From 70e7f52cdbf0d978180bf312c34c3a7c618da6d1 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Thu, 15 Jul 2021 02:10:26 +0200
+Subject: [PATCH 2/3] Add the Managarm amd64 repository and remove the Void
+ Linux repository
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ ...2:5b:a6:50:95:c7:b9:a4:10:e4:63:39:d0:b8:c5.plist | 12 ++++++++++++
+ ...e:0c:d6:f0:95:17:80:bc:93:46:7a:89:af:a3:2d.plist | 12 ------------
+ data/repod-main.conf                                 |  2 +-
+ 3 files changed, 13 insertions(+), 13 deletions(-)
+ create mode 100644 data/5d:d2:5b:a6:50:95:c7:b9:a4:10:e4:63:39:d0:b8:c5.plist
+ delete mode 100644 data/60:ae:0c:d6:f0:95:17:80:bc:93:46:7a:89:af:a3:2d.plist
+
+diff --git a/data/5d:d2:5b:a6:50:95:c7:b9:a4:10:e4:63:39:d0:b8:c5.plist b/data/5d:d2:5b:a6:50:95:c7:b9:a4:10:e4:63:39:d0:b8:c5.plist
+new file mode 100644
+index 00000000..96142fd8
+--- /dev/null
++++ b/data/5d:d2:5b:a6:50:95:c7:b9:a4:10:e4:63:39:d0:b8:c5.plist
+@@ -0,0 +1,12 @@
++<?xml version="1.0" encoding="UTF-8"?>
++<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
++<plist version="1.0">
++<dict>
++	<key>public-key</key>
++	<data>LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF2ejlOZnBRUlZDeTBZeDN5WW5QTAppc1RKNVVjV2QxYUJZUTFMMjlvR1kyZW1ZbjZNNmxjb1l1WS96TXVKS2ZMYjNPTktWVSs0TkVZU2QwU2xTeW5kCkxuODYzamsvTk5KZVBqdjdrcVBVVEw3V0doRGhXOXNxVjczYVhGMk1XSjc4S0c2bTA5TFNnVDlMNWdobG5IdkgKNldPcEQvV2dTSGN2YXFMdjlqb1ZLWjBMWkEzbHZmUVBlUzF6N1ZvSXJFblNOc29WbTcrS3VzSGpybnZMeis4UwpyV1lVU2dWV1dvS3BZa3lwcDJESHJOTG9OTDV4NytibWdMcmdic0dTSEgzS3dqOEs3MjQrcTRrcU5oVy9pZFRVCkNZVk93bzhRYjRsTGtiN0dCRjFiMVhJTGFLK01tR09oQU0vYjZILzl3MHdYcmgzMTVmNmZUTldpODlDNDJiS3IKQTl1dXNlbDF2b3Z1d3lNZ25meXF2NmRERkMxSlBzT0Z2Y2lXeGtzQ1BZbHZkM0pxOFhQQS95UGk2TitJbjlQZAp5WXR4WlFKaHVWSmRoRmErMzZsTGlWWDJKdmw2UkVhQlVyYktzT1ZITmtlOEdmOGZmYzZUT2t0VjY2Vm9xekdXCnVCS1hReDYzR0thUi82ZWtoeXJ2SDE4WXVtYzdpeW5GbXVhdmhFeTYrRlFPMHc3Y2VkSmVIaXVSWTlGby9VblAKMmRteGhIZjdqRE5xeGpMOE43Vlp3M1lob1RoR0l0cGtjQWJVZ0N2ZW9rUCtVUXZUVjFWL1FNczhnQ01FbTFhYwpJMjdadnJ4SGcrS0xQaHpaNUgyOWtmeDNoeDFHK1BmOXUvWkptNGJ3M3BwUllVdzRkdG9ieHpmdm83TThJWVExCkVCSjI3ZUlTKzNVWFIzWFNrRzZvTitVQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=</data>
++	<key>public-key-size</key>
++	<integer>4096</integer>
++	<key>signature-by</key>
++	<string>The Managarm Project &lt;info@managarm.org&gt;</string>
++</dict>
++</plist>
+diff --git a/data/60:ae:0c:d6:f0:95:17:80:bc:93:46:7a:89:af:a3:2d.plist b/data/60:ae:0c:d6:f0:95:17:80:bc:93:46:7a:89:af:a3:2d.plist
+deleted file mode 100644
+index c1e82a7e..00000000
+--- a/data/60:ae:0c:d6:f0:95:17:80:bc:93:46:7a:89:af:a3:2d.plist
++++ /dev/null
+@@ -1,12 +0,0 @@
+-<?xml version="1.0" encoding="UTF-8"?>
+-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+-<plist version="1.0">
+-<dict>
+-	<key>public-key</key>
+-	<data>LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF2clN6QlpNdmd2T0NJM0FYYk9qYQoycktSa0pTVE0zYy9FalRJZ0NnRFhndW05M0JQQ3RZOE1jRlZvQ1U0T2lYSEdmVG1xMzlCVk5wTHZMSEw5S2sxCnAyNzhTQmhYVk90YkIyRVZtREtudmZJREVUbGRMR3plN3JaTlJKZHR1TjJtWi9UVnJVQjlTMHlRYytJdWY0aHYKMytEOTdWSWRUSkhBN0FTcjA0MjhwcEVHSkd3U1NoWTJYSm05RDVJMEV1R1JXYzE0TUVHN2RJS0ppWWlNMG5FNAp0WW8yL3ZINElGVEhkblZBM2dZaVp5RG5idUNBUi84RVNmVVRVMTNTTkNPZGJ1ZGYzRDVCY3krVWlNREpJM1llCjRNRktCclQ5WmhaK0dzWEJaWTQ4MmxxaVppNkNMNXB0YzlJUUZmOC9lS1phOGphdGtpVkZWZ3JLZU5Sak9UeE4KZldTdTJua3hHTlgrYmhYWXRoaUdXbUpFWThjQ0FQeUZOK0x2NVJldEsyNTZnZGNiMnNrbUVxZWZ2MnpQQyt3VgpXQmJkSDViRDRiWmpuME42Wmw4MXJ2NVJ6RHZudmYrdkQxNGFGVWJaOFFGcXU3NVBiTDR3Nm1ZTTRsZE0vZzBSCjZOWEU4QXo5Qnd4MnREZlllS3V1dHcxRXBQbTJZdkZ5VFViMWNveUF1VEdSeUFhcDFVVEh2ZzlsaFBJSm1oRlEKSjVrQ2cxcUQ3QTMxV2wwUmxuZTZoZ0dvMFpaTko1Y0pNL3YvelNUS0pjdUZnd283SDBoT0dpbDZEZm84OUI0agpHOTZBQ3lQUytEVktQRlhSWXdqL0FrYkhwYVEyZjFGTUFvU3BCcXVEcUhoM3VrazcxS1g2ajE5dDBpRjhEUUxyCnZ0RlNTZElqREEwMmx3ZVY5TmFRcFdzQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=</data>
+-	<key>public-key-size</key>
+-	<integer>4096</integer>
+-	<key>signature-by</key>
+-	<string>Void Linux</string>
+-</dict>
+-</plist>
+diff --git a/data/repod-main.conf b/data/repod-main.conf
+index 9890a844..b96b00cb 100644
+--- a/data/repod-main.conf
++++ b/data/repod-main.conf
+@@ -1 +1 @@
+-repository=https://a-hel-fi.m.voidlinux.org/current
++repository=https://pkgs.managarm.org/repos/amd64/
+-- 
+2.32.0
+

--- a/patches/xbps/0003-Work-around-unimplemented-Managarm-features.patch
+++ b/patches/xbps/0003-Work-around-unimplemented-Managarm-features.patch
@@ -1,0 +1,34 @@
+From 512a7080e61b08eabdc85271ec36da79e326bdcd Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Thu, 15 Jul 2021 02:53:59 +0200
+Subject: [PATCH 3/3] Work around unimplemented Managarm features
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ bin/xbps-install/question.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bin/xbps-install/question.c b/bin/xbps-install/question.c
+index 865649ff..f2d6e9b4 100644
+--- a/bin/xbps-install/question.c
++++ b/bin/xbps-install/question.c
+@@ -50,7 +50,7 @@ question(bool preset, const char *fmt, va_list ap)
+ 		fputs(" [y/N] ", stderr);
+ 
+ 	response = fgetc(stdin);
+-	if (response == '\n')
++	if (response == '\n' || response == '\r')
+ 		rv = preset;
+ 	else if (response == 'y' || response == 'Y')
+ 		rv = true;
+@@ -58,7 +58,7 @@ question(bool preset, const char *fmt, va_list ap)
+ 		rv = false;
+ 
+ 	/* read the rest of the line */
+-	while (response != EOF && response != '\n')
++	while (response != EOF && (response != '\n' && response != '\r'))
+ 		response = fgetc(stdin);
+ 
+ 	return rv;
+2.32.0
+


### PR DESCRIPTION
This PR updates the `xbps` recipe to no longer install an obsolete file, properly patches the Managarm specific info into the codebase and works around 2 issues in Managarm / mlibc pending their implementation.

This PR is blocked on managarm/mlibc#250, as it contains the buffering fixes and the `lchown` stub that `xbps` wants.
This PR is blocked on managarm/mlibc#288

Properly closes #71 