### PR TITLE
havoc: Add port

### DIFF
--- a/bootstrap.d/gui-apps.yml
+++ b/bootstrap.d/gui-apps.yml
@@ -1,4 +1,54 @@
 packages:
+  - name: havoc
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Minimal terminal emulator for wayland 
+      description: This package contains a minimalistic terminal emulator for wayland.
+      spdx: 'MIT'
+      website: 'https://github.com/ii8/havoc'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['gui-apps']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/ii8/havoc.git'
+      tag: '0.4.0'
+      version: '0.4.0'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - wayland-scanner
+    pkgs_required:
+      - mlibc
+      - wayland
+      - wayland-protocols
+      - libxkbcommon
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+    build:
+      - args: ['make']
+        environ:
+          PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'
+          PKG_CONFIG_LIBDIR: '@BUILD_ROOT@/system-root/usr/lib/pkgconfig:@BUILD_ROOT@/system-root/usr/share/pkgconfig'
+          PREFIX: '/usr'
+          CC: "@OPTION:arch-triple@-gcc"
+          CXX: "@OPTION:arch-triple@-g++"
+          CPP: "@OPTION:arch-triple@-cpp"
+      - args: ['make', 'install']
+        environ:
+          PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'
+          PKG_CONFIG_LIBDIR: '@BUILD_ROOT@/system-root/usr/lib/pkgconfig:@BUILD_ROOT@/system-root/usr/share/pkgconfig'
+          PREFIX: '/usr'
+          DESTDIR: '@THIS_COLLECT_DIR@'
+          CC: "@OPTION:arch-triple@-gcc"
+          CXX: "@OPTION:arch-triple@-g++"
+          CPP: "@OPTION:arch-triple@-cpp"
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/home/managarm/.config']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/root/.config']
+      - args: ['cp', '@THIS_SOURCE_DIR@/havoc.cfg', '@THIS_COLLECT_DIR@/home/managarm/.config/havoc.cfg']
+      - args: ['cp', '@THIS_SOURCE_DIR@/havoc.cfg', '@THIS_COLLECT_DIR@/root/.config/havoc.cfg']
+
   - name: swaybg
     architecture: '@OPTION:arch@'
     metadata:

--- a/patches/havoc/0001-Change-some-config-values-to-sane-defaults.patch
+++ b/patches/havoc/0001-Change-some-config-values-to-sane-defaults.patch
@@ -1,0 +1,37 @@
+From bbc02777fc9fc29aea073aa4213bd7f31e14f02b Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 22 Feb 2022 04:34:12 +0100
+Subject: [PATCH] Change some config values to sane defaults
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ havoc.cfg | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/havoc.cfg b/havoc.cfg
+index abb3d59..9fca1c5 100644
+--- a/havoc.cfg
++++ b/havoc.cfg
+@@ -11,8 +11,8 @@ margin=no
+ 
+ [terminal]
+ # size of terminal
+-rows=16
+-columns=140
++rows=25
++columns=80
+ 
+ # number of lines to keep in scrollback
+ scrollback=1000
+@@ -22,7 +22,7 @@ scrollback=1000
+ size=18
+ 
+ # absolute path to a truetype font
+-path=/usr/share/fonts/TTF/DejaVuSansMono.ttf
++path=/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf
+ 
+ [bind]
+ # bind keys to actions
+-- 
+2.35.1
+


### PR DESCRIPTION
This PR adds a port of `havoc`, a minimalistic terminal emulator for weston.

Blocked on managarm/mlibc#398