### PR TITLE
Add a basic browser

### DIFF
--- a/bootstrap.d/www-client.yml
+++ b/bootstrap.d/www-client.yml
@@ -1,0 +1,53 @@
+packages:
+  - name: links
+    source:
+      subdir: 'ports'
+      url: 'http://links.twibright.com/download/links-2.25.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'links-2.25'
+      version: '2.25'
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: x86_64-managarm
+    pkgs_required:
+      - mlibc
+      - zlib
+      - openssl
+      - bzip2
+      - libpng
+      - zstd
+      - libxext
+      - freetype
+      - fontconfig
+      - libjpeg-turbo
+      - xz-utils
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--mandir=/usr/share/man'
+        - '--enable-graphics'
+        - '--without-directfb'
+        - '--without-librsvg'
+        - '--with-bzip2'
+        - '--with-X'
+        - '--with-zlib'
+        - '--with-zstd'
+        - '--with-openssl'
+        - '--with-libjpeg'
+        - '--without-libtiff'
+        - '--without-openmp'
+        - '--with-lzma'
+        - '--with-freetype'
+        - '--without-ipv6'
+        environ:
+          # Configure doesn't set CC correctly and assumes gcc unless manually overridden.
+          CC: 'x86_64-managarm-gcc'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -25,6 +25,7 @@ imports:
   - file: bootstrap.d/sys-boot.yml
   - file: bootstrap.d/sys-devel.yml
   - file: bootstrap.d/sys-libs.yml
+  - file: bootstrap.d/www-client.yml
   - file: bootstrap.d/x11-apps.yml
   - file: bootstrap.d/x11-base.yml
   - file: bootstrap.d/x11-libs.yml


### PR DESCRIPTION
This PR adds a port of `links`, a basic webbrowser with a terminal and a GUI mode. As far as I tested, I found nothing that was broken and to my knowledge it needs no additions to mlibc or source code hacks. Launch it either as `links` for the terminal mode or `links -g` for the graphical mode. Escape to bring up the menu, which can be controlled with the arrow keys and contains a small but helpful section on how to control the browser.