### PR TITLE
Fix various compilation errors under gcc 11

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1107,6 +1107,7 @@ packages:
       - host-protoc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -898,13 +898,13 @@ packages:
   - name: llvm
     labels: [aarch64]
     from_source: llvm
-    revision: 2
     tools_required:
       - host-cmake
       - system-gcc
     pkgs_required:
       - mlibc
       - zlib
+    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/patches/llvm/0001-Managarm-specific-changes.patch
+++ b/patches/llvm/0001-Managarm-specific-changes.patch
@@ -1,19 +1,21 @@
-From f5c9a743633444c042726e04b651fd99e45368de Mon Sep 17 00:00:00 2001
+From fba5efe7fc4760d30556a839a8e6771c4d229874 Mon Sep 17 00:00:00 2001
 From: Alexander van der Grinten <alexander.vandergrinten@gmail.com>
 Date: Thu, 6 Jun 2019 17:55:59 +0200
 Subject: [PATCH 1/2] Managarm-specific changes
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- llvm/cmake/modules/CrossCompile.cmake     | 4 ++--
- llvm/include/llvm/Support/SwapByteOrder.h | 2 +-
- llvm/lib/Support/Unix/Path.inc            | 6 +++---
- llvm/lib/Support/Unix/Program.inc         | 1 +
- llvm/tools/llvm-dwarfdump/Statistics.cpp  | 1 +
- llvm/tools/llvm-shlib/CMakeLists.txt      | 1 +
- 6 files changed, 9 insertions(+), 6 deletions(-)
+ llvm/cmake/modules/CrossCompile.cmake         | 4 ++--
+ llvm/include/llvm/Support/SwapByteOrder.h     | 2 +-
+ llvm/lib/Support/Unix/Path.inc                | 6 +++---
+ llvm/lib/Support/Unix/Program.inc             | 1 +
+ llvm/tools/llvm-dwarfdump/Statistics.cpp      | 1 +
+ llvm/tools/llvm-shlib/CMakeLists.txt          | 1 +
+ llvm/utils/benchmark/src/benchmark_register.h | 1 +
+ 7 files changed, 10 insertions(+), 6 deletions(-)
 
 diff --git a/llvm/cmake/modules/CrossCompile.cmake b/llvm/cmake/modules/CrossCompile.cmake
-index 8a6e880c4..fb86a7c17 100644
+index 8a6e880c4e21..fb86a7c17994 100644
 --- a/llvm/cmake/modules/CrossCompile.cmake
 +++ b/llvm/cmake/modules/CrossCompile.cmake
 @@ -17,8 +17,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
@@ -28,7 +30,7 @@ index 8a6e880c4..fb86a7c17 100644
    endif()
    set(CROSS_TOOLCHAIN_FLAGS_${target_name} ${CROSS_TOOLCHAIN_FLAGS_INIT}
 diff --git a/llvm/include/llvm/Support/SwapByteOrder.h b/llvm/include/llvm/Support/SwapByteOrder.h
-index 6cec87006..eac816c6b 100644
+index 6cec87006c02..eac816c6bb02 100644
 --- a/llvm/include/llvm/Support/SwapByteOrder.h
 +++ b/llvm/include/llvm/Support/SwapByteOrder.h
 @@ -22,7 +22,7 @@
@@ -41,7 +43,7 @@ index 6cec87006..eac816c6b 100644
  #elif defined(_AIX)
  #include <sys/machine.h>
 diff --git a/llvm/lib/Support/Unix/Path.inc b/llvm/lib/Support/Unix/Path.inc
-index 2a03dc682..5d07e56a7 100644
+index 2a03dc682bce..5d07e56a79f3 100644
 --- a/llvm/lib/Support/Unix/Path.inc
 +++ b/llvm/lib/Support/Unix/Path.inc
 @@ -64,7 +64,7 @@ extern char **environ;
@@ -72,7 +74,7 @@ index 2a03dc682..5d07e56a7 100644
  #define NFS_SUPER_MAGIC 0x6969
  #endif
 diff --git a/llvm/lib/Support/Unix/Program.inc b/llvm/lib/Support/Unix/Program.inc
-index 520685a0e..e6c2ddf20 100644
+index 520685a0e987..e6c2ddf2067f 100644
 --- a/llvm/lib/Support/Unix/Program.inc
 +++ b/llvm/lib/Support/Unix/Program.inc
 @@ -39,6 +39,7 @@
@@ -84,7 +86,7 @@ index 520685a0e..e6c2ddf20 100644
  #include <spawn.h>
  
 diff --git a/llvm/tools/llvm-dwarfdump/Statistics.cpp b/llvm/tools/llvm-dwarfdump/Statistics.cpp
-index 5bef4d514..2a237ef59 100644
+index 5bef4d5148ca..2a237ef59646 100644
 --- a/llvm/tools/llvm-dwarfdump/Statistics.cpp
 +++ b/llvm/tools/llvm-dwarfdump/Statistics.cpp
 @@ -1,3 +1,4 @@
@@ -93,7 +95,7 @@ index 5bef4d514..2a237ef59 100644
  #include "llvm/ADT/StringExtras.h"
  #include "llvm/ADT/StringSet.h"
 diff --git a/llvm/tools/llvm-shlib/CMakeLists.txt b/llvm/tools/llvm-shlib/CMakeLists.txt
-index 3eb6db33a..c03d2f455 100644
+index 3eb6db33a435..c03d2f45511c 100644
 --- a/llvm/tools/llvm-shlib/CMakeLists.txt
 +++ b/llvm/tools/llvm-shlib/CMakeLists.txt
 @@ -36,6 +36,7 @@ if(LLVM_BUILD_LLVM_DYLIB)
@@ -104,6 +106,18 @@ index 3eb6db33a..c03d2f455 100644
       OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "OpenBSD")
       OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "Fuchsia")
       OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "DragonFly")
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..6001fb8e0e48 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -2,6 +2,7 @@
+ #define BENCHMARK_REGISTER_H
+ 
+ #include <vector>
++#include <limits>
+ 
+ #include "check.h"
+ 
 -- 
-2.29.2
+2.32.0
 

--- a/patches/llvm/0002-Add-managarm-target.patch
+++ b/patches/llvm/0002-Add-managarm-target.patch
@@ -1,8 +1,9 @@
-From 47ffdf77faffead5c4d0b3ed5d9ff8f988744dda Mon Sep 17 00:00:00 2001
+From 3aa4a086912f07f57b7fd56d46077f93009937b0 Mon Sep 17 00:00:00 2001
 From: Alexander van der Grinten <alexander.vandergrinten@gmail.com>
 Date: Sun, 9 Jun 2019 16:29:17 +0200
 Subject: [PATCH 2/2] Add managarm target
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  clang/lib/Basic/Targets.cpp              |   4 +
  clang/lib/Basic/Targets/OSTargets.h      |  28 ++
@@ -18,7 +19,7 @@ Subject: [PATCH 2/2] Add managarm target
  create mode 100644 clang/lib/Driver/ToolChains/Managarm.h
 
 diff --git a/clang/lib/Basic/Targets.cpp b/clang/lib/Basic/Targets.cpp
-index c063f8ca4..9fe05e8f7 100644
+index c063f8ca4472..9fe05e8f7315 100644
 --- a/clang/lib/Basic/Targets.cpp
 +++ b/clang/lib/Basic/Targets.cpp
 @@ -144,6 +144,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
@@ -40,7 +41,7 @@ index c063f8ca4..9fe05e8f7 100644
        return new NaClTargetInfo<X86_64TargetInfo>(Triple, Opts);
      case llvm::Triple::PS4:
 diff --git a/clang/lib/Basic/Targets/OSTargets.h b/clang/lib/Basic/Targets/OSTargets.h
-index 70fac030b..f1f0c30c3 100644
+index 70fac030bc5d..f1f0c30c3b75 100644
 --- a/clang/lib/Basic/Targets/OSTargets.h
 +++ b/clang/lib/Basic/Targets/OSTargets.h
 @@ -342,6 +342,34 @@ public:
@@ -79,7 +80,7 @@ index 70fac030b..f1f0c30c3 100644
  template <typename Target>
  class LLVM_LIBRARY_VISIBILITY MinixTargetInfo : public OSTargetInfo<Target> {
 diff --git a/clang/lib/Driver/CMakeLists.txt b/clang/lib/Driver/CMakeLists.txt
-index 6f25d3588..97cfe3422 100644
+index 6f25d3588ebb..97cfe34224ef 100644
 --- a/clang/lib/Driver/CMakeLists.txt
 +++ b/clang/lib/Driver/CMakeLists.txt
 @@ -54,6 +54,7 @@ add_clang_library(clangDriver
@@ -91,7 +92,7 @@ index 6f25d3588..97cfe3422 100644
    ToolChains/MinGW.cpp
    ToolChains/Minix.cpp
 diff --git a/clang/lib/Driver/Driver.cpp b/clang/lib/Driver/Driver.cpp
-index fb8335a36..76369cd6d 100644
+index fb8335a3695d..76369cd6d8f7 100644
 --- a/clang/lib/Driver/Driver.cpp
 +++ b/clang/lib/Driver/Driver.cpp
 @@ -29,6 +29,7 @@
@@ -113,7 +114,7 @@ index fb8335a36..76369cd6d 100644
        TC = std::make_unique<toolchains::Solaris>(*this, Target, Args);
        break;
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index da197e476..69335dbd2 100644
+index da197e476621..69335dbd2132 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
 @@ -261,6 +261,8 @@ static const char *getLDMOption(const llvm::Triple &T, const ArgList &Args) {
@@ -147,7 +148,7 @@ index da197e476..69335dbd2 100644
    static const char *const X86Triples[] = {
 diff --git a/clang/lib/Driver/ToolChains/Managarm.cpp b/clang/lib/Driver/ToolChains/Managarm.cpp
 new file mode 100644
-index 000000000..3941ca892
+index 000000000000..3941ca892bfa
 --- /dev/null
 +++ b/clang/lib/Driver/ToolChains/Managarm.cpp
 @@ -0,0 +1,431 @@
@@ -584,7 +585,7 @@ index 000000000..3941ca892
 +
 diff --git a/clang/lib/Driver/ToolChains/Managarm.h b/clang/lib/Driver/ToolChains/Managarm.h
 new file mode 100644
-index 000000000..86ba4e0ce
+index 000000000000..86ba4e0ce52e
 --- /dev/null
 +++ b/clang/lib/Driver/ToolChains/Managarm.h
 @@ -0,0 +1,49 @@
@@ -638,7 +639,7 @@ index 000000000..86ba4e0ce
 +
 +#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_MANAGARM_H
 diff --git a/llvm/include/llvm/ADT/Triple.h b/llvm/include/llvm/ADT/Triple.h
-index 76a754d67..7104a41fd 100644
+index 76a754d671fb..7104a41fdce1 100644
 --- a/llvm/include/llvm/ADT/Triple.h
 +++ b/llvm/include/llvm/ADT/Triple.h
 @@ -168,6 +168,7 @@ public:
@@ -661,7 +662,7 @@ index 76a754d67..7104a41fd 100644
    enum ObjectFormatType {
      UnknownObjectFormat,
 diff --git a/llvm/lib/Support/Triple.cpp b/llvm/lib/Support/Triple.cpp
-index 2c480c109..b1087fbb8 100644
+index 2c480c1094a5..b1087fbb83a6 100644
 --- a/llvm/lib/Support/Triple.cpp
 +++ b/llvm/lib/Support/Triple.cpp
 @@ -201,6 +201,7 @@ StringRef Triple::getOSTypeName(OSType Kind) {
@@ -705,5 +706,5 @@ index 2c480c109..b1087fbb8 100644
  }
  
 -- 
-2.29.2
+2.32.0
 

--- a/patches/protobuf/0001-Fix-various-stuff-for-managarm.patch
+++ b/patches/protobuf/0001-Fix-various-stuff-for-managarm.patch
@@ -1,17 +1,32 @@
-From 63957b708ea9db538e3940f0db47de1a1c887ef8 Mon Sep 17 00:00:00 2001
+From 05841874b095ab2a64613ebd4214c9ba6cd43822 Mon Sep 17 00:00:00 2001
 From: avdgrinten <alexander.vandergrinten@gmail.com>
 Date: Fri, 21 Oct 2016 17:22:35 +0200
-Subject: [PATCH] Fix various stuff for managarm
+Subject: [PATCH 1/2] Fix various stuff for managarm
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- src/google/protobuf/io/coded_stream.h | 8 ++++++++
- src/google/protobuf/message_lite.cc   | 1 +
- src/google/protobuf/stubs/common.cc   | 8 ++++++--
- src/google/protobuf/stubs/port.h      | 8 ++++++++
- 4 files changed, 23 insertions(+), 2 deletions(-)
+ src/google/protobuf/compiler/java/java_file.cc | 2 +-
+ src/google/protobuf/io/coded_stream.h          | 8 ++++++++
+ src/google/protobuf/message_lite.cc            | 1 +
+ src/google/protobuf/stubs/common.cc            | 8 ++++++--
+ src/google/protobuf/stubs/port.h               | 8 ++++++++
+ 5 files changed, 24 insertions(+), 3 deletions(-)
 
+diff --git a/src/google/protobuf/compiler/java/java_file.cc b/src/google/protobuf/compiler/java/java_file.cc
+index 3cbc530eb..0eb0da19a 100644
+--- a/src/google/protobuf/compiler/java/java_file.cc
++++ b/src/google/protobuf/compiler/java/java_file.cc
+@@ -65,7 +65,7 @@ namespace java {
+ namespace {
+ 
+ struct FieldDescriptorCompare {
+-  bool operator ()(const FieldDescriptor* f1, const FieldDescriptor* f2) {
++  bool operator ()(const FieldDescriptor* f1, const FieldDescriptor* f2) const {
+     if(f1 == NULL) {
+       return false;
+     }
 diff --git a/src/google/protobuf/io/coded_stream.h b/src/google/protobuf/io/coded_stream.h
-index 1402cc1..2c3d4f6 100644
+index 1402cc170..2c3d4f61d 100644
 --- a/src/google/protobuf/io/coded_stream.h
 +++ b/src/google/protobuf/io/coded_stream.h
 @@ -122,6 +122,14 @@
@@ -30,7 +45,7 @@ index 1402cc1..2c3d4f6 100644
    #include <sys/param.h>   // __BYTE_ORDER
    #if ((defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)) || \
 diff --git a/src/google/protobuf/message_lite.cc b/src/google/protobuf/message_lite.cc
-index 9d6da26..d976930 100644
+index 9d6da264b..d976930ae 100644
 --- a/src/google/protobuf/message_lite.cc
 +++ b/src/google/protobuf/message_lite.cc
 @@ -33,6 +33,7 @@
@@ -42,7 +57,7 @@ index 9d6da26..d976930 100644
  #include <google/protobuf/generated_message_util.h>
  #include <google/protobuf/message_lite.h>
 diff --git a/src/google/protobuf/stubs/common.cc b/src/google/protobuf/stubs/common.cc
-index 54dbafab..6d6d3b8 100644
+index 54dbafab5..6d6d3b8af 100644
 --- a/src/google/protobuf/stubs/common.cc
 +++ b/src/google/protobuf/stubs/common.cc
 @@ -41,11 +41,15 @@
@@ -72,7 +87,7 @@ index 54dbafab..6d6d3b8 100644
  struct Mutex::Internal {
    pthread_mutex_t mutex;
 diff --git a/src/google/protobuf/stubs/port.h b/src/google/protobuf/stubs/port.h
-index 376be5f..3e71e71 100644
+index 376be5f7a..3e71e714b 100644
 --- a/src/google/protobuf/stubs/port.h
 +++ b/src/google/protobuf/stubs/port.h
 @@ -58,6 +58,14 @@
@@ -91,5 +106,5 @@ index 376be5f..3e71e71 100644
    #include <sys/param.h>   // __BYTE_ORDER
    #if ((defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)) || \
 -- 
-2.1.4
+2.32.0
 

--- a/patches/protobuf/0002-managarm-add-protoc.pc.patch
+++ b/patches/protobuf/0002-managarm-add-protoc.pc.patch
@@ -1,8 +1,9 @@
-From 4682febf9d07f930238f5a29e762e949eec327eb Mon Sep 17 00:00:00 2001
+From 70475a1e62453b3fb89b4725f83f4219da9a5a01 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Arsen=20Arsenovi=C4=87?= <arsen@aarsen.me>
 Date: Mon, 4 Jan 2021 14:42:36 +0100
-Subject: [PATCH] managarm: add protoc.pc
+Subject: [PATCH 2/2] managarm: add protoc.pc
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  Makefile.am  |  2 +-
  configure.ac |  2 +-
@@ -11,7 +12,7 @@ Subject: [PATCH] managarm: add protoc.pc
  create mode 100644 protoc.pc.in
 
 diff --git a/Makefile.am b/Makefile.am
-index 83f1043..cc2e74b 100644
+index 83f1043d1..cc2e74be1 100644
 --- a/Makefile.am
 +++ b/Makefile.am
 @@ -46,7 +46,7 @@ clean-local:
@@ -24,7 +25,7 @@ index 83f1043..cc2e74b 100644
  csharp_EXTRA_DIST=                                                           \
    csharp/.gitignore                                                          \
 diff --git a/configure.ac b/configure.ac
-index 896f347..d682c90 100644
+index 896f3471a..d682c9073 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -185,5 +185,5 @@ export CFLAGS
@@ -36,7 +37,7 @@ index 896f347..d682c90 100644
  AC_OUTPUT
 diff --git a/protoc.pc.in b/protoc.pc.in
 new file mode 100644
-index 0000000..7ae3560
+index 000000000..7ae35600e
 --- /dev/null
 +++ b/protoc.pc.in
 @@ -0,0 +1,11 @@
@@ -52,5 +53,5 @@ index 0000000..7ae3560
 +Libs.private: @LIBS@
 +Cflags: -I${includedir} @PTHREAD_CFLAGS@
 -- 
-2.26.2
+2.32.0
 


### PR DESCRIPTION
This PR fixes various compilation errors under gcc 11. This PR contains fixes for `llvm` and `protobuf`.

Complements managarm/lewis#3