### PR TITLE
Make the meta packages sourceless

### DIFF
--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -2,7 +2,9 @@ packages:
   # Meta package with the bare minimum to boot kmscon and be useful
   - name: base
     labels: [aarch64]
-    from_source: managarm
+    source:
+      subdir: meta-sources
+      version: '1.0'
     pkgs_required:
       - mlibc
       - core-files
@@ -37,7 +39,9 @@ packages:
 
   # Meta package with build essentials
   - name: base-devel
-    from_source: managarm
+    source:
+      subdir: meta-sources
+      version: '1.0'
     pkgs_required:
       - base
       - binutils
@@ -54,7 +58,9 @@ packages:
 
   # Meta package for weston and usefull utilities
   - name: weston-desktop
-    from_source: managarm
+    source:
+      subdir: meta-sources
+      version: '1.0'
     pkgs_required:
       - base
       - weston

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -634,8 +634,9 @@ packages:
   - name: core-files
     labels: [aarch64]
     default: true
-    from_source: managarm
-    revision: 2
+    source:
+      subdir: meta-sources
+      version: '1.0'
     configure: []
     build:
       # Create initial directories


### PR DESCRIPTION
The meta packages used to have the same source as managarm, this is unneeded and makes versioning hard to do for these packages. The same goes for the `core-files` package. This PR fixes those packages to be "sourceless" and sets their version to `1.0`.