### PR TITLE
Add various missing post install hooks

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -223,7 +223,7 @@ packages:
       - zlib
       - libiconv
       - libintl
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'
@@ -242,6 +242,10 @@ packages:
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+    scripts:
+        post_install:
+          - args: ['glib-compile-schemas /usr/share/glib-2.0/schemas']
+          - args: ['gio-querymodules /usr/lib/gio/modules']
 
   - name : gmp
     labels: [aarch64]

--- a/bootstrap.d/gnome-base.yml
+++ b/bootstrap.d/gnome-base.yml
@@ -23,6 +23,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
+    revision: 2
     configure:
       - args: |
               sed -i -r 's:"(/system):"/org/gnome\1:g' @THIS_SOURCE_DIR@/schemas/*.in
@@ -40,5 +41,4 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
     scripts:
         post_install:
-          - args: 'echo "Running glib-compile-schemas; this may take a few seconds..."'
-          - args: ['glib-compile-schemas /usr/share/glib-2.0/schemas']
+          - args: 'glib-compile-schemas /usr/share/glib-2.0/schemas'

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -23,6 +23,7 @@ packages:
       - glib
       - gnutls
       - gsettings-desktop-schemas
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -42,6 +43,9 @@ packages:
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+    scripts:
+        post_install:
+          - args: ['gio-querymodules', '/usr/lib/gio/modules']
 
   - name: gnutls
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -108,6 +108,7 @@ packages:
       - libpng
       - shared-mime-info
       - libx11
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -122,6 +123,9 @@ packages:
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+    scripts:
+        post_install:
+          - args: ['gdk-pixbuf-query-loaders', '--update-cache']
 
   - name: gtk+-2
     source:

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -159,7 +159,7 @@ packages:
       - libxcb
       - pango
       - hicolor-icon-theme
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -184,8 +184,8 @@ packages:
       - args: ['mv', '-v', '@THIS_COLLECT_DIR@/usr/bin/gtk-update-icon-cache', '@THIS_COLLECT_DIR@/usr/bin/gtk2-update-icon-cache']
     scripts:
         post_install:
-          - args: 'echo "Running gtk-query-immodules-2.0; this may a few moments..."'
-          - args: ['gtk-query-immodules-2.0 --update-cache']
+          - args: ['gtk-query-immodules-2.0', '--update-cache']
+          - args: ['glib-compile-schemas', '/usr/share/glib-2.0/schemas']
 
   - name: libdmx
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -53,7 +53,7 @@ packages:
       - glib
       - libxml
       - itstool
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -70,7 +70,7 @@ packages:
     scripts:
         post_install:
           - args: 'echo "Running update-mime-database; this may take a minute or 2..."'
-          - args: ['update-mime-database /usr/share/mime/']
+          - args: '/usr/bin/update-mime-database /usr/share/mime/'
 
   - name: xbitmaps
     source:


### PR DESCRIPTION
This PR adds several missing post install hooks to glib and related packages. Fixing this allows for a better experience in Managarm.