### PR TITLE
Switch to libxcrypt

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -149,8 +149,10 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-      - zlib
       - bzip2
+      - libxcrypt
+      - zlib
+    revision: 2
     configure:
       - args: ['cp', '-rf', '@THIS_SOURCE_DIR@/../perl-cross/.', '@THIS_SOURCE_DIR@/']
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
@@ -192,18 +194,19 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-      - zlib
+      - bzip2
+      - gdbm
       - libexpat
       - libffi
-      - ncurses
-      - readline
-      - bzip2
-      - openssl
-      - xz-utils
-      - gdbm
-      - util-linux-libs
       - libintl
-    revision: 6
+      - libxcrypt
+      - ncurses
+      - openssl
+      - readline
+      - util-linux-libs
+      - xz-utils
+      - zlib
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -13,7 +13,7 @@ packages:
       website: 'https://managarm.org'
       maintainer: "Dennis Bonke <dennis@managarm.org>"
       categories: ['meta-pkgs']
-    revision: 2
+    revision: 3
     pkgs_required:
       - mlibc
       - core-files
@@ -42,6 +42,7 @@ packages:
       - xz-utils
       - findutils
       - util-linux
+      - libxcrypt
       - gcc # Temporary solution to remove the need to copy libstdc++.so and libgcc.so from system-gcc
       - man-db
     configure: []

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -62,6 +62,43 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libxcrypt
+    labels: [aarch64]
+    architecture: '@OPTION:arch@'
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/besser82/libxcrypt.git'
+      tag: 'v4.4.26'
+      version: '4.4.26'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - system-gcc
+    pkgs_required:
+      - mlibc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--enable-obsolete-api=yes'
+        - '--disable-xcrypt-compat-files'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
   
   - name: mtdev
     labels: [aarch64]

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1130,6 +1130,7 @@ packages:
         - '--prefix=/usr'
         - '@THIS_SOURCE_DIR@'
         - '-Dheaders_only=true'
+        - '-Ddisable_crypt_option=true'
         - '-Ddisable_iconv_option=true'
         - '-Ddisable_intl_option=true'
     build:
@@ -1165,6 +1166,7 @@ packages:
         - '--libdir=lib'
         - '--buildtype=debugoptimized'
         - '-Dmlibc_no_headers=true'
+        - '-Ddisable_crypt_option=true'
         - '-Ddisable_iconv_option=true'
         - '-Ddisable_intl_option=true'
         - '@THIS_SOURCE_DIR@'


### PR DESCRIPTION
This PR is the managarm specific counterpart to managarm/mlibc#328. With this, we switch to `libxcrypt` as our crypt provider. I don't expect any significant breakage but we recompile `perl` and `python` for good measure to force them to link against the new libcrypt.

Blocked on managarm/mlibc#328