### PR TITLE
docker: Add 2 dependencies for swi-prolog

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,11 +51,14 @@ RUN apt-get update \
 		libgmp-dev \
 		libmpc-dev \
 		libmpfr-dev \
+		# Used by ace
+		libpng-dev \
 		# Used by cmake
 		libssl-dev \
-		# Used by ace
-		libpng-dev \		
-		# Used by many gnu build steps		
+		# Used by swi-prolog
+		libncurses-dev \
+		libreadline-dev \
+		# Used by many gnu build steps
 		m4 \
 		# Used by limine
 		mtools \


### PR DESCRIPTION
This PR adds `libncurses-dev` and `libreadline-dev` to the rootfs, which seems to be required to build `swi-prolog`. The resulting rootfs grows from `789MB` to `792MB`.