### PR TITLE
app-emulation: add qemu port

### DIFF
--- a/bootstrap.d/app-emulation.yml
+++ b/bootstrap.d/app-emulation.yml
@@ -1,0 +1,43 @@
+packages:
+  - name: qemu
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: A generic and open source machine emulator and virtualizer
+      description: A generic and open source machine emulator and virtualizer
+      spdx: 'GPL-2.0'
+      website: 'https://qemu.org/'
+      maintainer: 'Kacper Słomiński <qookie@managarm.org>'
+      categories: ['app-emulation']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/qemu/qemu.git'
+      tag: 'v6.2.0'
+      version: '6.2.0'
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+      - sdl2
+      - pcre
+      - libiconv
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--cross-prefix=@OPTION:arch-triple@-'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--target-list=i386-softmmu,x86_64-softmmu,aarch64-softmmu,riscv32-softmmu,riscv64-softmmu'
+        - '--disable-slirp'
+        - '--with-coroutine=sigaltstack'
+        environ:
+          PKG_CONFIG_LIBDIR: '@SYSROOT_DIR@/usr/lib/pkgconfig:@SYSROOT_DIR@/usr/share/pkgconfig'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -3,6 +3,7 @@ imports:
   - file: bootstrap.d/app-arch.yml
   - file: bootstrap.d/app-crypt.yml
   - file: bootstrap.d/app-editors.yml
+  - file: bootstrap.d/app-emulation.yml
   - file: bootstrap.d/app-misc.yml
   - file: bootstrap.d/app-shells.yml
   - file: bootstrap.d/dev-db.yml

--- a/patches/qemu/0001-configure-add-managarm-support.patch
+++ b/patches/qemu/0001-configure-add-managarm-support.patch
@@ -1,0 +1,46 @@
+From d926ae4df05650a7af615ae92cb98493cc7409fb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kacper=20S=C5=82omi=C5=84ski?=
+ <kacper.slominski72@gmail.com>
+Date: Tue, 21 Dec 2021 13:07:19 +0100
+Subject: [PATCH 1/2] configure: add managarm support
+
+---
+ configure | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/configure b/configure
+index 48c2177..a6e9161 100755
+--- a/configure
++++ b/configure
+@@ -521,6 +521,8 @@ elif check_define __NetBSD__; then
+   targetos='NetBSD'
+ elif check_define __APPLE__; then
+   targetos='Darwin'
++elif check_define __managarm__; then
++  targetos='Managarm'
+ else
+   # This is a fatal error, but don't report it yet, because we
+   # might be going to just print the --help text, or it might
+@@ -677,6 +679,9 @@ Linux)
+   linux_user="yes"
+   vhost_user=${default_feature:-yes}
+ ;;
++Managarm)
++  managarm="yes"
++;;
+ esac
+ 
+ : ${make=${MAKE-make}}
+@@ -3944,6 +3949,9 @@ if test "$skip_meson" = no; then
+     if test "$darwin" = "yes" ; then
+         echo "system = 'darwin'" >> $cross
+     fi
++    if test "$managarm" = "yes" ; then
++        echo "system = 'managarm'" >> $cross
++    fi
+     case "$ARCH" in
+         i386)
+             echo "cpu_family = 'x86'" >> $cross
+-- 
+2.34.1
+

--- a/patches/qemu/0002-qemu-thread-posix-patch-out-pthread_attr_setdetachst.patch
+++ b/patches/qemu/0002-qemu-thread-posix-patch-out-pthread_attr_setdetachst.patch
@@ -1,0 +1,26 @@
+From cc0fff8c2c1834c8cd5b7eb41a38a283737417d6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kacper=20S=C5=82omi=C5=84ski?=
+ <kacper.slominski72@gmail.com>
+Date: Tue, 21 Dec 2021 13:07:33 +0100
+Subject: [PATCH 2/2] qemu-thread-posix: patch out pthread_attr_setdetachstate
+
+---
+ util/qemu-thread-posix.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/util/qemu-thread-posix.c b/util/qemu-thread-posix.c
+index e1225b6..51f8db4 100644
+--- a/util/qemu-thread-posix.c
++++ b/util/qemu-thread-posix.c
+@@ -576,7 +576,7 @@ void qemu_thread_create(QemuThread *thread, const char *name,
+     }
+ 
+     if (mode == QEMU_THREAD_DETACHED) {
+-        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
++        //pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+     }
+ 
+     /* Leave signal handling to the iothread.  */
+-- 
+2.34.1
+


### PR DESCRIPTION
Some notes:
 - The second patch should be removed once managarm/mlibc#311 is merged.
 - Running qemu in a vm with more than one core may cause a kernel page fault.