### PR TITLE
Port webkitgtk

### DIFF
--- a/bootstrap.d/gui-libs.yml
+++ b/bootstrap.d/gui-libs.yml
@@ -99,3 +99,47 @@ packages:
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: wpebackend-fdo
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: WPE backend designed for Linux desktop systems
+      description: The wpebackend-fdo package contains the Freedesktop.org backend for WPE WebKit and the WPE renderer.
+      spdx: 'BSD-2-Clause'
+      website: 'https://wpewebkit.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['gui-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/Igalia/WPEBackend-fdo.git'
+      tag: '1.14.2'
+      version: '1.14.2'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - wayland-scanner
+    pkgs_required:
+      - mlibc
+      - libwpe
+      - wayland-protocols
+      - wayland
+      - libepoxy
+      - glib
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        - '--buildtype=debugoptimized'
+        - '-Dbuild_docs=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/gui-libs.yml
+++ b/bootstrap.d/gui-libs.yml
@@ -1,4 +1,45 @@
 packages:
+  - name: libwpe
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Platform-agnostic interfaces for WPE WebKit
+      description: The libwpe package contains a general purpose library for WPE WebKit and the WPE Renderer.
+      spdx: 'BSD-2-Clause'
+      website: 'https://wpewebkit.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['gui-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/WebPlatformForEmbedded/libwpe.git'
+      tag: '1.14.1'
+      version: '1.14.1'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - mesa
+      - libxkbcommon
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        - '--buildtype=debugoptimized'
+        - '-Denable-xkb=true'
+        - '-Dbuild-docs=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: wlroots
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -247,3 +247,97 @@ packages:
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: webkitgtk
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: 'An open source web browser engine, with a small example browser'
+      description: 'This package provides WebKitGTK, a port of the portable web rendering engine WebKit to the GTK+ 3 and GTK 4 platforms.'
+      spdx: 'LGPL-2.0-or-later BSD-2-Clause'
+      website: 'https://webkitgtk.org'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/WebKit/WebKit.git'
+      # I think? Apple is weird with naming
+      tag: 'Safari-612.1.27.0.24'
+      version: '2.33.3'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - wayland-scanner
+    pkgs_required:
+      - mlibc
+      - cairo
+      - fontconfig
+      - freetype
+      - libgcrypt
+      - glib
+      - harfbuzz
+      - icu
+      - libjpeg-turbo
+      - zlib
+      - sqlite
+      - libpng
+      - libxml
+      - atk
+      - libwebp
+      - gtk+-3
+      - libsoup
+      - libxslt
+      - at-spi2-core
+      - libtasn
+      - libx11
+      - libxcomposite
+      - libxdamage
+      - libxrender
+      - libxt
+      - mesa
+      - gst-plugins-base
+      - gst-plugins-bad
+      - gst-plugins-good
+      # - libwpe
+      # - wpebackend-fdo
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_SYSTEM_PROCESSOR=@OPTION:arch@'
+        - '-DCMAKE_BUILD_TYPE=Release'
+        - '-DCMAKE_SKIP_RPATH=ON'
+        - '-DPORT=GTK'
+        - '-DLIB_INSTALL_DIR=/usr/lib'
+        - '-DUSE_LIBHYPHEN=OFF'
+        - '-DENABLE_GAMEPAD=OFF'
+        - '-DENABLE_MINIBROWSER=ON'
+        - '-DUSE_WOFF2=OFF'
+        - '-DUSE_SYSTEMD=OFF'
+        - '-DENABLE_BUBBLEWRAP_SANDBOX=OFF'
+        - '-Wno-dev -G Ninja'
+        - '-DUSE_LIBNOTIFY=OFF'
+        - '-DUSE_SYSTEM_MALLOC=ON'
+        - '-DENABLE_GEOLOCATION=OFF'
+        - '-DENABLE_GLES2=ON'
+        - '-DENABLE_VIDEO=ON'
+        - '-DENABLE_WEB_AUDIO=ON'
+        - '-DENABLE_INTROSPECTION=OFF'
+        - '-DUSE_LIBSECRET=OFF'
+        - '-DUSE_OPENJPEG=OFF'
+        - '-DENABLE_SPELLCHECK=OFF'
+        - '-DENABLE_WAYLAND_TARGET=ON'
+        - '-DENABLE_X11_TARGET=ON'
+        - '-DENABLE_WEBGL=ON'
+        - '-DUSE_WPE_RENDERER=OFF'
+        - '-DENABLE_WEBGL2=OFF'
+        - '-DUSE_SOUP2=ON'
+        - '-DUSE_LCMS=OFF'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja', '-j6']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['ln', '-sv', '/usr/libexec/webkit2gtk-4.0/MiniBrowser', '@THIS_COLLECT_DIR@/usr/bin/browser']

--- a/patches/webkitgtk/0001-Initial-Managarm-support.patch
+++ b/patches/webkitgtk/0001-Initial-Managarm-support.patch
@@ -1,0 +1,318 @@
+From a8487fb2a189363486333a3a0f1933731dd2b34f Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 2 Jan 2022 00:19:17 +0100
+Subject: [PATCH] Initial Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ Source/JavaScriptCore/heap/BlockDirectory.cpp          |  2 +-
+ Source/JavaScriptCore/runtime/MachineContext.h         | 10 +++++-----
+ Source/JavaScriptCore/runtime/Options.cpp              |  1 +
+ Source/ThirdParty/ANGLE/include/GLSLANG/ShaderVars.h   |  1 +
+ Source/ThirdParty/ANGLE/src/common/platform.h          |  2 +-
+ Source/WTF/wtf/CompletionHandler.h                     |  1 +
+ Source/WTF/wtf/InlineASM.h                             |  8 +++++---
+ Source/WTF/wtf/MallocPtr.h                             |  1 +
+ Source/WTF/wtf/PlatformHave.h                          |  4 ++--
+ Source/WTF/wtf/PlatformOS.h                            |  6 ++++++
+ Source/WTF/wtf/text/IntegerToStringConversion.h        |  1 +
+ Source/WebCore/platform/graphics/x11/XUniqueResource.h |  2 ++
+ Source/WebCore/platform/sql/SQLiteDatabase.cpp         |  6 +++---
+ Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp     |  2 +-
+ Source/WebKit/Platform/unix/SharedMemoryUnix.cpp       |  4 +++-
+ 15 files changed, 34 insertions(+), 17 deletions(-)
+
+diff --git a/Source/JavaScriptCore/heap/BlockDirectory.cpp b/Source/JavaScriptCore/heap/BlockDirectory.cpp
+index e2a3540f86..d58513333e 100644
+--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
++++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
+@@ -60,7 +60,7 @@ void BlockDirectory::setSubspace(Subspace* subspace)
+ void BlockDirectory::updatePercentageOfPagedOutPages(SimpleStats& stats)
+ {
+     // FIXME: We should figure out a solution for Windows.
+-#if OS(UNIX)
++#if OS(UNIX) && !OS(MANAGARM)
+     size_t pageSize = WTF::pageSize();
+     ASSERT(!(MarkedBlock::blockSize % pageSize));
+     auto numberOfPagesInMarkedBlock = MarkedBlock::blockSize / pageSize;
+diff --git a/Source/JavaScriptCore/runtime/MachineContext.h b/Source/JavaScriptCore/runtime/MachineContext.h
+index 7857bfc167..5cb5f31ea8 100644
+--- a/Source/JavaScriptCore/runtime/MachineContext.h
++++ b/Source/JavaScriptCore/runtime/MachineContext.h
+@@ -195,7 +195,7 @@ static inline void*& stackPointerImpl(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(MANAGARM)
+ 
+ #if CPU(X86)
+     return reinterpret_cast<void*&>((uintptr_t&) machineContext.gregs[REG_ESP]);
+@@ -346,7 +346,7 @@ static inline void*& framePointerImpl(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(MANAGARM)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -497,7 +497,7 @@ static inline void*& instructionPointerImpl(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(MANAGARM)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -655,7 +655,7 @@ inline void*& argumentPointer<1>(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(MANAGARM)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+@@ -772,7 +772,7 @@ inline void*& llintInstructionPointer(mcontext_t& machineContext)
+ #error Unknown Architecture
+ #endif
+ 
+-#elif OS(FUCHSIA) || OS(LINUX)
++#elif OS(FUCHSIA) || OS(LINUX) || OS(MANAGARM)
+ 
+ // The following sequence depends on glibc's sys/ucontext.h.
+ #if CPU(X86)
+diff --git a/Source/JavaScriptCore/runtime/Options.cpp b/Source/JavaScriptCore/runtime/Options.cpp
+index e54387ef28..d159806731 100644
+--- a/Source/JavaScriptCore/runtime/Options.cpp
++++ b/Source/JavaScriptCore/runtime/Options.cpp
+@@ -35,6 +35,7 @@
+ #include <mutex>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include <wtf/ASCIICType.h>
+ #include <wtf/Compiler.h>
+ #include <wtf/DataLog.h>
+diff --git a/Source/ThirdParty/ANGLE/include/GLSLANG/ShaderVars.h b/Source/ThirdParty/ANGLE/include/GLSLANG/ShaderVars.h
+index 68dc7e2e32..08bf9e5fb5 100644
+--- a/Source/ThirdParty/ANGLE/include/GLSLANG/ShaderVars.h
++++ b/Source/ThirdParty/ANGLE/include/GLSLANG/ShaderVars.h
+@@ -12,6 +12,7 @@
+ 
+ #include <algorithm>
+ #include <array>
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 
+diff --git a/Source/ThirdParty/ANGLE/src/common/platform.h b/Source/ThirdParty/ANGLE/src/common/platform.h
+index 41f3cf4ff7..77c4a91f29 100644
+--- a/Source/ThirdParty/ANGLE/src/common/platform.h
++++ b/Source/ThirdParty/ANGLE/src/common/platform.h
+@@ -28,7 +28,7 @@
+ #    define ANGLE_PLATFORM_POSIX 1
+ #elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) ||              \
+     defined(__DragonFly__) || defined(__sun) || defined(__GLIBC__) || defined(__GNU__) || \
+-    defined(__QNX__) || defined(__Fuchsia__) || defined(__HAIKU__)
++    defined(__QNX__) || defined(__Fuchsia__) || defined(__HAIKU__) || defined(__managarm__)
+ #    define ANGLE_PLATFORM_POSIX 1
+ #else
+ #    error Unsupported platform.
+diff --git a/Source/WTF/wtf/CompletionHandler.h b/Source/WTF/wtf/CompletionHandler.h
+index a358c0f6ee..100cb29aca 100644
+--- a/Source/WTF/wtf/CompletionHandler.h
++++ b/Source/WTF/wtf/CompletionHandler.h
+@@ -27,6 +27,7 @@
+ 
+ #include <wtf/Function.h>
+ #include <wtf/MainThread.h>
++#include <utility>
+ 
+ namespace WTF {
+ 
+diff --git a/Source/WTF/wtf/InlineASM.h b/Source/WTF/wtf/InlineASM.h
+index 8379a69659..8f7493769f 100644
+--- a/Source/WTF/wtf/InlineASM.h
++++ b/Source/WTF/wtf/InlineASM.h
+@@ -43,11 +43,11 @@
+ #define THUMB_FUNC_PARAM(name)
+ #endif
+ 
+-#if (OS(LINUX) || OS(FREEBSD)) && CPU(X86_64)
++#if (OS(LINUX) || OS(FREEBSD) || OS(MANAGARM)) && CPU(X86_64)
+ #define GLOBAL_REFERENCE(name) #name "@plt"
+ #elif CPU(X86) && COMPILER(MINGW)
+ #define GLOBAL_REFERENCE(name) "@" #name "@4"
+-#elif OS(LINUX) && CPU(X86) && defined(__PIC__)
++#elif (OS(LINUX) || OS(MANAGARM)) && CPU(X86) && defined(__PIC__)
+ #define GLOBAL_REFERENCE(name) SYMBOL_STRING(name) "@plt"
+ #else
+ #define GLOBAL_REFERENCE(name) SYMBOL_STRING(name)
+@@ -70,7 +70,8 @@
+     || OS(FUCHSIA)             \
+     || OS(OPENBSD)             \
+     || OS(HPUX)                \
+-    || OS(NETBSD)
++    || OS(NETBSD)              \
++    || OS(MANAGARM)
+     // ELF platform
+ #define HIDE_SYMBOL(name) ".hidden " #name
+ #else
+@@ -88,6 +89,7 @@
+     || OS(OPENBSD)             \
+     || OS(HURD)                \
+     || OS(NETBSD)              \
++    || OS(MANAGARM)            \
+     || COMPILER(MINGW)
+     // GNU as-compatible syntax.
+ #define LOCAL_LABEL_STRING(name) ".L" #name
+diff --git a/Source/WTF/wtf/MallocPtr.h b/Source/WTF/wtf/MallocPtr.h
+index 2cbd861efd..0415cccea0 100644
+--- a/Source/WTF/wtf/MallocPtr.h
++++ b/Source/WTF/wtf/MallocPtr.h
+@@ -27,6 +27,7 @@
+ 
+ #include <wtf/FastMalloc.h>
+ #include <wtf/Noncopyable.h>
++#include <utility>
+ 
+ // MallocPtr is a smart pointer class that calls fastFree in its destructor.
+ // It is intended to be used for pointers where the C++ lifetime semantics
+diff --git a/Source/WTF/wtf/PlatformHave.h b/Source/WTF/wtf/PlatformHave.h
+index 61f13c2b73..de93124ef8 100644
+--- a/Source/WTF/wtf/PlatformHave.h
++++ b/Source/WTF/wtf/PlatformHave.h
+@@ -226,7 +226,7 @@
+ #define HAVE_HOSTED_CORE_ANIMATION 1
+ #endif
+ 
+-#if OS(DARWIN) || OS(FUCHSIA) || ((OS(FREEBSD) || OS(LINUX)) && (CPU(X86) || CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(MIPS)))
++#if OS(DARWIN) || OS(FUCHSIA) || OS(MANAGARM) || ((OS(FREEBSD) || OS(LINUX)) && (CPU(X86) || CPU(X86_64) || CPU(ARM) || CPU(ARM64) || CPU(MIPS)))
+ #define HAVE_MACHINE_CONTEXT 1
+ #endif
+ 
+@@ -238,7 +238,7 @@
+ #define HAVE_BACKTRACE_SYMBOLS 1
+ #endif
+ 
+-#if OS(DARWIN) || OS(LINUX)
++#if OS(DARWIN) || OS(LINUX) || OS(MANAGARM)
+ #define HAVE_DLADDR 1
+ #endif
+ 
+diff --git a/Source/WTF/wtf/PlatformOS.h b/Source/WTF/wtf/PlatformOS.h
+index e61715fb72..ed72f251a9 100644
+--- a/Source/WTF/wtf/PlatformOS.h
++++ b/Source/WTF/wtf/PlatformOS.h
+@@ -118,6 +118,11 @@
+ #define WTF_OS_WINDOWS 1
+ #endif
+ 
++/* OS(MANAGARM) - Managarm */
++#if defined(__managarm__)
++#define WTF_OS_MANAGARM 1
++#endif
++
+ 
+ /* OS(UNIX) - Any Unix-like system */
+ #if    OS(AIX)              \
+@@ -128,6 +133,7 @@
+     || OS(LINUX)            \
+     || OS(NETBSD)           \
+     || OS(OPENBSD)          \
++    || OS(MANAGARM)         \
+     || defined(unix)        \
+     || defined(__unix)      \
+     || defined(__unix__)
+diff --git a/Source/WTF/wtf/text/IntegerToStringConversion.h b/Source/WTF/wtf/text/IntegerToStringConversion.h
+index 03f5861c33..f8143ba977 100644
+--- a/Source/WTF/wtf/text/IntegerToStringConversion.h
++++ b/Source/WTF/wtf/text/IntegerToStringConversion.h
+@@ -21,6 +21,7 @@
+ 
+ #pragma once
+ 
++#include <array>
+ #include <wtf/text/LChar.h>
+ 
+ namespace WTF {
+diff --git a/Source/WebCore/platform/graphics/x11/XUniqueResource.h b/Source/WebCore/platform/graphics/x11/XUniqueResource.h
+index 0da8b0c9c0..9296efca23 100644
+--- a/Source/WebCore/platform/graphics/x11/XUniqueResource.h
++++ b/Source/WebCore/platform/graphics/x11/XUniqueResource.h
+@@ -26,6 +26,8 @@
+ #ifndef XUniqueResource_h
+ #define XUniqueResource_h
+ 
++#include <utility>
++
+ #if PLATFORM(X11)
+ 
+ #if USE(GLX)
+diff --git a/Source/WebCore/platform/sql/SQLiteDatabase.cpp b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+index 743ef3dc84..3a61bc1dc3 100644
+--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
++++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+@@ -148,8 +148,8 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode)
+             LOG_ERROR("SQLite database could not set temp_store to memory");
+     }
+ 
+-    if (openMode != OpenMode::ReadOnly)
+-        useWALJournalMode();
++    // if (openMode != OpenMode::ReadOnly)
++        // useWALJournalMode();
+ 
+     auto shmFileName = makeString(filename, "-shm"_s);
+     if (FileSystem::fileExists(shmFileName)) {
+@@ -727,7 +727,7 @@ Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatement(ASCIILiteral que
+ {
+     auto sqlStatement = constructAndPrepareStatement(*this, query.characters(), query.length());
+     if (!sqlStatement) {
+-        RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %{public}s", query.characters());
++        RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %s" /*%{public}s"*/, query.characters());
+         return makeUnexpected(sqlStatement.error());
+     }
+     return SQLiteStatement { *this, sqlStatement.value() };
+diff --git a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+index efcd663f84..11e5467c10 100644
+--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
++++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+@@ -46,7 +46,7 @@
+ 
+ // Although it's available on Darwin, SOCK_SEQPACKET seems to work differently
+ // than in traditional Unix so fallback to STREAM on that platform.
+-#if defined(SOCK_SEQPACKET) && !OS(DARWIN)
++#if defined(SOCK_SEQPACKET) && !OS(DARWIN) && !OS(MANAGARM)
+ #define SOCKET_TYPE SOCK_SEQPACKET
+ #else
+ #if USE(GLIB)
+diff --git a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+index 998a2a7679..a490b3fb5f 100644
+--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
++++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+@@ -47,8 +47,10 @@
+ 
+ #if HAVE(LINUX_MEMFD_H)
+ #include <linux/memfd.h>
++#if !OS(MANAGARM)
+ #include <sys/syscall.h>
+ #endif
++#endif
+ 
+ #if PLATFORM(PLAYSTATION)
+ #include "ArgumentCoders.h"
+@@ -132,7 +134,7 @@ static int createSharedMemory()
+     static bool isMemFdAvailable = true;
+     if (isMemFdAvailable) {
+         do {
+-            fileDescriptor = syscall(__NR_memfd_create, "WebKitSharedMemory", MFD_CLOEXEC);
++            fileDescriptor = memfd_create("WebKitSharedMemory", MFD_CLOEXEC);
+         } while (fileDescriptor == -1 && errno == EINTR);
+ 
+         if (fileDescriptor != -1)
+-- 
+2.43.0
+


### PR DESCRIPTION
This PR adds a port of `webkitgtk`. This PR remains a draft for the foreseeable future and only serves to help others debug various issues in `webkitgtk`.

This PR adds the following ports:
- `libwpe` (needed for newer versions);
- `wpebackend-fdo` (needed for newer versions);
- `webkitgtk`.

Blocked on #169 
Blocked on #176 
Blocked on managarm/managarm#525
Blocked on managarm/managarm#526