### PR TITLE
Temporarily add gcc to base as it includes libstdc++ and libgcc

### DIFF
--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -32,6 +32,7 @@ packages:
       - findutils
       - util-linux
       - limine
+      - gcc # Temporary solution to remove the need to copy libstdc++.so and libgcc.so from system-gcc
     configure: []
     build: []
 
@@ -41,7 +42,6 @@ packages:
     pkgs_required:
       - base
       - binutils
-      - gcc
       - make
       - patch
       - m4

--- a/scripts/update-image.py
+++ b/scripts/update-image.py
@@ -401,9 +401,6 @@ class UpdateFsAction:
 		plan_rsync('var/')
 		plan_rsync('home/')
 
-		plan_cp(f'tools/system-gcc/{self.arch}/lib64/libgcc_s.so.1', 'usr/lib')
-		plan_cp(f'tools/system-gcc/{self.arch}/lib64/libstdc++.so.6', 'usr/lib')
-
 		print('update-image: Updating the file system...')
 
 		commands = '\n'.join([join_command(step) for step in steps])


### PR DESCRIPTION
This PR adds `gcc` to `base` and removes it from `base-devel`. This eliminates the need to copy `libgcc_s.so.1` and `libstdc++.so.6` from `system-gcc` as the `gcc` package provides them. This is an temporarily solution, and should be partially reverted whenever `xbstrap` gains the ability to make multiple packages from one build recipe, in which case `gcc` will be split in at least `gcc`, `libgcc` and `libstdc++`, `gcc` will move back to `base-devel` and both `libgcc` and `libstdc++` will be added as a dependency to `base`.