### PR TITLE
Add a bunch of new ports, working towards WebKitGTK

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -726,6 +726,47 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libunistring
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Library for manipulating Unicode and C strings according to Unicode standard
+      description: This package provides a library containing functions for manipulating Unicode strings and for manipulating C strings according to the Unicode standard.
+      spdx: 'LGPL-3.0-or-later'
+      website: 'https://www.gnu.org/software/libunistring/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: 'ports'
+      url: 'https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz'
+      format: 'tar.xz'
+      extract_path: 'libunistring-0.9.10'
+      version: '0.9.10'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+      - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--disable-static'
+        - '--docdir=/usr/share/doc/libunistring-0.9.10'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: libuv
     source:
       subdir: ports

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -376,7 +376,14 @@ packages:
         quiet: true
 
   - name: libgcrypt
-    stability_level: broken
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: General purpose crypto library based on the code used in GnuPG
+      description: This package contains a general purpose crypto library based on the code used in GnuPG. The library provides a high level interface to cryptographic building blocks using an extendable and flexible API.
+      spdx: 'LGPL-2.0-only'
+      website: 'https://www.gnupg.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: 'ports'
       git: 'https://github.com/gpg/libgcrypt.git'
@@ -388,9 +395,7 @@ packages:
         - host-libtool
       regenerate:
         - args: ['./autogen.sh']
-        - args: ['cp',
-            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
-            '@THIS_SOURCE_DIR@/build-aux/']
+        - args: ['autoreconf', '-fvi']
     tools_required:
       - system-gcc
     pkgs_required:
@@ -400,6 +405,8 @@ packages:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=@OPTION:arch-triple@'
+        - '--enable-shared'
+        - '--disable-static'
         - '--prefix=/usr'
         - '--disable-nls'
         - '--disable-doc'
@@ -416,6 +423,14 @@ packages:
         quiet: true
 
   - name: libgpg-error
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Contains error handling functions used by GnuPG software
+      description: This package contains a library that defines common error values for all GnuPG components.
+      spdx: 'LGPL-2.1-only'
+      website: 'https://www.gnupg.org/related_software/libgpg-error'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: 'ports'
       git: 'https://dev.gnupg.org/source/libgpg-error.git'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -5,6 +5,12 @@ sources:
     tag: '2.68.3'
     version: '2.68.3'
 
+  - name: gobject-introspection
+    subdir: 'ports'
+    git: 'https://gitlab.gnome.org/GNOME/gobject-introspection.git'
+    tag: '1.64.1'
+    version: '1.64.1'
+
   - name: icu
     subdir: 'ports'
     git: 'https://github.com/unicode-org/icu.git'
@@ -29,6 +35,19 @@ tools:
   - name: host-glib
     exports_aclocal: true
     from_source: glib
+    configure:
+      - args:
+        - 'meson'
+        - '--prefix=@PREFIX@'
+        - '@THIS_SOURCE_DIR@'
+    compile:
+      - args: ['ninja']
+    install:
+      - args: ['ninja', 'install']
+
+  - name: host-gobject-introspection
+    exports_aclocal: true
+    from_source: gobject-introspection
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/gnome-base.yml
+++ b/bootstrap.d/gnome-base.yml
@@ -1,0 +1,44 @@
+packages:
+  - name: gsettings-desktop-schemas
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Collection of GSettings schemas for GNOME desktop
+      description: This package contains a collection of GSettings schemas for settings shared by various components of a GNOME Desktop.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['gnome-base']
+    source:
+      subdir: ports
+      git: 'https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas.git'
+      tag: '3.38.0'
+      version: '3.38.0'
+    tools_required:
+      - system-gcc
+      - host-gobject-introspection
+      - host-libtool
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+    configure:
+      - args: |
+              sed -i -r 's:"(/system):"/org/gnome\1:g' @THIS_SOURCE_DIR@/schemas/*.in
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '-Dintrospection=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+    scripts:
+        post_install:
+          - args: 'echo "Running glib-compile-schemas; this may take a few seconds..."'
+          - args: ['glib-compile-schemas /usr/share/glib-2.0/schemas']

--- a/bootstrap.d/net-dns.yml
+++ b/bootstrap.d/net-dns.yml
@@ -1,0 +1,72 @@
+packages:
+  - name: libidn2
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: An implementation of the IDNA2008 specifications (RFCs 5890, 5891, 5892, 5893)
+      description: This package provides a library for internationalized string handling based on standards from the Internet Engineering Task Force (IETF)'s IDN working group, designed for internationalized domain names.
+      spdx: 'LGPL-3.0-or-later'
+      website: 'https://www.gnu.org/software/libidn/#libidn2'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-dns']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.com/libidn/libidn2.git'
+      tag: 'v2.3.2'
+      version: '2.3.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./bootstrap']
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-libtool
+      - host-pkg-config
+    pkgs_required:
+      - mlibc
+      - libunistring
+      - libiconv
+    configure:
+      # Remove some files from the source directory if they exist.
+      - args: |
+              if [ -f @THIS_SOURCE_DIR@/lib/gendata ]; then
+                  rm -rv @THIS_SOURCE_DIR@/lib/gendata
+              fi
+      - args: |
+              if [ -f @THIS_SOURCE_DIR@/lib/gentr46map ]; then
+                  rm -rv @THIS_SOURCE_DIR@/lib/gentr46map
+              fi
+      # Configure for the host, we need some files to be generated
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--disable-doc'
+        - '--disable-nls'
+      # Broken out of tree build, but also broken in tree for some reason, work around it
+      - args: ['cp', '-v', '@THIS_SOURCE_DIR@/lib/idna-tables-properties.csv', '@THIS_BUILD_DIR@/lib/']
+      - args: ['cp', '-v', '@THIS_BUILD_DIR@/lib/idn2.h', '@THIS_SOURCE_DIR@/lib/']
+      # Build it so we get our files
+      - args: ['make', '-j@PARALLELISM@']
+      # Copy the files to the source dir, where libidn2 wants them
+      - args: ['cp', '-v', '@THIS_BUILD_DIR@/lib/gendata', '@THIS_SOURCE_DIR@/lib/gendata']
+      - args: ['cp', '-v', '@THIS_BUILD_DIR@/lib/gentr46map', '@THIS_SOURCE_DIR@/lib/gentr46map']
+      # Finally, configure for managarm
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--disable-static'
+        - '--disable-doc'
+        - '--disable-nls'
+      # Again, copy the header, it might've changed due to configure.
+      - args: ['cp', '-v', '@THIS_BUILD_DIR@/lib/idn2.h', '@THIS_SOURCE_DIR@/lib/']
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -1,4 +1,49 @@
 packages:
+  - name: glib-networking
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Network-related giomodules for glib
+      description: This package contains network related gio modules for GLib.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://gitlab.gnome.org/GNOME/glib-networking'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/glib-networking.git'
+      tag: '2.68.2'
+      version: '2.68.2'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+      - gnutls
+      - gsettings-desktop-schemas
+    configure:
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--buildtype=debugoptimized'
+        - '-Dintrospection=false'
+        - '-Dgnutls=enabled'
+        - '-Dopenssl=disabled'
+        - '-Dinstalled_tests=false'
+        - '-Dstatic_modules=false'
+        - '-Dlibproxy=disabled'
+        - '-Dgnome_proxy=disabled'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: gnutls
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -148,3 +148,55 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libsoup
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: https://wiki.gnome.org/Projects/libsoup
+      description: This package is a HTTP client/server library for GNOME. It uses GObject and the GLib main loop to integrate with GNOME applications and it also has an asynchronous API for use in threaded applications.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://wiki.gnome.org/Projects/libsoup'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/libsoup.git'
+      tag: '2.72.0'
+      version: '2.72.0'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+      - glib-networking
+      - zlib
+      - libxml
+      - sqlite
+      - libpsl
+    configure:
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--buildtype=debugoptimized'
+        - '-Dintrospection=disabled'
+        - '-Dinstalled_tests=false'
+        - '-Dsysprof=disabled'
+        - '-Dgtk_doc=false'
+        - '-Dvapi=disabled'
+        - '-Dgnome=false'
+        - '-Dtls_check=false'
+        - '-Dbrotli=disabled'
+        - '-Dntlm=disabled'
+        - '-Dgssapi=disabled'
+        - '-Dtests=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -1,0 +1,58 @@
+packages:
+  - name: gnutls
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: A secure communications library implementing the SSL, TLS and DTLS protocols
+      description: This package contains libraries and userspace tools which provide a secure layer over a reliable transport layer. Currently the GnuTLS library implements the proposed standards by the IETF's TLS working group.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://www.gnutls.org'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-libs']
+    source:
+      subdir: 'ports'
+      url: 'https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.2.tar.xz'
+      format: 'tar.xz'
+      extract_path: 'gnutls-3.7.2'
+      version: '3.7.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - libtasn
+      - p11-kit
+      - nettle
+      - gmp
+      - libunistring
+      - libidn2
+      - libiconv
+      - libintl
+      - openssl
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-guile'
+        - '--disable-rpath'
+        - '--with-default-trust-store-pkcs11=pkcs11:'
+        - '--docdir=/usr/share/doc/gnutls-3.7.2'
+        - '--with-default-trust-store-file=/etc/pki/tls/certs/ca-bundle.crt'
+        - '--enable-openssl-compatibility'
+        - '--without-tpm'
+        - '--disable-libdane'
+        - '--disable-nls'
+        - '--enable-ssl3-support'
+        - '--enable-local-libopts'
+        - '--enable-cross-guesses=risky'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -101,3 +101,50 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libpsl
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: C library for the Public Suffix List
+      description: This package provides a library for accessing and resolving information from the Public Suffix List (PSL). The PSL is a set of domain names beyond the standard suffixes, such as .com.
+      spdx: 'MIT'
+      website: 'https://github.com/rockdaboot/libpsl'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/rockdaboot/libpsl.git'
+      tag: '0.21.1'
+      version: '0.21.1'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - libidn2
+      - libunistring
+      - libiconv
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--enable-builtin=libidn2'
+        - '--enable-runtime=libidn2'
+        # Gentoo disables asan, cfi and ubsan
+        - '--disable-asan'
+        - '--disable-cfi'
+        - '--disable-ubsan'
+        - '--disable-man'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -154,6 +154,8 @@ packages:
       - libxext
       - libxcb
       - pango
+      - hicolor-icon-theme
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -174,6 +176,12 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
+      # Rename a file to avoid conflicts, we will use gtk3 as default, so rename this one.
+      - args: ['mv', '-v', '@THIS_COLLECT_DIR@/usr/bin/gtk-update-icon-cache', '@THIS_COLLECT_DIR@/usr/bin/gtk2-update-icon-cache']
+    scripts:
+        post_install:
+          - args: 'echo "Running gtk-query-immodules-2.0; this may a few moments..."'
+          - args: ['gtk-query-immodules-2.0 --update-cache']
 
   - name: libdrm
     labels: [aarch64]

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -53,6 +53,7 @@ packages:
       - glib
       - libxml
       - itstool
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -66,6 +67,10 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+    scripts:
+        post_install:
+          - args: 'echo "Running update-mime-database; this may take a minute or 2..."'
+          - args: ['update-mime-database /usr/share/mime/']
 
   - name: xbitmaps
     source:

--- a/bootstrap.d/x11-themes.yml
+++ b/bootstrap.d/x11-themes.yml
@@ -1,4 +1,36 @@
 packages:
+  - name: hicolor-icon-theme
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Fallback theme for the freedesktop icon theme specification
+      description: This package contains a default fallback theme for implementations of the icon theme specification.
+      spdx: 'GPL-2.0-only'
+      website: 'https://freedesktop.org/wiki/Software/icon-theme'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['x11-themes']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.freedesktop.org/xdg/default-icon-theme.git'
+      tag: '0.17'
+      version: '0.17'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+      regenerate:
+        - args: ['./autogen.sh', '--no-configure']
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: xcursor-themes
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/x11-themes.yml
+++ b/bootstrap.d/x11-themes.yml
@@ -1,0 +1,39 @@
+packages:
+  - name: xcursor-themes
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: 'X.Org cursor themes: whiteglass, redglass and handhelds'
+      description: This package provides various themes for cursors.
+      spdx: 'MIT'
+      website: 'https://gitlab.freedesktop.org/xorg/data/xcursor-themes'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['x11-themes']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.freedesktop.org/xorg/data/cursors.git'
+      tag: 'xcursor-themes-1.0.6'
+      version: '1.0.6'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+        - host-xorg-macros
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            NOCONFIGURE: '1'
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -11,6 +11,7 @@ imports:
   - file: bootstrap.d/dev-util.yml
   - file: bootstrap.d/games-board.yml
   - file: bootstrap.d/games-misc.yml
+  - file: bootstrap.d/gnome-base.yml
   - file: bootstrap.d/media-fonts.yml
   - file: bootstrap.d/media-gfx.yml
   - file: bootstrap.d/media-libs.yml

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -16,6 +16,7 @@ imports:
   - file: bootstrap.d/media-libs.yml
   - file: bootstrap.d/meta-pkgs.yml
   - file: bootstrap.d/net-dns.yml
+  - file: bootstrap.d/net-libs.yml
   - file: bootstrap.d/net-misc.yml
   - file: bootstrap.d/sys-apps.yml
   - file: bootstrap.d/sys-boot.yml

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -27,6 +27,7 @@ imports:
   - file: bootstrap.d/x11-base.yml
   - file: bootstrap.d/x11-libs.yml
   - file: bootstrap.d/x11-misc.yml
+  - file: bootstrap.d/x11-themes.yml
 
 general:
     patch_author: The Managarm Project

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -15,6 +15,7 @@ imports:
   - file: bootstrap.d/media-gfx.yml
   - file: bootstrap.d/media-libs.yml
   - file: bootstrap.d/meta-pkgs.yml
+  - file: bootstrap.d/net-dns.yml
   - file: bootstrap.d/net-misc.yml
   - file: bootstrap.d/sys-apps.yml
   - file: bootstrap.d/sys-boot.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update \
 	&& apt-get -y install \
 		# Don't install recommended stuff
 		--no-install-recommends \
+		# Used by gnutls
+		autogen \
 		# Used by host-bison
 		autopoint \
 		# Used by binutils in the build process

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update \
 		libfl2 \
 		# Used by many tools in the build process
 		gawk \
+		# Used by libidn2
+		gengetopt \
 		# Used by host-gettext
 		gettext \
 		# Git is used extensively in the build process

--- a/patches/libgcrypt/0001-Add-Managarm-support.patch
+++ b/patches/libgcrypt/0001-Add-Managarm-support.patch
@@ -1,0 +1,36 @@
+From db1c8580aca27a8f3428aef9f988c44d7d62392a Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 30 Aug 2021 02:05:47 +0200
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ random/rndunix.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/random/rndunix.c b/random/rndunix.c
+index fcb45b7..1e32242 100644
+--- a/random/rndunix.c
++++ b/random/rndunix.c
+@@ -105,7 +105,7 @@
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <pwd.h>
+-#ifndef __QNX__
++#if !defined __QNX__ && !defined (__managarm__)
+ #include <sys/errno.h>
+ #include <sys/ipc.h>
+ #endif				/* __QNX__ */
+@@ -119,7 +119,9 @@
+ #ifndef __QNX__
+ #include <sys/shm.h>
+ #include <signal.h>
++#ifndef __managarm__
+ #include <sys/signal.h>
++#endif
+ #endif				/* __QNX__ */
+ #include <sys/stat.h>
+ #include <sys/types.h>		/* Verschiedene komische Typen */
+-- 
+2.33.0
+


### PR DESCRIPTION
This PR adds a bunch of new ports, all in preparation for upstreaming `gtk+3` and `WebKitGTK`. More ports are expected, but are in need of a cleanup. Furthermore, some post install scripts have been added and the Dockerfile has been updated to accommodate the new ports.

New ports:
- `libgcrypt`,
- `libunistring`,
- `libidn2`,
- `gnutls`,
- `gsettings-desktop-schemas`, includes a post install script to compile the schemas.
- `glib-networking`,
- `libpsl`,
- `libsoup`,
- `xcursor-themes`,
- `hicolor-icon-theme`.

New tools:
- `host-gobject-introspection`, only used for some aclocal files.

Updated ports:
- `shared-mime-info`, added a post install script to build the mime database,
- `gtk+2`, rename a file which conflicts with `gtk+3`, add a post install script to build a cache and depend on `hicolor-icon-themes`.