### PR TITLE
Add a port of GTK3 and related dependencies

### DIFF
--- a/bootstrap.d/app-accessibility.yml
+++ b/bootstrap.d/app-accessibility.yml
@@ -1,0 +1,32 @@
+packages:
+  - name: at-spi2-core
+    architecture: '@OPTION:arch@'
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/at-spi2-core.git'
+      tag: 'AT_SPI2_CORE_2_38_0'
+      version: '2.38.0'
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: '@OPTION:arch-triple@'
+    pkgs_required:
+      - mlibc
+      - dbus
+      - glib
+    configure:
+      - args:
+          - 'meson'
+          - '--cross-file'
+          - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+          - '--prefix=/usr'
+          - '--sysconfdir=/etc'
+          - '-Dsystemd_user_dir=/tmp'
+          - '-Dintrospection=no'
+          - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/app-accessibility.yml
+++ b/bootstrap.d/app-accessibility.yml
@@ -1,4 +1,35 @@
 packages:
+  - name: at-spi2-atk
+    architecture: '@OPTION:arch@'
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/at-spi2-atk.git'
+      tag: 'AT_SPI2_ATK_2_38_0'
+      version: '2.38.0'
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: '@OPTION:arch-triple@'
+    pkgs_required:
+      - mlibc
+      - at-spi2-core
+      - glib
+      - atk
+      - dbus
+    configure:
+      - args:
+          - 'meson'
+          - '--cross-file'
+          - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+          - '--prefix=/usr'
+          - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: at-spi2-core
     architecture: '@OPTION:arch@'
     source:

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -993,6 +993,48 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxslt
+    architecture: '@OPTION:arch@'
+    source:
+      subdir: ports
+      git: 'https://gitlab.gnome.org/GNOME/libxslt.git'
+      tag: 'v1.1.34'
+      version: '1.1.34'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            'NOCONFIGURE': 'yes'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - libxml
+    configure:
+      # BLFS increases the recursion limit, apparently some packages need that to build their documentation.
+      - args: ['sed', '-i', 's/3000/5000/', '@THIS_SOURCE_DIR@/libxslt/transform.c']
+      - args: ['sed', '-i', 's/3000/5000/', '@THIS_SOURCE_DIR@/doc/xsltproc.1']
+      - args: ['sed', '-i', 's/3000/5000/', '@THIS_SOURCE_DIR@/doc/xsltproc.xml']
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-managarm'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--without-crypto'
+        - '--without-debug'
+        - '--without-debugger'
+        - '--without-profiler'
+        - '--without-python'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name : mpc
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -87,6 +87,64 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: dbus
+    architecture: '@OPTION:arch@'
+    source:
+      subdir: ports
+      git: 'https://gitlab.freedesktop.org/dbus/dbus.git'
+      tag: 'dbus-1.12.20'
+      version: '1.12.20'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-autoconf-archive
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            NOCONFIGURE: 'yes'
+    tools_required:
+      - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-pkg-config
+      - host-python
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--localstatedir=/var'
+        - '--disable-doxygen-docs'
+        - '--disable-xml-docs'
+        - '--disable-static'
+        - '--enable-shared'
+        - '--enable-verbose-mode'
+        - '--with-systemdsystemunitdir=no'
+        - '--with-systemduserunitdir=no'
+        - '--docdir=/usr/share/doc/dbus-1.12.20'
+        - '--with-console-auth-dir=/run/console'
+        - '--with-system-pid-file=/run/dbus/pid'
+        - '--with-system-socket=/run/dbus/system_bus_socket'
+        - '--disable-selinux'
+        - '--disable-apparmor'
+        - '--disable-libaudit'
+        - '--disable-kqueue'
+        - '--disable-launchd'
+        - '--disable-systemd'
+        - '--disable-tests'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: diffutils
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -242,6 +242,74 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: gtk+-3
+    architecture: '@OPTION:arch@'
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/gtk.git'
+      tag: '3.24.23'
+      version: '3.24.23'
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - host-glib
+      - wayland-scanner
+    pkgs_required:
+      - mlibc
+      - atk
+      - at-spi2-atk
+      - cairo
+      - glib
+      - gdk-pixbuf
+      - libx11
+      - libxext
+      - libxcb
+      - libxrender
+      - libxrandr
+      - libxfixes
+      - libxdamage
+      - pango
+      - fribidi
+      - libepoxy
+      - libxkbcommon
+      - wayland
+      - wayland-protocols
+      - fontconfig
+      - freetype
+      - libxi
+      - harfbuzz
+      - libxcursor
+      - gsettings-desktop-schemas
+      - dbus
+    configure:
+      - args:
+        - 'meson'
+        - '--native-file'
+        - '@SOURCE_ROOT@/scripts/meson.native-file'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        - '--buildtype=debugoptimized'
+        - '-Dprint_backends=file'
+        - '-Dintrospection=false'
+        - '-Dx11_backend=true'
+        - '-Dbroadway_backend=true'
+        - '-Dwayland_backend=true'
+        - '-Dgtk_doc=false'
+        - '-Dcolord=no'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+    scripts:
+        post_install:
+          - args: ['gtk-query-immodules-3.0', '--update-cache']
+          - args: ['glib-compile-schemas', '/usr/share/glib-2.0/schemas']
+
   - name: libdrm
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1,4 +1,5 @@
 imports:
+  - file: bootstrap.d/app-accessibility.yml
   - file: bootstrap.d/app-admin.yml
   - file: bootstrap.d/app-arch.yml
   - file: bootstrap.d/app-crypt.yml

--- a/patches/dbus/0001-Disable-the-use-of-getresuid-as-we-don-t-implement-t.patch
+++ b/patches/dbus/0001-Disable-the-use-of-getresuid-as-we-don-t-implement-t.patch
@@ -1,0 +1,27 @@
+From b14b395c00d34cfd2ba5a92fb23ceb3c65908d60 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 10 Oct 2022 16:24:57 +0200
+Subject: [PATCH] Disable the use of getresuid as we don't implement that yet
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ dbus/dbus-sysdeps-unix.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/dbus/dbus-sysdeps-unix.c b/dbus/dbus-sysdeps-unix.c
+index e511afc..7651b06 100644
+--- a/dbus/dbus-sysdeps-unix.c
++++ b/dbus/dbus-sysdeps-unix.c
+@@ -4562,7 +4562,7 @@ _dbus_check_setuid (void)
+ 
+   if (_DBUS_UNLIKELY (!check_setuid_initialised))
+     {
+-#ifdef HAVE_GETRESUID
++// Managarm runs as root, we don't care about setuid and stuff.
++#if defined HAVE_GETRESUID && !defined(__managarm__)
+       if (getresuid (&ruid, &euid, &suid) != 0 ||
+           getresgid (&rgid, &egid, &sgid) != 0)
+ #endif /* HAVE_GETRESUID */
+-- 
+2.37.2
+

--- a/patches/gtk+-3/0001-Initial-Managarm-support.patch
+++ b/patches/gtk+-3/0001-Initial-Managarm-support.patch
@@ -1,0 +1,79 @@
+From 2662bf6f999bbc1685ea616405f655d7b6a1e7fe Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 3 Apr 2022 22:48:43 +0200
+Subject: [PATCH] Initial Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ gdk/wayland/gdkdisplay-wayland.c | 1 -
+ gtk/a11y/gtkaccessibility.c      | 5 +++++
+ gtk/gtkmain.c                    | 5 +++++
+ meson.build                      | 3 ++-
+ 4 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/gdk/wayland/gdkdisplay-wayland.c b/gdk/wayland/gdkdisplay-wayland.c
+index d4503c2..0e2efc6 100644
+--- a/gdk/wayland/gdkdisplay-wayland.c
++++ b/gdk/wayland/gdkdisplay-wayland.c
+@@ -28,7 +28,6 @@
+ #endif
+ 
+ #include <sys/mman.h>
+-#include <sys/syscall.h>
+ 
+ #include <glib.h>
+ #include "gdkwayland.h"
+diff --git a/gtk/a11y/gtkaccessibility.c b/gtk/a11y/gtkaccessibility.c
+index 7f0e520..7231eb3 100644
+--- a/gtk/a11y/gtkaccessibility.c
++++ b/gtk/a11y/gtkaccessibility.c
+@@ -974,6 +974,9 @@ do_window_event_initialization (void)
+ void
+ _gtk_accessibility_init (void)
+ {
++// We don't care about a11y and dbus isn't working, so let's just not start that.
++#ifdef __managarm__
++	return;
++#else
+   if (initialized)
+     return;
+ 
+@@ -993,4 +996,5 @@ _gtk_accessibility_init (void)
+ #endif
+ 
+   atk_misc_instance = g_object_new (GTK_TYPE_MISC_IMPL, NULL);
++#endif
+ }
+diff --git a/gtk/gtkmain.c b/gtk/gtkmain.c
+index f7cbb34..8e035d4 100644
+--- a/gtk/gtkmain.c
++++ b/gtk/gtkmain.c
+@@ -357,6 +357,11 @@ static gboolean
+ check_setugid (void)
+ {
+ /* this isn't at all relevant on MS Windows and doesn't compile ... --hb */
++#ifdef __managarm__
++  /* Managarm runs everything as root for the time being, this check is thus useless. */
++  g_warning("Managarm ignores the setugid check!\n");
++  return TRUE;
++#endif
+ #ifndef G_OS_WIN32
+   uid_t ruid, euid, suid; /* Real, effective and saved user ID's */
+   gid_t rgid, egid, sgid; /* Real, effective and saved group ID's */
+diff --git a/meson.build b/meson.build
+index a8f1383..32118df 100644
+--- a/meson.build
++++ b/meson.build
+@@ -307,7 +307,7 @@ elif cc.get_id() == 'gcc' or cc.get_id() == 'clang'
+     '-Werror=sequence-point',
+     '-Werror=return-type',
+     '-Werror=trigraphs',
+-    '-Werror=array-bounds',
++    # We get build errors with this enabled
++    #'-Werror=array-bounds',
+     '-Werror=write-strings',
+     '-Werror=address',
+     '-Werror=int-to-pointer-cast',
+-- 
+2.37.2
+


### PR DESCRIPTION
This PR splits off the `gtk3` part from #152. Several issues still remain, including `dbus` not working properly and `gtk3` missing `pwrite()`, potentially among other things.

This PR adds the following ports:
- `libxslt`,
- `dbus`,
- `at-spi2-core`,
- `at-spi2-atk`,
- `gtk+-3`.

Blocked on #168 and a draft pending the things I mentioned above.
Blocked on #176 