### PR TITLE
Add a cups port

### DIFF
--- a/bootstrap.d/net-print.yml
+++ b/bootstrap.d/net-print.yml
@@ -1,0 +1,56 @@
+packages:
+  - name: cups
+    metadata:
+      summary: The Common Unix Printing System
+      description: The Common Unix Printing System (CUPS) is a print spooler and associated utilities. It is based on the "Internet Printing Protocol" and provides printing services to most PostScript and raster printers.
+      spdx: 'Apache-2.0'
+      website: 'https://www.cups.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-print']
+    source:
+      subdir: ports
+      git: 'https://github.com/apple/cups.git'
+      tag: 'v2.3.3'
+      version: '2.3.3'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+      regenerate:
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/']
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - gnutls
+      - libiconv
+      - zlib
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+      - args:
+        - './configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--libdir=/usr/lib'
+        - '--disable-systemd'
+        - '--with-rcdir=/tmp/cupsinit'
+        - '--with-system-groups=lpadmin'
+        - '--with-docdir=/usr/share/cups/doc-2.3.3op2'
+        - '--disable-dbus'
+        - '--disable-gssapi'
+        - '--disable-pam'
+        - '--disable-avahi'
+        - '--disable-dnssd'
+        - '--disable-browsing'
+        - '--with-components=libcups'
+      - args: 'sed -i s/-Werror//g @THIS_BUILD_DIR@/Makedefs'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      # Create Print Service User home directory
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/var/spool/cups']

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -19,6 +19,7 @@ imports:
   - file: bootstrap.d/net-dns.yml
   - file: bootstrap.d/net-libs.yml
   - file: bootstrap.d/net-misc.yml
+  - file: bootstrap.d/net-print.yml
   - file: bootstrap.d/sys-apps.yml
   - file: bootstrap.d/sys-boot.yml
   - file: bootstrap.d/sys-devel.yml
@@ -678,6 +679,7 @@ packages:
     source:
       subdir: meta-sources
       version: '1.0'
+    revision: 2
     configure: []
     build:
       # Create initial directories

--- a/extrafiles/group
+++ b/extrafiles/group
@@ -2,9 +2,10 @@ root:x:0:
 bin:x:1:daemon
 tty:x:5:
 disk:x:6:
-lp:x:7:
 daemon:x:8:
+lp:x:9:
 kmem:x:15:
+lpadmin:x:19:
 dialout:x:20:
 cdrom:x:24:
 tape:x:26:

--- a/extrafiles/passwd
+++ b/extrafiles/passwd
@@ -1,5 +1,6 @@
 root:x:0:0:root:/root:/bin/bash
 bin:x:1:1:bin:/dev/null:/bin/false
 daemon:x:8:8:Daemon User:/dev/null:/bin/false
-nobody:x:99:99:nobody:/dev/null:/usr/bin/false
+lp:x:9:9:Print Service User:/var/spool/cups:/bin/false
+nobody:x:99:99:Unprivileged User:/dev/null:/bin/false
 managarm:x:1000:1000:Managarm:/home/managarm:/bin/bash

--- a/patches/cups/0001-Add-Managarm-support.patch
+++ b/patches/cups/0001-Add-Managarm-support.patch
@@ -1,0 +1,36 @@
+From eefe118dee85dc8fcfca06ad202dd0a333bccf75 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Thu, 23 Sep 2021 21:44:56 +0200
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ cups/getifaddrs-internal.h | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/cups/getifaddrs-internal.h b/cups/getifaddrs-internal.h
+index 35e98be..36a2fe8 100644
+--- a/cups/getifaddrs-internal.h
++++ b/cups/getifaddrs-internal.h
+@@ -16,6 +16,7 @@
+  */
+ 
+ #  include "config.h"
++#  include "versioning.h"
+ #  ifdef _WIN32
+ #    define _WINSOCK_DEPRECATED_NO_WARNINGS 1
+ #    include <io.h>
+@@ -28,6 +29,10 @@
+ #    define CUPS_SOCAST
+ #  endif /* _WIN32 */
+ 
++#ifdef __managarm__
++#include <linux/sockios.h>
++#endif
++
+ #  if defined(__APPLE__) && !defined(_SOCKLEN_T)
+ /*
+  * macOS 10.2.x does not define socklen_t, and in fact uses an int instead of
+-- 
+2.33.0
+


### PR DESCRIPTION
This PR adds a port of `cups` and updates the `passwd` and `group` files to accommodate for this, by adding the `lpadmin` group and the `lp` user.