### PR TITLE
Some small bugfixes for xcursor-themes and host-gobject-introspection

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -50,6 +50,8 @@ tools:
     from_source: gobject-introspection
     tools_required:
       - host-glib
+      - virtual: pkgconfig-for-host
+        triple: "@OPTION:arch-triple@"
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -1,3 +1,32 @@
+sources:
+  - name: xcursorgen
+    subdir: ports
+    git: 'https://gitlab.freedesktop.org/xorg/app/xcursorgen.git'
+    tag: 'xcursorgen-1.0.7'
+    version: '1.0.7'
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-libtool
+      - host-pkg-config
+      - host-xorg-macros
+    regenerate:
+      - args: ['./autogen.sh']
+        environ:
+          'NOCONFIGURE': 'yes'
+
+tools:
+  - name: host-xcursorgen
+    from_source: xcursorgen
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--prefix=@PREFIX@'
+    compile:
+      - args: ['make', '-j@PARALLELISM@']
+    install:
+      - args: ['make', 'install']
+
 packages:
   - name: mesa-demos
     source:

--- a/bootstrap.d/x11-themes.yml
+++ b/bootstrap.d/x11-themes.yml
@@ -57,8 +57,11 @@ packages:
             NOCONFIGURE: '1'
     tools_required:
       - system-gcc
+      - host-xcursorgen
     pkgs_required:
       - mlibc
+      - xorg-util-macros
+      - libxcursor
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'


### PR DESCRIPTION
The PR adding `xcursor-themes` was missing some dependencies in that recipe. It also fixed a missing tool and attempts to fix `host-gobject-introspection`.