### PR TITLE
X11 libraries fixes

### DIFF
--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -239,7 +239,7 @@ packages:
       version: '1.1.4'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -253,6 +253,9 @@ packages:
       - system-gcc
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -261,6 +264,7 @@ packages:
       - libxtrans
       - xorg-font-util
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -285,7 +289,7 @@ packages:
       version: '1.0.10'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -297,12 +301,16 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -327,7 +335,7 @@ packages:
       version: '1.2.3'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -339,6 +347,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -346,6 +357,7 @@ packages:
       - libx11
       - libxtrans
       - libice
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -381,12 +393,16 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
       - libxcb
       - libxtrans
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -414,7 +430,7 @@ packages:
       version: '1.0.9'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -424,10 +440,14 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -452,7 +472,7 @@ packages:
       version: '1.0.14'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -462,6 +482,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -471,6 +494,7 @@ packages:
       - libxt
       - libxmu
       - libxpm
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -495,7 +519,7 @@ packages:
       version: '1.14'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -506,6 +530,9 @@ packages:
     tools_required:
       - system-gcc
       - host-python
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -513,6 +540,7 @@ packages:
       - libxau
       - libxdmcp
       - xcb-proto
+    revision: 2
     configure:
       - args: ['sed', '-i', "s/pthread-stubs//", '@THIS_SOURCE_DIR@/configure']
       - args:
@@ -541,7 +569,7 @@ packages:
       version: '1.2.0'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -551,6 +579,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -558,6 +589,7 @@ packages:
       - libx11
       - libxfixes
       - libxrender
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -582,7 +614,7 @@ packages:
       version: '1.1.5'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -593,6 +625,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -600,6 +635,7 @@ packages:
       - libx11
       - libxtrans
       - libxfixes
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -624,7 +660,7 @@ packages:
       version: '1.1.3'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -634,11 +670,15 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
       - libxau
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -663,7 +703,7 @@ packages:
       version: '1.3.4'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -674,12 +714,16 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -705,7 +749,7 @@ packages:
       version: '6.0.0'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -716,12 +760,16 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -746,7 +794,7 @@ packages:
       version: '2.0.4'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -761,6 +809,9 @@ packages:
       - host-xtrans
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -772,6 +823,7 @@ packages:
       - bzip2
       - libfontenc
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -800,7 +852,7 @@ packages:
       version: '2.3.3'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -810,6 +862,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -818,6 +873,7 @@ packages:
       - libxrender
       - freetype
       - fontconfig
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -842,7 +898,7 @@ packages:
       version: '1.7.10'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -853,6 +909,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -861,6 +920,7 @@ packages:
       - libxtrans
       - libxext
       - libxfixes
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -928,7 +988,7 @@ packages:
       version: '1.1.0'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -939,11 +999,15 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -968,7 +1032,7 @@ packages:
       version: '1.1.3'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -980,6 +1044,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -988,6 +1055,7 @@ packages:
       - libxext
       - libxtrans
       - libxt
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1012,7 +1080,7 @@ packages:
       version: '3.5.13'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1022,6 +1090,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -1029,6 +1100,7 @@ packages:
       - libx11
       - libxext
       - libxt
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1053,7 +1125,7 @@ packages:
       version: '1.5.2'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1064,6 +1136,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -1072,6 +1147,7 @@ packages:
       - libxtrans
       - libxrender
       - libxext
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1097,7 +1173,7 @@ packages:
       version: '0.9.10'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1108,12 +1184,16 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1139,7 +1219,7 @@ packages:
       version: '1.3'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1150,12 +1230,16 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
       - xorg-proto
       - libx11
       - libxtrans
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1180,7 +1264,7 @@ packages:
       version: '1.2.1'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1191,6 +1275,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -1199,6 +1286,7 @@ packages:
       - libxtrans
       - libsm
       - libice
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1221,10 +1309,14 @@ packages:
     from_source: libxtrans
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - xorg-util-macros
       - xorg-proto
       - libxcb
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1249,7 +1341,7 @@ packages:
       version: '1.2.3'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1260,6 +1352,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -1268,6 +1363,7 @@ packages:
       - libxtrans
       - libxext
       - libxi
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1292,7 +1388,7 @@ packages:
       version: '1.1.5'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1303,6 +1399,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -1310,6 +1409,7 @@ packages:
       - libx11
       - libxtrans
       - libxext
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1335,7 +1435,7 @@ packages:
       version: '1.1.4'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1346,6 +1446,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -1353,6 +1456,7 @@ packages:
       - libx11
       - libxtrans
       - libxext
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1457,7 +1561,7 @@ packages:
       version: '0.4.0'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
         - host-xorg-macros
@@ -1469,6 +1573,9 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
     pkgs_required:
       - mlibc
       - xorg-util-macros
@@ -1476,6 +1583,7 @@ packages:
       - libx11
       - libxtrans
       - libxcb
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'


### PR DESCRIPTION
The Vinix team found several issues with our X libraries involving accidental linkage to libraries from the host. They fixed that problem for themselves and alerted us to it, I've backported their fix so that we're no longer affected by it as well.