### PR TITLE
rust: upgrade to 1.57.0

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -21,8 +21,8 @@ sources:
   - name: rust
     subdir: 'ports'
     git: 'https://github.com/rust-lang/rust.git'
-    tag: '1.51.0'
-    version: '1.51.0'
+    tag: '1.57.0'
+    version: '1.57.0'
 
   - name: host-bootstrap-cargo
     subdir: 'ports'
@@ -48,7 +48,7 @@ tools:
   - name: host-rust
     from_source: rust
     sources_required:
-      - rust-libc
+      - rust-patched-libs
     tools_required:
       - host-llvm-toolchain
       - host-python
@@ -71,6 +71,7 @@ tools:
 
             [rust]
             codegen-tests = false
+            deny-warnings = false # work around rust-num-cpus warning
 
             [target.x86_64-unknown-linux-gnu]
             llvm-config = "@BUILD_ROOT@/tools/host-llvm-toolchain/bin/llvm-config"

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -2,8 +2,8 @@ sources:
   - name: rust-libc
     subdir: 'ports'
     git: 'https://github.com/rust-lang/libc.git'
-    tag: '0.2.93'
-    version: '0.2.93'
+    tag: '0.2.117'
+    version: '0.2.117'
 
   - name: rust-num-cpus
     subdir: 'ports'
@@ -17,6 +17,12 @@ sources:
     tag: 'v0.11.0'
     version: '0.11.0'
 
+  - name: rust-backtrace
+    subdir: 'ports'
+    git: 'https://github.com/rust-lang/backtrace-rs.git'
+    tag: '0.3.64'
+    version: '0.3.64'
+
   - name: rust-patched-libs
     subdir: 'ports'
     sources_required:
@@ -25,6 +31,8 @@ sources:
       - name: rust-num-cpus
         recursive: true
       - name: rust-users
+        recursive: true
+      - name: rust-backtrace
         recursive: true
 
 packages:

--- a/extrafiles/config.toml
+++ b/extrafiles/config.toml
@@ -1,6 +1,3 @@
-[unstable]
-patch-in-config = true
-
 [build]
 rustc = "@BUILD_ROOT@/tools/host-rust/bin/rustc"
 target = "x86_64-unknown-managarm-system"
@@ -12,3 +9,4 @@ linker = "@BUILD_ROOT@/tools/system-gcc/bin/x86_64-managarm-gcc"
 libc = { path = "@SOURCE_ROOT@/ports/rust-libc" }
 num_cpus = { path = "@SOURCE_ROOT@/ports/rust-num-cpus" }
 users = { path = "@SOURCE_ROOT@/ports/rust-users" }
+backtrace = { path = "@SOURCE_ROOT@/ports/rust-backtrace" }

--- a/extrafiles/config.toml
+++ b/extrafiles/config.toml
@@ -1,3 +1,6 @@
+[unstable]
+patch-in-config = true
+
 [build]
 rustc = "@BUILD_ROOT@/tools/host-rust/bin/rustc"
 target = "x86_64-unknown-managarm-system"

--- a/patches/rust-backtrace/0001-managarm-use-dl_iterate_phdr.patch
+++ b/patches/rust-backtrace/0001-managarm-use-dl_iterate_phdr.patch
@@ -1,0 +1,32 @@
+From 53f9681c247e1ff4d868f7a217ad8d3028a767f5 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 14 Feb 2022 01:31:01 +0000
+Subject: [PATCH] managarm: use dl_iterate_phdr
+
+---
+ src/symbolize/gimli.rs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/symbolize/gimli.rs b/src/symbolize/gimli.rs
+index a9495cc..3d752d7 100644
+--- a/src/symbolize/gimli.rs
++++ b/src/symbolize/gimli.rs
+@@ -41,6 +41,7 @@ cfg_if::cfg_if! {
+         target_os = "openbsd",
+         target_os = "solaris",
+         target_os = "illumos",
++        target_os = "managarm",
+     ))] {
+         #[path = "gimli/mmap_unix.rs"]
+         mod mmap;
+@@ -175,6 +176,7 @@ cfg_if::cfg_if! {
+     } else if #[cfg(all(
+         any(
+             target_os = "linux",
++            target_os = "managarm",
+             target_os = "fuchsia",
+             target_os = "freebsd",
+             target_os = "openbsd",
+-- 
+2.35.1
+

--- a/patches/rust-libc/0001-managarm-initial-port.patch
+++ b/patches/rust-libc/0001-managarm-initial-port.patch
@@ -1,7 +1,7 @@
-From 6946817a03e47b6f14449041f29670c344ac4e5f Mon Sep 17 00:00:00 2001
+From f953a4fb413e50afaaa83e2fa867ead4c5ec5360 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Thu, 8 Apr 2021 22:08:55 +0100
-Subject: [PATCH 1/2] managarm: initial port
+Subject: [PATCH 1/3] managarm: initial port
 
 ---
  src/unix/mlibc/mod.rs | 547 ++++++++++++++++++++++++++++++++++++++++++
@@ -563,10 +563,10 @@ index 0000000..51b9ee9
 +    pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
 +}
 diff --git a/src/unix/mod.rs b/src/unix/mod.rs
-index be7b6e7..b7c67bb 100644
+index 5ff2294..7e6e68b 100644
 --- a/src/unix/mod.rs
 +++ b/src/unix/mod.rs
-@@ -1459,6 +1459,9 @@ cfg_if! {
+@@ -1475,6 +1475,9 @@ cfg_if! {
      } else if #[cfg(target_os = "redox")] {
          mod redox;
          pub use self::redox::*;
@@ -577,5 +577,5 @@ index be7b6e7..b7c67bb 100644
          // Unknown target_os
      }
 -- 
-2.31.1
+2.35.1
 

--- a/patches/rust-libc/0002-managarm-Add-missing-glue-for-memmap-num_cpus-and-us.patch
+++ b/patches/rust-libc/0002-managarm-Add-missing-glue-for-memmap-num_cpus-and-us.patch
@@ -1,7 +1,7 @@
-From 07284dd588cf5dfa11ea03ac384c457bb0261126 Mon Sep 17 00:00:00 2001
+From bc6fe0bd98c7df373acb777072ce8da7499553ba Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Sat, 8 May 2021 19:33:53 +0100
-Subject: [PATCH 2/2] managarm: Add missing glue for memmap, num_cpus and users
+Subject: [PATCH 2/3] managarm: Add missing glue for memmap, num_cpus and users
 
 ---
  src/unix/mlibc/mod.rs | 110 +++++++++++++++++++++++++++++++-----------
@@ -200,5 +200,5 @@ index 51b9ee9..f374aa1 100644
      pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
  }
 -- 
-2.31.1
+2.35.1
 

--- a/patches/rust-libc/0003-managarm-misc-additions-plus-dl_iterate_phdr.patch
+++ b/patches/rust-libc/0003-managarm-misc-additions-plus-dl_iterate_phdr.patch
@@ -1,0 +1,340 @@
+From d4a58699c6c35bd9133dcfc067091cb8d948d162 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 14 Feb 2022 01:29:54 +0000
+Subject: [PATCH 3/3] managarm: misc additions plus dl_iterate_phdr
+
+---
+ src/unix/mlibc/mod.rs | 194 +++++++++++++++++++++++++++++++++++-------
+ 1 file changed, 165 insertions(+), 29 deletions(-)
+
+diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
+index f374aa1..cd7e4dd 100644
+--- a/src/unix/mlibc/mod.rs
++++ b/src/unix/mlibc/mod.rs
+@@ -19,7 +19,7 @@ pub type socklen_t = ::c_ulong;
+ // options/internal/include/bits/off_t.h
+ pub type off_t = ::c_long;
+ 
+-// abis/mlibc/vm-flags.h 
++// abis/mlibc/vm-flags.h
+ pub const MAP_ANON: ::c_int = 8;
+ pub const MAP_PRIVATE: ::c_int = 1;
+ pub const MAP_SHARED: ::c_int = 2;
+@@ -61,6 +61,12 @@ pub type time_t = ::c_long;
+ // options/posix/include/bits/posix/suseconds_t.h
+ pub type suseconds_t = ::c_long;
+ 
++// abis/mlibc/uid_t.h
++pub type uid_t = ::c_uint;
++
++// abis/mlibc/gid_t.h
++pub type gid_t = ::c_uint;
++
+ // abis/mlibc/dev_t.h
+ pub type dev_t = ::c_ulong;
+ 
+@@ -71,17 +77,61 @@ pub type fsblkcnt_t = ::c_uint;
+ pub type fsfilcnt_t = ::c_uint;
+ 
+ // abis/mlibc/signal.h
++pub const SIGHUP: ::c_int = 1;
++pub const SIGINT: ::c_int = 2;
++pub const SIGQUIT: ::c_int = 3;
++pub const SIGILL: ::c_int = 4;
++pub const SIGTRAP: ::c_int = 5;
++pub const SIGABRT: ::c_int = 6;
++pub const SIGBUS: ::c_int = 7;
++pub const SIGFPE: ::c_int = 8;
+ pub const SIGKILL: ::c_int = 9;
++pub const SIGUSR1: ::c_int = 10;
++pub const SIGSEGV: ::c_int = 11;
++pub const SIGUSR2: ::c_int = 12;
+ pub const SIGPIPE: ::c_int = 13;
++pub const SIGALRM: ::c_int = 14;
++pub const SIGTERM: ::c_int = 15;
++pub const SIGSTKFLT: ::c_int = 16;
++pub const SIGCHLD: ::c_int = 17;
++pub const SIGCONT: ::c_int = 18;
++pub const SIGSTOP: ::c_int = 19;
++pub const SIGTSTP: ::c_int = 20;
++pub const SIGTTIN: ::c_int = 21;
++pub const SIGTTOU: ::c_int = 22;
++pub const SIGURG: ::c_int = 23;
++pub const SIGXCPU: ::c_int = 24;
++pub const SIGXFSZ: ::c_int = 25;
++pub const SIGVTALRM: ::c_int = 26;
++pub const SIGPROF: ::c_int = 27;
++pub const SIGWINCH: ::c_int = 28;
++pub const SIGIO: ::c_int = 29;
++pub const SIGPOLL: ::c_int = SIGIO;
++pub const SIGPWR: ::c_int = 30;
++pub const SIGSYS: ::c_int = 31;
++pub const SIGRTMIN: ::c_int = 32;
++pub const SIGRTMAX: ::c_int = 33;
++pub const SIGCANCEL: ::c_int = 34;
++
+ pub const SIG_SETMASK: ::c_int = 3;
++
++
++pub const SA_NOCLDSTOP: ::c_int = 1 << 0;
++pub const SA_ONSTACK: ::c_int = 1 << 1;
++pub const SA_RESETHAND: ::c_int = 1 << 2;
++pub const SA_RESTART: ::c_int = 1 << 3;
++pub const SA_SIGINFO: ::c_int = 1 << 4;
++pub const SA_NOCLDWAIT: ::c_int = 1 << 5;
++pub const SA_NODEFER: ::c_int = 1 << 6;
++
+ pub type sigset_t = ::c_long;
+ s! {
+     pub struct siginfo_t {
+         pub si_signo: ::c_int,
+         pub si_code: ::c_int,
+         pub si_errno: ::c_int,
+-        pub si_pid: ::pid_t,
+-        pub si_uid: ::uid_t,
++        pub si_pid: pid_t,
++        pub si_uid: uid_t,
+         pub si_addr: *mut ::c_void,
+         pub si_status: ::c_int,
+         pub si_value: sigval,
+@@ -93,9 +143,8 @@ s! {
+         pub sa_sigaction: ::Option<extern fn(::c_int, *mut siginfo_t, *mut ::c_void)>,
+     }
+ }
+-s_no_extra_traits! {
+-    pub union sigval {
+-        pub sival_int: ::c_int,
++s! {
++    pub struct sigval {
+         pub sival_ptr: *mut ::c_void,
+     }
+ }
+@@ -120,6 +169,13 @@ s! {
+ // options/posix/include/termios.h
+ pub const TIOCGWINSZ: ::c_ulong = 0x5413;
+ 
++pub const CSTOPB: ::c_int = 0x0004;
++pub const CREAD: ::c_int = 0x0008;
++pub const PARENB: ::c_int = 0x0010;
++pub const PARODD: ::c_int = 0x0020;
++pub const HUPCL: ::c_int = 0x0040;
++pub const CLOCAL: ::c_int = 0x0080;
++
+ // abis/mlibc/ino_t.h
+ pub type ino_t = ::c_long;
+ 
+@@ -132,6 +188,9 @@ pub type blkcnt_t = ::c_long;
+ // abis/mlibc/nlink_t.h
+ pub type nlink_t = ::c_int;
+ 
++// abis/mlibc/pid_t.h
++pub type pid_t = ::c_int;
++
+ // options/posix/include/bits/posix/in_addr_t.h
+ pub type in_addr_t = u32;
+ 
+@@ -176,11 +235,29 @@ pub const SHUT_WR: ::c_int = 3;
+ pub const SOCK_DGRAM: ::c_int = 1;
+ pub const SOCK_STREAM: ::c_int = 4;
+ pub const SOL_SOCKET: ::c_int = 1;
+-pub const SO_BROADCAST: ::c_int = 6;
++
++pub const SO_ACCEPTCONN: ::c_int = 1;
++pub const SO_BROADCAST: ::c_int = 2;
++pub const SO_DEBUG: ::c_int = 3;
++pub const SO_DONTROUTE: ::c_int = 4;
+ pub const SO_ERROR: ::c_int = 5;
++pub const SO_KEEPALIVE: ::c_int = 6;
++pub const SO_LINGER: ::c_int = 7;
++pub const SO_OOBINLINE: ::c_int = 8;
++pub const SO_RCVBUF: ::c_int = 9;
++pub const SO_RCVLOWAT: ::c_int = 10;
+ pub const SO_RCVTIMEO: ::c_int = 11;
+ pub const SO_REUSEADDR: ::c_int = 12;
++pub const SO_SNDBUF: ::c_int = 13;
++pub const SO_SNDLOWAT: ::c_int = 14;
+ pub const SO_SNDTIMEO: ::c_int = 15;
++pub const SO_TYPE: ::c_int = 16;
++pub const SO_SNDBUFFORCE: ::c_int = 17;
++pub const SO_PEERCRED: ::c_int = 18;
++pub const SO_ATTACH_FILTER: ::c_int = 19;
++pub const SO_PASSCRED: ::c_int = 20;
++pub const SO_RCVBUFFORCE: ::c_int = 21;
++
+ pub type sa_family_t = ::c_uint;
+ s! {
+     pub struct sockaddr_storage {
+@@ -190,27 +267,47 @@ s! {
+ }
+ 
+ // abis/mlibc/errno.h
++pub const E2BIG: ::c_int = 1001;
+ pub const EACCES: ::c_int = 1002;
+ pub const EADDRINUSE: ::c_int = 1003;
+ pub const EADDRNOTAVAIL: ::c_int = 1004;
+ pub const EAGAIN: ::c_int = 1006;
+ pub const EBADF: ::c_int = 1008;
++pub const EBUSY: ::c_int = 1010;
+ pub const ECONNABORTED: ::c_int = 1013;
+ pub const ECONNREFUSED: ::c_int = 1014;
+ pub const ECONNRESET: ::c_int = 1015;
+ pub const EDEADLK: ::c_int = 1016;
++pub const EDQUOT: ::c_int = 1018;
+ pub const EEXIST: ::c_int = 1019;
++pub const EFBIG: ::c_int = 1021;
++pub const EHOSTUNREACH: ::c_int = 1022;
+ pub const EINPROGRESS: ::c_int = 1024;
+ pub const EINTR: ::c_int = 1025;
+ pub const EINVAL: ::c_int = 1026;
++pub const EISDIR: ::c_int = 1029;
++pub const ELOOP: ::c_int = 1030;
++pub const EMLINK: ::c_int = 1032;
++pub const ENAMETOOLONG: ::c_int = 1036;
++pub const ENETDOWN: ::c_int = 1037;
++pub const ENETUNREACH: ::c_int = 1039;
+ pub const ENOENT: ::c_int = 1043;
++pub const ENOMEM: ::c_int = 1047;
++pub const ENOSPC: ::c_int = 1050;
+ pub const ENOSYS: ::c_int = 1051;
+ pub const ENOTCONN: ::c_int = 1052;
++pub const ENOTDIR: ::c_int = 1053;
++pub const ENOTEMPTY: ::c_int = 1054;
+ pub const EPERM: ::c_int = 1063;
+ pub const EPIPE: ::c_int = 1064;
+ pub const ERANGE: ::c_int = 3;
++pub const EROFS: ::c_int = 1068;
++pub const ESPIPE: ::c_int = 1069;
++pub const ESTALE: ::c_int = 1071;
+ pub const ETIMEDOUT: ::c_int = 1072;
++pub const ETXTBSY: ::c_int = 1073;
+ pub const EWOULDBLOCK: ::c_int = EAGAIN;
++pub const EXDEV: ::c_int = 1075;
+ 
+ // options/posix/include/fcntl.h
+ pub const AT_FDCWD: ::c_int = -100;
+@@ -259,22 +356,22 @@ pub const S_IXOTH: mode_t = 0o1;
+ pub const S_IXUSR: mode_t = 0o100;
+ s! {
+     pub struct stat {
+-        pub st_dev: ::dev_t,
+-        pub st_ino: ::ino_t,
+-        pub st_mode: ::mode_t,
+-        pub st_nlink: ::nlink_t,
+-        pub st_uid: ::uid_t,
+-        pub st_gid: ::gid_t,
+-        pub st_rdev: ::dev_t,
+-        pub st_size: ::off_t,
+-        pub st_atime: ::time_t,
+-        pub st_atime_nsec: ::c_long,
+-        pub st_mtime: ::time_t,
+-        pub st_mtime_nsec: ::c_long,
+-        pub st_ctime: ::time_t,
+-        pub st_ctime_nsec: ::c_long,
+-        pub st_blksize: ::blksize_t,
+-        pub st_blocks: ::blkcnt_t,
++        pub st_dev: dev_t,
++        pub st_ino: ino_t,
++        pub st_mode: mode_t,
++        pub st_nlink: nlink_t,
++        pub st_uid: uid_t,
++        pub st_gid: gid_t,
++        pub st_rdev: dev_t,
++        pub st_size: off_t,
++        pub st_atime: time_t,
++        pub st_atime_nsec: c_long,
++        pub st_mtime: time_t,
++        pub st_mtime_nsec: c_long,
++        pub st_ctime: time_t,
++        pub st_ctime_nsec: c_long,
++        pub st_blksize: blksize_t,
++        pub st_blocks: blkcnt_t,
+     }
+ }
+ 
+@@ -323,13 +420,43 @@ pub const FIONBIO: ::c_ulong = 0x5421;
+ // options/ansi/include/limits.h
+ pub const PTHREAD_STACK_MIN: ::size_t = 16384;
+ 
++// options/elf/include/link.h
++pub type Elf64_Half = u16;
++pub type Elf64_Word = u32;
++pub type Elf64_Off = u64;
++pub type Elf64_Addr = u64;
++pub type Elf64_Xword = u64;
++s! {
++    pub struct dl_phdr_info {
++        pub dlpi_addr: Elf64_Addr,
++        pub dlpi_name: *const ::c_char,
++        pub dlpi_phdr: *const Elf64_Phdr,
++        pub dlpi_phnum: Elf64_Half,
++        pub dlpi_adds: ::c_ulonglong,
++        pub dlpi_subs: ::c_ulonglong,
++        pub dlpi_tls_modid: ::size_t,
++        pub dlpi_tls_data: *mut ::c_void,
++    }
++
++    pub struct Elf64_Phdr {
++        pub p_type: Elf64_Word,
++        pub p_flags: Elf64_Word,
++        pub p_offset: Elf64_Off,
++        pub p_vaddr: Elf64_Addr,
++        pub p_paddr: Elf64_Addr,
++        pub p_filesz: Elf64_Xword,
++        pub p_memsz: Elf64_Xword,
++        pub p_align: Elf64_Xword,
++    }
++}
++
+ // options/posix/include/pwd.h
+ s! {
+     pub struct passwd {
+         pub pw_name: *mut ::c_char,
+         pub pw_passwd: *mut ::c_char,
+-        pub pw_uid: ::uid_t,
+-        pub pw_gid: ::gid_t,
++        pub pw_uid: uid_t,
++        pub pw_gid: gid_t,
+         pub pw_gecos: *mut ::c_char,
+         pub pw_dir: *mut ::c_char,
+         pub pw_shell: *mut ::c_char,
+@@ -522,9 +649,8 @@ s! {
+ }
+ 
+ // options/posix/include/bits/posix/fd_set.h
+-s_no_extra_traits! {
+-    pub union fd_set {
+-        pub __mlibc_elems: [c_char; 128],
++s! {
++    pub struct fd_set {
+         pub fds_bits: [c_char; 128],
+     }
+ }
+@@ -533,6 +659,16 @@ extern "C" {
+     pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
+     pub fn clock_gettime(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
+     pub fn clock_settime(clk_id: clockid_t, tp: *const ::timespec) -> ::c_int;
++    pub fn dl_iterate_phdr(
++        callback: ::Option<
++            unsafe extern "C" fn(
++                info: *mut ::dl_phdr_info,
++                size: ::size_t,
++                data: *mut ::c_void,
++            ) -> ::c_int,
++        >,
++        data: *mut ::c_void,
++    ) -> ::c_int;
+     pub fn endpwent();
+     pub fn getpwent() -> *mut passwd;
+     pub fn getgrgid_r(
+@@ -563,7 +699,7 @@ extern "C" {
+         result: *mut *mut passwd,
+     ) -> ::c_int;
+     pub fn getpwuid_r(
+-        uid: ::uid_t,
++        uid: uid_t,
+         pwd: *mut passwd,
+         buf: *mut ::c_char,
+         buflen: ::size_t,
+-- 
+2.35.1
+

--- a/patches/rust/0001-managarm-initial-port.patch
+++ b/patches/rust/0001-managarm-initial-port.patch
@@ -1,10 +1,9 @@
-From 4036157782a6d630d1c0605925d9029b7372ee9f Mon Sep 17 00:00:00 2001
+From fdc4f49530f22009b0a18fbfc5187da772d8f7c3 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Sat, 10 Apr 2021 17:53:24 +0100
-Subject: [PATCH 1/2] managarm: initial port
+Subject: [PATCH 1/3] managarm: initial port
 
 ---
- Cargo.lock                                    |   4 +-
  Cargo.toml                                    |   1 +
  .../src/spec/managarm_system_base.rs          |  35 +++++
  compiler/rustc_target/src/spec/mod.rs         |   3 +
@@ -16,40 +15,24 @@ Subject: [PATCH 1/2] managarm: initial port
  library/std/src/os/mod.rs                     |   2 +
  library/std/src/sys/unix/args.rs              |   3 +-
  library/std/src/sys/unix/env.rs               |  11 ++
- library/std/src/sys/unix/fs.rs                |   6 +-
- library/std/src/sys/unix/mod.rs               |   2 +
+ library/std/src/sys/unix/fs.rs                |   2 +
  library/std/src/sys/unix/os.rs                |  34 +++-
  library/std/src/sys/unix/thread.rs            |   7 +
  library/std/src/sys/unix/thread_local_dtor.rs |   3 +-
  library/std/src/sys/unix/time.rs              |   7 +-
  library/unwind/build.rs                       |   2 +
- 19 files changed, 344 insertions(+), 16 deletions(-)
+ 17 files changed, 339 insertions(+), 11 deletions(-)
  create mode 100644 compiler/rustc_target/src/spec/managarm_system_base.rs
  create mode 100644 compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
  create mode 100644 library/std/src/os/managarm/fs.rs
  create mode 100644 library/std/src/os/managarm/mod.rs
  create mode 100644 library/std/src/os/managarm/raw.rs
 
-diff --git a/Cargo.lock b/Cargo.lock
-index 2b68f725..4eaf3ca4 100644
---- a/Cargo.lock
-+++ b/Cargo.lock
-@@ -1839,9 +1839,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
- 
- [[package]]
- name = "libc"
--version = "0.2.85"
--source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
-+version = "0.2.93"
- dependencies = [
-  "rustc-std-workspace-core",
- ]
 diff --git a/Cargo.toml b/Cargo.toml
-index f961d3e9..9b7a31f9 100644
+index 8d6afd2b..1b4c23d2 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -105,6 +105,7 @@ rustc-workspace-hack = { path = 'src/tools/rustc-workspace-hack' }
+@@ -123,6 +123,7 @@ rustc-workspace-hack = { path = 'src/tools/rustc-workspace-hack' }
  rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
  rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
  rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
@@ -99,10 +82,10 @@ index 00000000..08b7d8a8
 +    }
 +}
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 7a93bac7..75e38b62 100644
+index ff5dfa3f..f1439c3b 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -60,6 +60,7 @@
+@@ -61,6 +61,7 @@
  mod freebsd_base;
  mod fuchsia_base;
  mod haiku_base;
@@ -110,7 +93,7 @@ index 7a93bac7..75e38b62 100644
  mod hermit_base;
  mod hermit_kernel_base;
  mod illumos_base;
-@@ -706,6 +707,8 @@ fn to_json(&self) -> Json {
+@@ -831,6 +832,8 @@ fn $module() {
      ("i686-unknown-haiku", i686_unknown_haiku),
      ("x86_64-unknown-haiku", x86_64_unknown_haiku),
  
@@ -145,7 +128,7 @@ index 00000000..7c16ed9b
 +    }
 +}
 diff --git a/library/std/build.rs b/library/std/build.rs
-index a14ac63c..de7f9fc4 100644
+index cc7184d5..666aae4e 100644
 --- a/library/std/build.rs
 +++ b/library/std/build.rs
 @@ -23,6 +23,7 @@ fn main() {
@@ -395,10 +378,10 @@ index 00000000..5124020d
 +    pub st_blocks: libc::blkcnt_t, 
 +}
 diff --git a/library/std/src/os/mod.rs b/library/std/src/os/mod.rs
-index fd6ee088..d6adf1d9 100644
+index 90c30313..ebb3ec7b 100644
 --- a/library/std/src/os/mod.rs
 +++ b/library/std/src/os/mod.rs
-@@ -58,6 +58,8 @@
+@@ -129,6 +129,8 @@ pub mod windows {}
  pub mod ios;
  #[cfg(target_os = "macos")]
  pub mod macos;
@@ -408,10 +391,10 @@ index fd6ee088..d6adf1d9 100644
  pub mod netbsd;
  #[cfg(target_os = "openbsd")]
 diff --git a/library/std/src/sys/unix/args.rs b/library/std/src/sys/unix/args.rs
-index 69676472..898aa0e3 100644
+index ee5e3983..bd59fb3a 100644
 --- a/library/std/src/sys/unix/args.rs
 +++ b/library/std/src/sys/unix/args.rs
-@@ -71,7 +71,8 @@ fn next_back(&mut self) -> Option<OsString> {
+@@ -68,7 +68,8 @@ fn next_back(&mut self) -> Option<OsString> {
      target_os = "l4re",
      target_os = "fuchsia",
      target_os = "redox",
@@ -422,10 +405,10 @@ index 69676472..898aa0e3 100644
  mod imp {
      use super::Args;
 diff --git a/library/std/src/sys/unix/env.rs b/library/std/src/sys/unix/env.rs
-index 7f5e9b04..dd976565 100644
+index 60551aeb..f9b5322b 100644
 --- a/library/std/src/sys/unix/env.rs
 +++ b/library/std/src/sys/unix/env.rs
-@@ -173,3 +173,14 @@ pub mod os {
+@@ -195,3 +195,14 @@ pub mod os {
      pub const EXE_SUFFIX: &str = "";
      pub const EXE_EXTENSION: &str = "";
  }
@@ -441,47 +424,30 @@ index 7f5e9b04..dd976565 100644
 +    pub const EXE_EXTENSION: &str = "";
 +}
 diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
-index d1b0ad9e..a9ba3a30 100644
+index a4fff9b2..e9b4310e 100644
 --- a/library/std/src/sys/unix/fs.rs
 +++ b/library/std/src/sys/unix/fs.rs
-@@ -594,7 +594,8 @@ pub fn file_type(&self) -> io::Result<FileType> {
-         target_os = "l4re",
-         target_os = "fuchsia",
+@@ -613,6 +613,7 @@ pub fn file_type(&self) -> io::Result<FileType> {
          target_os = "redox",
--        target_os = "vxworks"
-+        target_os = "vxworks",
+         target_os = "vxworks",
+         target_os = "espidf"
 +        target_os = "managarm"
      ))]
      pub fn ino(&self) -> u64 {
          self.entry.d_ino as u64
-@@ -633,7 +634,8 @@ fn name_bytes(&self) -> &[u8] {
-         target_os = "emscripten",
-         target_os = "l4re",
+@@ -653,6 +654,7 @@ fn name_bytes(&self) -> &[u8] {
          target_os = "haiku",
--        target_os = "vxworks"
-+        target_os = "vxworks",
+         target_os = "vxworks",
+         target_os = "espidf"
 +        target_os = "managarm"
      ))]
      fn name_bytes(&self) -> &[u8] {
          unsafe { CStr::from_ptr(self.entry.d_name.as_ptr()).to_bytes() }
-diff --git a/library/std/src/sys/unix/mod.rs b/library/std/src/sys/unix/mod.rs
-index f8a5ee89..b48ef812 100644
---- a/library/std/src/sys/unix/mod.rs
-+++ b/library/std/src/sys/unix/mod.rs
-@@ -25,6 +25,8 @@
- pub use crate::os::linux as platform;
- #[cfg(all(not(doc), target_os = "macos"))]
- pub use crate::os::macos as platform;
-+#[cfg(all(not(doc), target_os = "managarm"))]
-+pub use crate::os::managarm as platform;
- #[cfg(all(not(doc), target_os = "netbsd"))]
- pub use crate::os::netbsd as platform;
- #[cfg(all(not(doc), target_os = "openbsd"))]
 diff --git a/library/std/src/sys/unix/os.rs b/library/std/src/sys/unix/os.rs
-index d5e14bec..a3f4f5c0 100644
+index 87893d26..68adcb10 100644
 --- a/library/std/src/sys/unix/os.rs
 +++ b/library/std/src/sys/unix/os.rs
-@@ -37,7 +37,7 @@
+@@ -39,7 +39,7 @@
  }
  
  extern "C" {
@@ -490,7 +456,7 @@ index d5e14bec..a3f4f5c0 100644
      #[cfg_attr(
          any(
              target_os = "linux",
-@@ -67,13 +67,13 @@
+@@ -69,13 +69,13 @@
  }
  
  /// Returns the platform-specific value of errno
@@ -506,7 +472,7 @@ index d5e14bec..a3f4f5c0 100644
  #[allow(dead_code)] // but not all target cfgs actually end up using it
  pub fn set_errno(e: i32) {
      unsafe { *errno_location() = e as c_int }
-@@ -111,6 +111,29 @@ pub fn set_errno(e: i32) {
+@@ -108,6 +108,29 @@ pub fn set_errno(e: i32) {
      }
  }
  
@@ -536,7 +502,7 @@ index d5e14bec..a3f4f5c0 100644
  /// Gets a detailed string description for the given error number.
  pub fn error_string(errno: i32) -> String {
      extern "C" {
-@@ -350,6 +373,11 @@ pub fn current_exe() -> io::Result<PathBuf> {
+@@ -360,6 +383,11 @@ pub fn current_exe() -> io::Result<PathBuf> {
      }
  }
  
@@ -547,12 +513,12 @@ index d5e14bec..a3f4f5c0 100644
 +
  #[cfg(any(target_os = "macos", target_os = "ios"))]
  pub fn current_exe() -> io::Result<PathBuf> {
-     extern "C" {
+     unsafe {
 diff --git a/library/std/src/sys/unix/thread.rs b/library/std/src/sys/unix/thread.rs
-index cda17eb4..fa977f57 100644
+index 6f486305..245b8805 100644
 --- a/library/std/src/sys/unix/thread.rs
 +++ b/library/std/src/sys/unix/thread.rs
-@@ -103,6 +103,13 @@ pub fn set_name(name: &CStr) {
+@@ -138,6 +138,13 @@ pub fn set_name(name: &CStr) {
          }
      }
  
@@ -567,7 +533,7 @@ index cda17eb4..fa977f57 100644
      pub fn set_name(name: &CStr) {
          use crate::ffi::CString;
 diff --git a/library/std/src/sys/unix/thread_local_dtor.rs b/library/std/src/sys/unix/thread_local_dtor.rs
-index c3275eb6..7ffeaea3 100644
+index c3f41035..df3d08dc 100644
 --- a/library/std/src/sys/unix/thread_local_dtor.rs
 +++ b/library/std/src/sys/unix/thread_local_dtor.rs
 @@ -15,7 +15,8 @@
@@ -581,16 +547,16 @@ index c3275eb6..7ffeaea3 100644
  pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
      use crate::mem;
 diff --git a/library/std/src/sys/unix/time.rs b/library/std/src/sys/unix/time.rs
-index 23a5c81c..4170857d 100644
+index 824283ef..de405297 100644
 --- a/library/std/src/sys/unix/time.rs
 +++ b/library/std/src/sys/unix/time.rs
-@@ -361,12 +361,7 @@ fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+@@ -362,12 +362,7 @@ fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
          }
      }
  
--    #[cfg(not(target_os = "dragonfly"))]
+-    #[cfg(not(any(target_os = "dragonfly", target_os = "espidf")))]
 -    pub type clock_t = libc::c_int;
--    #[cfg(target_os = "dragonfly")]
+-    #[cfg(any(target_os = "dragonfly", target_os = "espidf"))]
 -    pub type clock_t = libc::c_ulong;
 -
 -    fn now(clock: clock_t) -> Timespec {
@@ -599,10 +565,10 @@ index 23a5c81c..4170857d 100644
          cvt(unsafe { libc::clock_gettime(clock, &mut t.t) }).unwrap();
          t
 diff --git a/library/unwind/build.rs b/library/unwind/build.rs
-index 694e6b98..8ab01ff6 100644
+index 1d0b4a59..dba57c26 100644
 --- a/library/unwind/build.rs
 +++ b/library/unwind/build.rs
-@@ -48,6 +48,8 @@ fn main() {
+@@ -43,5 +43,7 @@ fn main() {
          println!("cargo:rustc-link-lib=gcc_s");
      } else if target.contains("redox") {
          // redox is handled in lib.rs
@@ -610,7 +576,6 @@ index 694e6b98..8ab01ff6 100644
 +        println!("cargo:rustc-link-lib=gcc_s");
      }
  }
- 
 -- 
-2.31.1
+2.35.1
 

--- a/patches/rust/0002-managarm-fix-build-target-in-x.py-and-bootstrap.patch
+++ b/patches/rust/0002-managarm-fix-build-target-in-x.py-and-bootstrap.patch
@@ -1,18 +1,55 @@
-From ba9081c05d5cca4ecbd732563fd7b448d64b233e Mon Sep 17 00:00:00 2001
+From f5f7f9c127a46ca699b55e68cca654f3e605a165 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Mon, 31 May 2021 21:19:44 +0100
-Subject: [PATCH 2/2] managarm: fix build target in x.py and bootstrap
+Subject: [PATCH 2/3] managarm: fix build target in x.py and bootstrap
 
 ---
- src/bootstrap/bootstrap.py | 8 ++++++--
- src/bootstrap/builder.rs   | 6 ++++--
- 2 files changed, 10 insertions(+), 4 deletions(-)
+ compiler/rustc_target/src/spec/managarm_system_base.rs | 2 +-
+ library/std/src/sys/unix/fs.rs                         | 4 ++--
+ src/bootstrap/bootstrap.py                             | 8 ++++++--
+ src/bootstrap/builder.rs                               | 6 ++++--
+ 4 files changed, 13 insertions(+), 7 deletions(-)
 
+diff --git a/compiler/rustc_target/src/spec/managarm_system_base.rs b/compiler/rustc_target/src/spec/managarm_system_base.rs
+index 08b7d8a8..cec689f1 100644
+--- a/compiler/rustc_target/src/spec/managarm_system_base.rs
++++ b/compiler/rustc_target/src/spec/managarm_system_base.rs
+@@ -22,7 +22,7 @@ pub fn opts() -> TargetOptions {
+         os: "managarm".to_string(),
+         dynamic_linking: true,
+         executables: true,
+-        os_family: Some("unix".to_string()),
++        families: vec!["unix".to_string()],
+         linker_is_gnu: true,
+         has_rpath: true,
+         pre_link_args: args,
+diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
+index e9b4310e..9effc7c8 100644
+--- a/library/std/src/sys/unix/fs.rs
++++ b/library/std/src/sys/unix/fs.rs
+@@ -612,7 +612,7 @@ pub fn file_type(&self) -> io::Result<FileType> {
+         target_os = "fuchsia",
+         target_os = "redox",
+         target_os = "vxworks",
+-        target_os = "espidf"
++        target_os = "espidf",
+         target_os = "managarm"
+     ))]
+     pub fn ino(&self) -> u64 {
+@@ -653,7 +653,7 @@ fn name_bytes(&self) -> &[u8] {
+         target_os = "l4re",
+         target_os = "haiku",
+         target_os = "vxworks",
+-        target_os = "espidf"
++        target_os = "espidf",
+         target_os = "managarm"
+     ))]
+     fn name_bytes(&self) -> &[u8] {
 diff --git a/src/bootstrap/bootstrap.py b/src/bootstrap/bootstrap.py
-index 6708b27b..0a8a5c49 100644
+index 0170be96..5a93849a 100644
 --- a/src/bootstrap/bootstrap.py
 +++ b/src/bootstrap/bootstrap.py
-@@ -796,7 +796,7 @@ class RustBuild(object):
+@@ -910,7 +910,7 @@ class RustBuild(object):
          ... "debug", "bootstrap")
          True
          """
@@ -21,7 +58,7 @@ index 6708b27b..0a8a5c49 100644
  
      def build_bootstrap(self):
          """Build bootstrap"""
-@@ -804,7 +804,7 @@ class RustBuild(object):
+@@ -918,7 +918,7 @@ class RustBuild(object):
          if self.clean and os.path.exists(build_dir):
              shutil.rmtree(build_dir)
          env = os.environ.copy()
@@ -30,7 +67,7 @@ index 6708b27b..0a8a5c49 100644
          # See also: <https://github.com/rust-lang/rust/issues/70208>.
          if "CARGO_BUILD_TARGET" in env:
              del env["CARGO_BUILD_TARGET"]
-@@ -852,6 +852,10 @@ class RustBuild(object):
+@@ -965,6 +965,10 @@ class RustBuild(object):
              args.append("--locked")
          if self.use_vendored_sources:
              args.append("--frozen")
@@ -42,10 +79,10 @@ index 6708b27b..0a8a5c49 100644
  
      def build_triple(self):
 diff --git a/src/bootstrap/builder.rs b/src/bootstrap/builder.rs
-index f1a16025..c00cf4cd 100644
+index 6750f7a5..1f839cf5 100644
 --- a/src/bootstrap/builder.rs
 +++ b/src/bootstrap/builder.rs
-@@ -1023,6 +1023,8 @@ pub fn cargo(
+@@ -1092,6 +1092,8 @@ pub fn cargo(
              self.clear_if_dirty(&out_dir, &self.rustc(compiler));
          }
  
@@ -54,7 +91,7 @@ index f1a16025..c00cf4cd 100644
          // Customize the compiler we're running. Specify the compiler to cargo
          // as our shim and then pass it some various options used to configure
          // how the actual compiler itself is called.
-@@ -1035,7 +1037,7 @@ pub fn cargo(
+@@ -1104,7 +1106,7 @@ pub fn cargo(
              .env("RUSTC_STAGE", stage.to_string())
              .env("RUSTC_SYSROOT", &sysroot)
              .env("RUSTC_LIBDIR", &libdir)
@@ -63,7 +100,7 @@ index f1a16025..c00cf4cd 100644
              .env(
                  "RUSTDOC_REAL",
                  if cmd == "doc" || cmd == "rustdoc" || (cmd == "test" && want_rustdoc) {
-@@ -1049,7 +1051,7 @@ pub fn cargo(
+@@ -1118,7 +1120,7 @@ pub fn cargo(
          // Clippy support is a hack and uses the default `cargo-clippy` in path.
          // Don't override RUSTC so that the `cargo-clippy` in path will be run.
          if cmd != "clippy" {
@@ -73,5 +110,5 @@ index f1a16025..c00cf4cd 100644
  
          // Dealing with rpath here is a little special, so let's go into some
 -- 
-2.31.1
+2.35.1
 

--- a/patches/rust/0003-managarm-fixes-for-1.57.0.patch
+++ b/patches/rust/0003-managarm-fixes-for-1.57.0.patch
@@ -1,0 +1,126 @@
+From 8c82aabf5e95a88e8c2dbcc0567e4aa7d557dec8 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Sun, 13 Feb 2022 23:31:33 +0000
+Subject: [PATCH 3/3] managarm: fixes for 1.57.0
+
+---
+ Cargo.lock                         | 20 +++++++++++++++-----
+ library/std/Cargo.toml             |  2 +-
+ library/std/src/lib.rs             |  2 +-
+ library/std/src/os/managarm/fs.rs  |  2 +-
+ library/std/src/os/managarm/raw.rs |  8 ++++++++
+ library/std/src/os/unix/mod.rs     |  2 ++
+ 6 files changed, 28 insertions(+), 8 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index dce77450..f165a0be 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1880,9 +1880,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.103"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
++version = "0.2.117"
+ dependencies = [
+  "rustc-std-workspace-core",
+ ]
+@@ -2291,9 +2289,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "num_cpus"
+-version = "1.13.0"
++version = "1.13.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
++checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+ dependencies = [
+  "hermit-abi",
+  "libc",
+@@ -5792,3 +5790,15 @@ checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+ dependencies = [
+  "winapi",
+ ]
++
++[[patch.unused]]
++name = "backtrace"
++version = "0.3.64"
++
++[[patch.unused]]
++name = "num_cpus"
++version = "1.13.0"
++
++[[patch.unused]]
++name = "users"
++version = "0.11.0"
+diff --git a/library/std/Cargo.toml b/library/std/Cargo.toml
+index 6bc445c6..96f574ce 100644
+--- a/library/std/Cargo.toml
++++ b/library/std/Cargo.toml
+@@ -15,7 +15,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
+ panic_unwind = { path = "../panic_unwind", optional = true }
+ panic_abort = { path = "../panic_abort" }
+ core = { path = "../core" }
+-libc = { version = "0.2.103", default-features = false, features = ['rustc-dep-of-std'] }
++libc = { path = "../../../rust-libc", default-features = false, features = ['rustc-dep-of-std'] }
+ compiler_builtins = { version = "0.1.44" }
+ profiler_builtins = { path = "../profiler_builtins", optional = true }
+ unwind = { path = "../unwind" }
+diff --git a/library/std/src/lib.rs b/library/std/src/lib.rs
+index 1d2d26b8..48d385a2 100644
+--- a/library/std/src/lib.rs
++++ b/library/std/src/lib.rs
+@@ -545,7 +545,7 @@ pub mod task {
+ // Private support modules
+ mod panicking;
+ 
+-#[path = "../../backtrace/src/lib.rs"]
++#[path = "../../../../rust-backtrace/src/lib.rs"]
+ #[allow(dead_code, unused_attributes)]
+ mod backtrace_rs;
+ 
+diff --git a/library/std/src/os/managarm/fs.rs b/library/std/src/os/managarm/fs.rs
+index efd774d2..dd8f2955 100644
+--- a/library/std/src/os/managarm/fs.rs
++++ b/library/std/src/os/managarm/fs.rs
+@@ -1,4 +1,4 @@
+-#![stable(feature = "raw_ext", since = "1.1.0")]
++#![stable(feature = "metadata_ext", since = "1.1.0")]
+ 
+ use crate::fs::Metadata;
+ use crate::sys_common::AsInner;
+diff --git a/library/std/src/os/managarm/raw.rs b/library/std/src/os/managarm/raw.rs
+index 5124020d..0e8bdd77 100644
+--- a/library/std/src/os/managarm/raw.rs
++++ b/library/std/src/os/managarm/raw.rs
+@@ -1,4 +1,12 @@
+ #![stable(feature = "raw_ext", since = "1.1.0")]
++#![rustc_deprecated(
++    since = "1.8.0",
++    reason = "these type aliases are no longer supported by \
++              the standard library, the `libc` crate on \
++              crates.io should be used instead for the correct \
++              definitions"
++)]
++#![allow(deprecated)]
+ 
+ #[stable(feature = "pthread_t", since = "1.8.0")]
+ pub type pthread_t = usize; // TODO: This is completely wrong tbh
+diff --git a/library/std/src/os/unix/mod.rs b/library/std/src/os/unix/mod.rs
+index 62f750fa..00c6e3ab 100644
+--- a/library/std/src/os/unix/mod.rs
++++ b/library/std/src/os/unix/mod.rs
+@@ -59,6 +59,8 @@ mod platform {
+     pub use crate::os::linux::*;
+     #[cfg(target_os = "macos")]
+     pub use crate::os::macos::*;
++    #[cfg(target_os = "managarm")]
++    pub use crate::os::managarm::*;
+     #[cfg(target_os = "netbsd")]
+     pub use crate::os::netbsd::*;
+     #[cfg(target_os = "openbsd")]
+-- 
+2.35.1
+

--- a/scripts/cargo-inject-patches.py
+++ b/scripts/cargo-inject-patches.py
@@ -3,9 +3,10 @@
 import argparse, os, subprocess, pathlib
 
 patched_libs = {
-	'libc': '0.2.93',
+	'libc': '0.2.117',
 	'num_cpus': '1.13.0',
 	'users': '0.11.0',
+    'backtrace': '0.3.64',
 }
 
 parser = argparse.ArgumentParser(description='Inject patched Rust libraries into Cargo lockfiles')

--- a/scripts/cargo-inject-patches.py
+++ b/scripts/cargo-inject-patches.py
@@ -6,7 +6,7 @@ patched_libs = {
 	'libc': '0.2.117',
 	'num_cpus': '1.13.0',
 	'users': '0.11.0',
-    'backtrace': '0.3.64',
+	'backtrace': '0.3.64',
 }
 
 parser = argparse.ArgumentParser(description='Inject patched Rust libraries into Cargo lockfiles')


### PR DESCRIPTION
Bump `host-rust` to 1.57. This involves some libc additions. We also enable backtraces via `dl_iterate_phdr` which requires us to patch the `backtrace` crate.

Supercedes https://github.com/managarm/bootstrap-managarm/pull/163.