### PR TITLE
util-linux: Split into a library and binaries package

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -197,9 +197,9 @@ packages:
       - openssl
       - xz-utils
       - gdbm
-      - util-linux
+      - util-linux-libs
       - libintl
-    revision: 5
+    revision: 6
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -11,6 +11,19 @@ sources:
     regenerate:
       - args: ['autoreconf', '-f', '-i']
 
+  - name: util-linux
+    subdir: ports
+    git: 'https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git'
+    tag: 'v2.36.2'
+    version: '2.36.2'
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
+      - host-libtool
+    regenerate:
+      - args: ['./autogen.sh']
+
 tools:
   - name: host-file
     labels: [aarch64]
@@ -496,30 +509,166 @@ packages:
         - '@THIS_COLLECT_DIR@'
         - '-j@PARALLELISM@'
 
-  - name: util-linux
+  - name: util-linux-libs
     labels: [aarch64]
-    source:
-      subdir: ports
-      git: 'https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git'
-      tag: 'v2.36.2'
-      version: '2.36.2'
-      tools_required:
-        - host-autoconf-v2.69
-        - host-automake-v1.15
-        - host-pkg-config
-        - host-libtool
-      regenerate:
-        - args: ['./autogen.sh']
+    from_source: util-linux
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
     pkgs_required:
-      - mlibc
-      - eudev
       - readline
       - ncurses
       - zlib
       - libiconv
       - file
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--exec-prefix=/usr'
+        - '--libdir=/usr/lib'
+        - '--bindir=/usr/bin'
+        - '--sbindir=/usr/sbin'
+        - '--without-udev'
+        - '--disable-nls'
+        - '--disable-static'
+        - '--without-python'
+        - '--without-systemd'
+        - '--without-systemdsystemunitdir'
+        - '--disable-fdisks'
+        - '--disable-mount'
+        - '--disable-losetup'
+        - '--disable-zramctl'
+        - '--disable-fsck'
+        - '--disable-partx'
+        - '--disable-uuidd'
+        - '--disable-wipefs'
+        - '--disable-mountpoint'
+        - '--disable-fallocate'
+        - '--disable-unshare'
+        - '--disable-nsenter'
+        - '--disable-setpriv'
+        - '--disable-hardlink'
+        - '--disable-eject'
+        - '--disable-agetty'
+        - '--disable-plymouth_support'
+        - '--disable-cramfs'
+        - '--disable-bfs'
+        - '--disable-minix'
+        - '--disable-fdformat'
+        - '--disable-hwclock'
+        - '--disable-hwclock-cmos'
+        - '--disable-hwclock-gplv3'
+        - '--disable-mkfs'
+        - '--disable-isosize'
+        - '--disable-lsblk'
+        - '--disable-lslogins'
+        - '--disable-wdctl'
+        - '--disable-swaplabel'
+        - '--disable-mkswap'
+        - '--disable-cal'
+        - '--disable-logger'
+        - '--disable-look'
+        - '--disable-mcookie'
+        - '--disable-namei'
+        - '--disable-getopt'
+        - '--disable-blockdev'
+        - '--disable-lslocks'
+        - '--disable-switch_root'
+        - '--disable-pivot_root'
+        - '--disable-flock'
+        - '--disable-lsmem'
+        - '--disable-chmem'
+        - '--disable-ipcmk'
+        - '--disable-ipcrm'
+        - '--disable-ipcs'
+        - '--disable-irqtop'
+        - '--disable-lsirq'
+        - '--disable-choom'
+        - '--disable-renice'
+        - '--disable-rfkill'
+        - '--disable-setsid'
+        - '--disable-ctrlaltdel'
+        - '--disable-script'
+        - '--disable-scriptreplay'
+        - '--disable-scriptlive'
+        - '--disable-col'
+        - '--disable-colcrt'
+        - '--disable-colrm'
+        - '--disable-column'
+        - '--disable-hexdump'
+        - '--disable-rev'
+        - '--disable-kill'
+        - '--disable-last'
+        - '--disable-utmpdump'
+        - '--disable-mesg'
+        - '--disable-raw'
+        - '--disable-rename'
+        - '--disable-chfn-chsh'
+        - '--disable-login'
+        - '--disable-nologin'
+        - '--disable-sulogin'
+        - '--disable-su'
+        - '--disable-runuser'
+        - '--disable-ul'
+        - '--disable-more'
+        - '--disable-setterm'
+        - '--disable-schedutils'
+        - '--disable-pg-bell'
+        - '--disable-fstrim'
+        - '--disable-swapon'
+        - '--disable-lscpu'
+        - '--disable-chcpu'
+        - '--disable-blockdev'
+        - '--disable-prlimit'
+        - '--disable-lsipc'
+        - '--disable-lsns'
+        - '--disable-readprofile'
+        - '--disable-dmesg'
+        - '--disable-fincore'
+        - '--disable-fsfreeze'
+        - '--disable-blkdiscard'
+        - '--disable-blkzone'
+        - '--disable-ldattach'
+        - '--disable-rtcwake'
+        - '--disable-setarch'
+        - '--disable-tunelp'
+        - '--disable-wall'
+        - '--disable-bash-completion'
+        - '--without-cap-ng'
+        - '--without-btrfs'
+        - '--without-selinux'
+        - '--without-audit'
+        - '--enable-usrdir-path'
+        - '--disable-makeinstall-chown'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/bin']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/sbin']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/share/bash-completion']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/share/man/man1']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/share/man/man8']
+
+  - name: util-linux
+    labels: [aarch64]
+    from_source: util-linux
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - eudev
+      - util-linux-libs
+      - readline
+      - ncurses
+      - zlib
+      - libiconv
+      - file
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -596,6 +745,10 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/include']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/share/man/man3']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/share/man/man5/terminal-colors.d.5']
 
   - name: which
     labels: [aarch64]


### PR DESCRIPTION
This PR changes `util-linux` to produce `util-linux-libs`, which contains the libraries and header files that `util-linux` provides, and `util-linux`, which holds binaries and their documentation. The rationale behind this change is allowing `eudev` to be build with `libblkid` support (to be enabled at a later date), which is currently impossible as `util-linux` uses `eudev` itself when building certain programs, creating a circular dependency.