### PR TITLE
llvm: Update from version 13.0.1 to 14.0.1

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -21,8 +21,8 @@ sources:
   - name: rust
     subdir: 'ports'
     git: 'https://github.com/rust-lang/rust.git'
-    tag: '1.58.1'
-    version: '1.58.1'
+    tag: '1.60.0'
+    version: '1.60.0'
 
   - name: host-bootstrap-cargo
     subdir: 'ports'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -538,7 +538,7 @@ packages:
       version: '21.3.5'
       tools_required:
         - host-pkg-config
-    revision: 3
+    revision: 4
     tools_required:
       - host-pkg-config
       - system-gcc

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -124,6 +124,14 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: exa
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: A modern replacement for 'ls' written in Rust
+      description: Exa is a modern `ls` replacement written in rust.
+      spdx: 'Apache-2.0 MIT Unlicense'
+      website: 'https://github.com/ogham/exa'
+      maintainer: "Matt Taylor <mstaveleytaylor@gmail.com>"
+      categories: ['sys-apps']
     source:
       subdir: ports
       git: 'https://github.com/ogham/exa.git'
@@ -137,6 +145,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
@@ -153,6 +162,8 @@ packages:
         - '-j@PARALLELISM@'
         environ: # Required to build libgit2
           CC: x86_64-managarm-gcc
+      - args: ['rm', '-v', '@THIS_COLLECT_DIR@/usr/.crates.toml']
+      - args: ['rm', '-v', '@THIS_COLLECT_DIR@/usr/.crates2.json']
 
   - name: file
     labels: [aarch64]
@@ -503,6 +514,14 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: ripgrep
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: a search tool that combines the usability of ag with the raw speed of grep
+      description: Ripgrep is a `grep` replacement written in rust, while taking several features from ag.
+      spdx: 'Apache-2.0 MIT Unlicense BSD-2-Clause BSL-1.0'
+      website: 'https://github.com/BurntSushi/ripgrep'
+      maintainer: "Matt Taylor <mstaveleytaylor@gmail.com>"
+      categories: ['sys-apps']
     source:
       subdir: ports
       git: 'https://github.com/BurntSushi/ripgrep.git'
@@ -514,6 +533,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
@@ -528,6 +548,8 @@ packages:
         - '--root'
         - '@THIS_COLLECT_DIR@/usr'
         - '-j@PARALLELISM@'
+      - args: ['rm', '-v', '@THIS_COLLECT_DIR@/usr/.crates.toml']
+      - args: ['rm', '-v', '@THIS_COLLECT_DIR@/usr/.crates2.json']
 
   - name: util-linux-libs
     labels: [aarch64]

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -106,8 +106,8 @@ sources:
   - name: llvm
     subdir: 'ports'
     git: 'https://github.com/llvm/llvm-project'
-    tag: 'llvmorg-13.0.1'
-    version: '13.0.1'
+    tag: 'llvmorg-14.0.1'
+    version: '14.0.1'
 
   - name: gcc
     subdir: 'ports'
@@ -987,6 +987,8 @@ packages:
         - '-DLLVM_HOST_TRIPLE=@OPTION:arch-triple@'
         # Disable linking against ncurses, which we do not build with -fPIC.
         - '-DLLVM_ENABLE_TERMINFO=OFF'
+        # Suppress developer warnings
+        - '-Wno-dev'
         - '@THIS_SOURCE_DIR@/llvm'
     build:
       - args: ['ninja']
@@ -994,6 +996,8 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
+      # One empty directory found, touch it so xbps doesn't complain
+      - args: ['touch', '@THIS_COLLECT_DIR@/usr/include/clang-tidy/plugin/.keep']
 
   - name: kmscube
     source:

--- a/patches/llvm/0001-Managarm-specific-changes.patch
+++ b/patches/llvm/0001-Managarm-specific-changes.patch
@@ -1,4 +1,4 @@
-From a608eab300e14a52782df121beef5d7c0e893165 Mon Sep 17 00:00:00 2001
+From d30c07fc77aa02e4b2442a60f87ab8fe671c134c Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Mon, 14 Feb 2022 08:28:17 +0100
 Subject: [PATCH 1/2] Managarm-specific changes
@@ -13,7 +13,7 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  5 files changed, 8 insertions(+), 6 deletions(-)
 
 diff --git a/llvm/cmake/modules/CrossCompile.cmake b/llvm/cmake/modules/CrossCompile.cmake
-index 01cd37124..5d55ac110 100644
+index 2a39b6a40..ceceb2aab 100644
 --- a/llvm/cmake/modules/CrossCompile.cmake
 +++ b/llvm/cmake/modules/CrossCompile.cmake
 @@ -17,8 +17,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
@@ -41,10 +41,10 @@ index e8612ba66..56d3dd721 100644
  #elif defined(_AIX)
  #include <sys/machine.h>
 diff --git a/llvm/lib/Support/Unix/Path.inc b/llvm/lib/Support/Unix/Path.inc
-index c37b3a546..cb1078363 100644
+index 788460d65..02728957f 100644
 --- a/llvm/lib/Support/Unix/Path.inc
 +++ b/llvm/lib/Support/Unix/Path.inc
-@@ -71,7 +71,7 @@ extern char **environ;
+@@ -74,7 +74,7 @@ extern char **environ;
  
  #include <sys/types.h>
  #if !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__FreeBSD__) &&   \
@@ -53,7 +53,7 @@ index c37b3a546..cb1078363 100644
  #include <sys/statvfs.h>
  #define STATVFS statvfs
  #define FSTATVFS fstatvfs
-@@ -80,7 +80,7 @@ extern char **environ;
+@@ -83,7 +83,7 @@ extern char **environ;
  #if defined(__OpenBSD__) || defined(__FreeBSD__)
  #include <sys/mount.h>
  #include <sys/param.h>
@@ -62,7 +62,7 @@ index c37b3a546..cb1078363 100644
  #if defined(HAVE_LINUX_MAGIC_H)
  #include <linux/magic.h>
  #else
-@@ -458,7 +458,7 @@ std::error_code remove(const Twine &path, bool IgnoreNonExisting) {
+@@ -478,7 +478,7 @@ std::error_code remove(const Twine &path, bool IgnoreNonExisting) {
  }
  
  static bool is_local_impl(struct STATVFS &Vfs) {
@@ -72,7 +72,7 @@ index c37b3a546..cb1078363 100644
  #define NFS_SUPER_MAGIC 0x6969
  #endif
 diff --git a/llvm/tools/llvm-dwarfdump/Statistics.cpp b/llvm/tools/llvm-dwarfdump/Statistics.cpp
-index 19a971afa..7b81da3a3 100644
+index 5c08e43b4..516d22d45 100644
 --- a/llvm/tools/llvm-dwarfdump/Statistics.cpp
 +++ b/llvm/tools/llvm-dwarfdump/Statistics.cpp
 @@ -6,6 +6,7 @@
@@ -84,7 +84,7 @@ index 19a971afa..7b81da3a3 100644
  #include "llvm/ADT/DenseMap.h"
  #include "llvm/ADT/StringSet.h"
 diff --git a/llvm/tools/llvm-shlib/CMakeLists.txt b/llvm/tools/llvm-shlib/CMakeLists.txt
-index 76b9a25cb..e6d236c39 100644
+index 8e2b78f1b..4c6763391 100644
 --- a/llvm/tools/llvm-shlib/CMakeLists.txt
 +++ b/llvm/tools/llvm-shlib/CMakeLists.txt
 @@ -36,6 +36,7 @@ if(LLVM_BUILD_LLVM_DYLIB)
@@ -96,5 +96,5 @@ index 76b9a25cb..e6d236c39 100644
       OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "Fuchsia")
       OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "DragonFly")
 -- 
-2.34.1
+2.35.1
 

--- a/patches/llvm/0002-Add-Managarm-target.patch
+++ b/patches/llvm/0002-Add-Managarm-target.patch
@@ -1,7 +1,7 @@
-From 47a1a92ab7f1a588d18967674db826b3d37d4505 Mon Sep 17 00:00:00 2001
+From c367e444fe659d83c6ee5620d367ab16ae095470 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
-Date: Mon, 14 Feb 2022 08:41:04 +0100
-Subject: [PATCH 2/2] Add managarm target
+Date: Sat, 2 Apr 2022 19:44:10 +0200
+Subject: [PATCH 2/2] Add Managarm target
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
@@ -19,7 +19,7 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  create mode 100644 clang/lib/Driver/ToolChains/Managarm.h
 
 diff --git a/clang/lib/Basic/Targets.cpp b/clang/lib/Basic/Targets.cpp
-index ba91d0439..4ee6367af 100644
+index 994a491cd..e3df5bfa4 100644
 --- a/clang/lib/Basic/Targets.cpp
 +++ b/clang/lib/Basic/Targets.cpp
 @@ -149,6 +149,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
@@ -50,10 +50,10 @@ index ba91d0439..4ee6367af 100644
        return new NaClTargetInfo<X86_64TargetInfo>(Triple, Opts);
      case llvm::Triple::PS4:
 diff --git a/clang/lib/Basic/Targets/OSTargets.h b/clang/lib/Basic/Targets/OSTargets.h
-index 12df95c19..6d2472529 100644
+index 3c1830d5f..4e80429aa 100644
 --- a/clang/lib/Basic/Targets/OSTargets.h
 +++ b/clang/lib/Basic/Targets/OSTargets.h
-@@ -337,6 +337,36 @@ public:
+@@ -338,6 +338,36 @@ public:
        : OSTargetInfo<Target>(Triple, Opts) {}
  };
  
@@ -91,10 +91,10 @@ index 12df95c19..6d2472529 100644
  template <typename Target>
  class LLVM_LIBRARY_VISIBILITY MinixTargetInfo : public OSTargetInfo<Target> {
 diff --git a/clang/lib/Driver/CMakeLists.txt b/clang/lib/Driver/CMakeLists.txt
-index 08be9f011..5dc595778 100644
+index 78e8fd185..a3fbd19bd 100644
 --- a/clang/lib/Driver/CMakeLists.txt
 +++ b/clang/lib/Driver/CMakeLists.txt
-@@ -56,6 +56,7 @@ add_clang_library(clangDriver
+@@ -59,6 +59,7 @@ add_clang_library(clangDriver
    ToolChains/Hexagon.cpp
    ToolChains/Hurd.cpp
    ToolChains/Linux.cpp
@@ -103,10 +103,10 @@ index 08be9f011..5dc595778 100644
    ToolChains/MinGW.cpp
    ToolChains/Minix.cpp
 diff --git a/clang/lib/Driver/Driver.cpp b/clang/lib/Driver/Driver.cpp
-index 94a7553e2..95b27caa0 100644
+index 3bfddeefc..4d3341a1d 100644
 --- a/clang/lib/Driver/Driver.cpp
 +++ b/clang/lib/Driver/Driver.cpp
-@@ -29,6 +29,7 @@
+@@ -30,6 +30,7 @@
  #include "ToolChains/Hurd.h"
  #include "ToolChains/Lanai.h"
  #include "ToolChains/Linux.h"
@@ -114,7 +114,7 @@ index 94a7553e2..95b27caa0 100644
  #include "ToolChains/MSP430.h"
  #include "ToolChains/MSVC.h"
  #include "ToolChains/MinGW.h"
-@@ -5299,6 +5300,9 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
+@@ -5564,6 +5565,9 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
      case llvm::Triple::Fuchsia:
        TC = std::make_unique<toolchains::Fuchsia>(*this, Target, Args);
        break;
@@ -125,7 +125,7 @@ index 94a7553e2..95b27caa0 100644
        TC = std::make_unique<toolchains::Solaris>(*this, Target, Args);
        break;
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index da39f29e4..7f89f16fd 100644
+index 7a9570a68..5c561f970 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
 @@ -246,6 +246,8 @@ static const char *getLDMOption(const llvm::Triple &T, const ArgList &Args) {
@@ -137,32 +137,32 @@ index da39f29e4..7f89f16fd 100644
      return "aarch64linux";
    case llvm::Triple::aarch64_be:
      return "aarch64linuxb";
-@@ -2077,7 +2079,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2073,7 +2075,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
    static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
    static const char *const AArch64Triples[] = {
        "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
--      "aarch64-suse-linux", "aarch64-linux-android"};
-+      "aarch64-suse-linux", "aarch64-linux-android",
+-      "aarch64-suse-linux"};
++      "aarch64-suse-linux",
 +      "aarch64-managarm", "aarch64-managarm-system", "aarch64-managarm-kernel"};
    static const char *const AArch64beLibDirs[] = {"/lib"};
    static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
                                                   "aarch64_be-linux-gnu"};
-@@ -2105,7 +2108,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2099,7 +2102,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
        "x86_64-redhat-linux",    "x86_64-suse-linux",
        "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
        "x86_64-slackware-linux", "x86_64-unknown-linux",
--      "x86_64-amazon-linux",    "x86_64-linux-android"};
-+      "x86_64-amazon-linux",    "x86_64-linux-android",
+-      "x86_64-amazon-linux"};
++      "x86_64-amazon-linux",
 +      "x86_64-managarm", "x86_64-managarm-system", "x86_64-managarm-kernel"};
    static const char *const X32Triples[] = {"x86_64-linux-gnux32",
                                             "x86_64-pc-linux-gnux32"};
    static const char *const X32LibDirs[] = {"/libx32", "/lib"};
-@@ -2183,7 +2187,10 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2171,7 +2175,10 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+   static const char *const RISCV64LibDirs[] = {"/lib64", "/lib"};
+   static const char *const RISCV64Triples[] = {"riscv64-unknown-linux-gnu",
                                                 "riscv64-linux-gnu",
-                                                "riscv64-unknown-elf",
-                                                "riscv64-redhat-linux",
--                                               "riscv64-suse-linux"};
-+                                               "riscv64-suse-linux",
+-                                               "riscv64-unknown-elf"};
++                                               "riscv64-unknown-elf",
 +                                               "riscv64-managarm",
 +                                               "riscv64-managarm-kernel",
 +                                               "riscv64-managarm-system"};
@@ -663,10 +663,10 @@ index 000000000..2d87decd8
 +
 +#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_MANAGARM_H
 diff --git a/llvm/include/llvm/ADT/Triple.h b/llvm/include/llvm/ADT/Triple.h
-index 76f351405..ea37cd381 100644
+index 42277c013..e9db917ae 100644
 --- a/llvm/include/llvm/ADT/Triple.h
 +++ b/llvm/include/llvm/ADT/Triple.h
-@@ -175,6 +175,7 @@ public:
+@@ -181,6 +181,7 @@ public:
      Linux,
      Lv2,        // PS3
      MacOSX,
@@ -674,7 +674,7 @@ index 76f351405..ea37cd381 100644
      NetBSD,
      OpenBSD,
      Solaris,
-@@ -226,7 +227,9 @@ public:
+@@ -232,7 +233,9 @@ public:
      CoreCLR,
      Simulator, // Simulator variants of other systems, e.g., Apple's iOS
      MacABI, // Mac Catalyst variant of Apple's iOS deployment target.
@@ -686,10 +686,10 @@ index 76f351405..ea37cd381 100644
    enum ObjectFormatType {
      UnknownObjectFormat,
 diff --git a/llvm/lib/Support/Triple.cpp b/llvm/lib/Support/Triple.cpp
-index 883115463..05a80faf2 100644
+index a9afcc9db..b1e7c8259 100644
 --- a/llvm/lib/Support/Triple.cpp
 +++ b/llvm/lib/Support/Triple.cpp
-@@ -209,6 +209,7 @@ StringRef Triple::getOSTypeName(OSType Kind) {
+@@ -215,6 +215,7 @@ StringRef Triple::getOSTypeName(OSType Kind) {
    case Linux: return "linux";
    case Lv2: return "lv2";
    case MacOSX: return "macosx";
@@ -697,7 +697,7 @@ index 883115463..05a80faf2 100644
    case Mesa3D: return "mesa3d";
    case Minix: return "minix";
    case NVCL: return "nvcl";
-@@ -245,6 +246,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
+@@ -251,6 +252,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
    case GNUX32: return "gnux32";
    case GNUILP32: return "gnu_ilp32";
    case Itanium: return "itanium";
@@ -705,7 +705,7 @@ index 883115463..05a80faf2 100644
    case MSVC: return "msvc";
    case MacABI: return "macabi";
    case Musl: return "musl";
-@@ -252,6 +254,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
+@@ -258,6 +260,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
    case MuslEABIHF: return "musleabihf";
    case MuslX32: return "muslx32";
    case Simulator: return "simulator";
@@ -713,7 +713,7 @@ index 883115463..05a80faf2 100644
    }
  
    llvm_unreachable("Invalid EnvironmentType!");
-@@ -513,6 +516,7 @@ static Triple::OSType parseOS(StringRef OSName) {
+@@ -523,6 +526,7 @@ static Triple::OSType parseOS(StringRef OSName) {
      .StartsWith("linux", Triple::Linux)
      .StartsWith("lv2", Triple::Lv2)
      .StartsWith("macos", Triple::MacOSX)
@@ -721,7 +721,7 @@ index 883115463..05a80faf2 100644
      .StartsWith("netbsd", Triple::NetBSD)
      .StartsWith("openbsd", Triple::OpenBSD)
      .StartsWith("solaris", Triple::Solaris)
-@@ -564,6 +568,8 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
+@@ -574,6 +578,8 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
        .StartsWith("coreclr", Triple::CoreCLR)
        .StartsWith("simulator", Triple::Simulator)
        .StartsWith("macabi", Triple::MacABI)
@@ -731,5 +731,5 @@ index 883115463..05a80faf2 100644
  }
  
 -- 
-2.34.1
+2.35.1
 

--- a/patches/rust/0001-managarm-initial-port.patch
+++ b/patches/rust/0001-managarm-initial-port.patch
@@ -1,10 +1,11 @@
-From d8dac34b54d3dfd3232a0c44fe811d21f6f1ace0 Mon Sep 17 00:00:00 2001
+From 32947df9d8b0b002c7da0c10674b2c23addd3c62 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Sat, 10 Apr 2021 17:53:24 +0100
 Subject: [PATCH 1/2] managarm: initial port
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- Cargo.lock                                    |  20 ++-
+ Cargo.lock                                    |  16 +-
  Cargo.toml                                    |   1 +
  .../src/spec/managarm_system_base.rs          |  35 +++++
  compiler/rustc_target/src/spec/mod.rs         |   3 +
@@ -19,13 +20,13 @@ Subject: [PATCH 1/2] managarm: initial port
  library/std/src/os/unix/mod.rs                |   2 +
  library/std/src/sys/unix/args.rs              |   3 +-
  library/std/src/sys/unix/env.rs               |  11 ++
- library/std/src/sys/unix/fs.rs                |   2 +
+ library/std/src/sys/unix/fs.rs                |   3 +-
  library/std/src/sys/unix/os.rs                |  34 +++-
  library/std/src/sys/unix/thread.rs            |   7 +
  library/std/src/sys/unix/thread_local_dtor.rs |   3 +-
  library/std/src/sys/unix/time.rs              |   7 +-
  library/unwind/build.rs                       |   2 +
- 21 files changed, 366 insertions(+), 18 deletions(-)
+ 21 files changed, 364 insertions(+), 17 deletions(-)
  create mode 100644 compiler/rustc_target/src/spec/managarm_system_base.rs
  create mode 100644 compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
  create mode 100644 library/std/src/os/managarm/fs.rs
@@ -33,33 +34,21 @@ Subject: [PATCH 1/2] managarm: initial port
  create mode 100644 library/std/src/os/managarm/raw.rs
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 48d9fdb3..06167a11 100644
+index e3ab987b..7589d40b 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1900,9 +1900,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+@@ -1972,9 +1972,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
  
  [[package]]
  name = "libc"
--version = "0.2.106"
+-version = "0.2.116"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 +version = "0.2.117"
  dependencies = [
   "rustc-std-workspace-core",
  ]
-@@ -2325,9 +2323,9 @@ dependencies = [
- 
- [[package]]
- name = "num_cpus"
--version = "1.13.0"
-+version = "1.13.1"
- source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
- dependencies = [
-  "hermit-abi",
-  "libc",
-@@ -5860,3 +5858,15 @@ checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+@@ -5648,3 +5646,15 @@ checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
  dependencies = [
   "winapi",
  ]
@@ -75,6 +64,7 @@ index 48d9fdb3..06167a11 100644
 +[[patch.unused]]
 +name = "users"
 +version = "0.11.0"
+\ No newline at end of file
 diff --git a/Cargo.toml b/Cargo.toml
 index cae48d79..a3328ea6 100644
 --- a/Cargo.toml
@@ -123,16 +113,16 @@ index 00000000..08b7d8a8
 +        pre_link_args: args,
 +        position_independent_executables: true,
 +        relro_level: RelroLevel::Full,
-+        has_elf_tls: true,
++        has_thread_local: true,
 +        crt_static_respected: true,
 +        ..Default::default()
 +    }
 +}
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 0d49c7f6..1e6f23af 100644
+index 92678aed..ac96c04a 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -61,6 +61,7 @@
+@@ -62,6 +62,7 @@
  mod freebsd_base;
  mod fuchsia_base;
  mod haiku_base;
@@ -140,7 +130,7 @@ index 0d49c7f6..1e6f23af 100644
  mod hermit_base;
  mod hermit_kernel_base;
  mod illumos_base;
-@@ -887,6 +888,8 @@ fn $module() {
+@@ -894,6 +895,8 @@ fn $module() {
      ("i686-unknown-haiku", i686_unknown_haiku),
      ("x86_64-unknown-haiku", x86_64_unknown_haiku),
  
@@ -175,16 +165,16 @@ index 00000000..7c16ed9b
 +    }
 +}
 diff --git a/library/std/Cargo.toml b/library/std/Cargo.toml
-index 4147f7ee..6dfd3a40 100644
+index 14609653..ca735bcf 100644
 --- a/library/std/Cargo.toml
 +++ b/library/std/Cargo.toml
 @@ -15,7 +15,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
  panic_unwind = { path = "../panic_unwind", optional = true }
  panic_abort = { path = "../panic_abort" }
  core = { path = "../core" }
--libc = { version = "0.2.106", default-features = false, features = ['rustc-dep-of-std'] }
+-libc = { version = "0.2.116", default-features = false, features = ['rustc-dep-of-std'] }
 +libc = { path = "../../../rust-libc", default-features = false, features = ['rustc-dep-of-std'] }
- compiler_builtins = { version = "0.1.53" }
+ compiler_builtins = { version = "0.1.69" }
  profiler_builtins = { path = "../profiler_builtins", optional = true }
  unwind = { path = "../unwind" }
 diff --git a/library/std/build.rs b/library/std/build.rs
@@ -200,10 +190,10 @@ index 43168e77..3ffa1ff2 100644
          || target.contains("wasm32")
          || target.contains("wasm64")
 diff --git a/library/std/src/lib.rs b/library/std/src/lib.rs
-index 133cda4f..fdcbc79e 100644
+index 8c38db9b..278225fd 100644
 --- a/library/std/src/lib.rs
 +++ b/library/std/src/lib.rs
-@@ -547,7 +547,7 @@ pub mod task {
+@@ -576,7 +576,7 @@ pub mod arch {
  // Private support modules
  mod panicking;
  
@@ -518,27 +508,21 @@ index 60551aeb..f9b5322b 100644
 +    pub const EXE_EXTENSION: &str = "";
 +}
 diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
-index 111639d9..af15aad5 100644
+index 8bd0b9b1..c7492b62 100644
 --- a/library/std/src/sys/unix/fs.rs
 +++ b/library/std/src/sys/unix/fs.rs
-@@ -607,6 +607,7 @@ pub fn file_type(&self) -> io::Result<FileType> {
+@@ -633,7 +633,8 @@ pub fn file_type(&self) -> io::Result<FileType> {
+         target_os = "fuchsia",
          target_os = "redox",
          target_os = "vxworks",
-         target_os = "espidf"
+-        target_os = "espidf"
++        target_os = "espidf",
 +        target_os = "managarm"
      ))]
      pub fn ino(&self) -> u64 {
          self.entry.d_ino as u64
-@@ -647,6 +648,7 @@ fn name_bytes(&self) -> &[u8] {
-         target_os = "haiku",
-         target_os = "vxworks",
-         target_os = "espidf"
-+        target_os = "managarm"
-     ))]
-     fn name_bytes(&self) -> &[u8] {
-         unsafe { CStr::from_ptr(self.entry.d_name.as_ptr()).to_bytes() }
 diff --git a/library/std/src/sys/unix/os.rs b/library/std/src/sys/unix/os.rs
-index 87893d26..68adcb10 100644
+index b268ef5c..2b7863e3 100644
 --- a/library/std/src/sys/unix/os.rs
 +++ b/library/std/src/sys/unix/os.rs
 @@ -39,7 +39,7 @@
@@ -561,12 +545,12 @@ index 87893d26..68adcb10 100644
  }
  
  /// Sets the platform-specific value of errno
--#[cfg(all(not(target_os = "linux"), not(target_os = "dragonfly"), not(target_os = "vxworks")))] // needed for readdir and syscall!
-+#[cfg(all(not(target_os = "linux"), not(target_os = "dragonfly"), not(target_os = "vxworks"), not(target_os = "managarm")))] // needed for readdir and syscall!
+-#[cfg(all(not(target_os = "dragonfly"), not(target_os = "vxworks")))] // needed for readdir and syscall!
++#[cfg(all(not(target_os = "dragonfly"), not(target_os = "vxworks"), not(target_os = "managarm")))] // needed for readdir and syscall!
  #[allow(dead_code)] // but not all target cfgs actually end up using it
  pub fn set_errno(e: i32) {
      unsafe { *errno_location() = e as c_int }
-@@ -108,6 +108,29 @@ pub fn set_errno(e: i32) {
+@@ -109,6 +109,29 @@ pub fn set_errno(e: i32) {
      }
  }
  
@@ -596,7 +580,7 @@ index 87893d26..68adcb10 100644
  /// Gets a detailed string description for the given error number.
  pub fn error_string(errno: i32) -> String {
      extern "C" {
-@@ -360,6 +383,11 @@ pub fn current_exe() -> io::Result<PathBuf> {
+@@ -241,6 +264,11 @@ fn description(&self) -> &str {
      }
  }
  
@@ -605,14 +589,14 @@ index 87893d26..68adcb10 100644
 +    unimplemented!()
 +}
 +
- #[cfg(any(target_os = "macos", target_os = "ios"))]
+ #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
  pub fn current_exe() -> io::Result<PathBuf> {
      unsafe {
 diff --git a/library/std/src/sys/unix/thread.rs b/library/std/src/sys/unix/thread.rs
-index b99eb2e5..4a3ee5d8 100644
+index cf8cf5ad..e6228074 100644
 --- a/library/std/src/sys/unix/thread.rs
 +++ b/library/std/src/sys/unix/thread.rs
-@@ -138,6 +138,13 @@ pub fn set_name(name: &CStr) {
+@@ -140,6 +140,13 @@ pub fn set_name(name: &CStr) {
          }
      }
  
@@ -641,10 +625,10 @@ index c3f41035..df3d08dc 100644
  pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
      use crate::mem;
 diff --git a/library/std/src/sys/unix/time.rs b/library/std/src/sys/unix/time.rs
-index 824283ef..de405297 100644
+index 59ddd1aa..c3fe5b00 100644
 --- a/library/std/src/sys/unix/time.rs
 +++ b/library/std/src/sys/unix/time.rs
-@@ -362,12 +362,7 @@ fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+@@ -343,12 +343,7 @@ fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
          }
      }
  
@@ -659,10 +643,10 @@ index 824283ef..de405297 100644
          cvt(unsafe { libc::clock_gettime(clock, &mut t.t) }).unwrap();
          t
 diff --git a/library/unwind/build.rs b/library/unwind/build.rs
-index 1d0b4a59..dba57c26 100644
+index a3f52241..2c785c17 100644
 --- a/library/unwind/build.rs
 +++ b/library/unwind/build.rs
-@@ -43,5 +43,7 @@ fn main() {
+@@ -46,5 +46,7 @@ fn main() {
          println!("cargo:rustc-link-lib=gcc_s");
      } else if target.contains("redox") {
          // redox is handled in lib.rs
@@ -671,5 +655,5 @@ index 1d0b4a59..dba57c26 100644
      }
  }
 -- 
-2.35.1
+2.35.2
 

--- a/patches/rust/0002-managarm-fix-build-target-in-x.py-and-bootstrap.patch
+++ b/patches/rust/0002-managarm-fix-build-target-in-x.py-and-bootstrap.patch
@@ -1,14 +1,14 @@
-From 8af5e0038ed6027808886fe0f269c80ea5ec1d42 Mon Sep 17 00:00:00 2001
+From 068c961a17dad873da9626ebac98ab8f28c9deb2 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Mon, 31 May 2021 21:19:44 +0100
 Subject: [PATCH 2/2] managarm: fix build target in x.py and bootstrap
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  compiler/rustc_target/src/spec/managarm_system_base.rs | 2 +-
- library/std/src/sys/unix/fs.rs                         | 4 ++--
  src/bootstrap/bootstrap.py                             | 8 ++++++--
  src/bootstrap/builder.rs                               | 6 ++++--
- 4 files changed, 13 insertions(+), 7 deletions(-)
+ 3 files changed, 11 insertions(+), 5 deletions(-)
 
 diff --git a/compiler/rustc_target/src/spec/managarm_system_base.rs b/compiler/rustc_target/src/spec/managarm_system_base.rs
 index 08b7d8a8..cec689f1 100644
@@ -23,33 +23,11 @@ index 08b7d8a8..cec689f1 100644
          linker_is_gnu: true,
          has_rpath: true,
          pre_link_args: args,
-diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
-index af15aad5..2e5ce66d 100644
---- a/library/std/src/sys/unix/fs.rs
-+++ b/library/std/src/sys/unix/fs.rs
-@@ -606,7 +606,7 @@ pub fn file_type(&self) -> io::Result<FileType> {
-         target_os = "fuchsia",
-         target_os = "redox",
-         target_os = "vxworks",
--        target_os = "espidf"
-+        target_os = "espidf",
-         target_os = "managarm"
-     ))]
-     pub fn ino(&self) -> u64 {
-@@ -647,7 +647,7 @@ fn name_bytes(&self) -> &[u8] {
-         target_os = "l4re",
-         target_os = "haiku",
-         target_os = "vxworks",
--        target_os = "espidf"
-+        target_os = "espidf",
-         target_os = "managarm"
-     ))]
-     fn name_bytes(&self) -> &[u8] {
 diff --git a/src/bootstrap/bootstrap.py b/src/bootstrap/bootstrap.py
-index 22f2e405..2be8a253 100644
+index 6c1128b3..3740b090 100644
 --- a/src/bootstrap/bootstrap.py
 +++ b/src/bootstrap/bootstrap.py
-@@ -931,7 +931,7 @@ class RustBuild(object):
+@@ -984,7 +984,7 @@ class RustBuild(object):
          ... "debug", "bootstrap")
          True
          """
@@ -58,7 +36,7 @@ index 22f2e405..2be8a253 100644
  
      def build_bootstrap(self):
          """Build bootstrap"""
-@@ -939,7 +939,7 @@ class RustBuild(object):
+@@ -993,7 +993,7 @@ class RustBuild(object):
          if self.clean and os.path.exists(build_dir):
              shutil.rmtree(build_dir)
          env = os.environ.copy()
@@ -67,7 +45,7 @@ index 22f2e405..2be8a253 100644
          # See also: <https://github.com/rust-lang/rust/issues/70208>.
          if "CARGO_BUILD_TARGET" in env:
              del env["CARGO_BUILD_TARGET"]
-@@ -986,6 +986,10 @@ class RustBuild(object):
+@@ -1040,6 +1040,10 @@ class RustBuild(object):
              args.append("--locked")
          if self.use_vendored_sources:
              args.append("--frozen")
@@ -79,10 +57,10 @@ index 22f2e405..2be8a253 100644
  
      def build_triple(self):
 diff --git a/src/bootstrap/builder.rs b/src/bootstrap/builder.rs
-index 6ba1b1b6..0eb49ee9 100644
+index 0d387ff1..5dd2cb92 100644
 --- a/src/bootstrap/builder.rs
 +++ b/src/bootstrap/builder.rs
-@@ -1111,6 +1111,8 @@ pub fn cargo(
+@@ -1211,6 +1211,8 @@ pub fn cargo(
              self.clear_if_dirty(&out_dir, &self.rustc(compiler));
          }
  
@@ -91,7 +69,7 @@ index 6ba1b1b6..0eb49ee9 100644
          // Customize the compiler we're running. Specify the compiler to cargo
          // as our shim and then pass it some various options used to configure
          // how the actual compiler itself is called.
-@@ -1123,7 +1125,7 @@ pub fn cargo(
+@@ -1223,7 +1225,7 @@ pub fn cargo(
              .env("RUSTC_STAGE", stage.to_string())
              .env("RUSTC_SYSROOT", &sysroot)
              .env("RUSTC_LIBDIR", &libdir)
@@ -100,7 +78,7 @@ index 6ba1b1b6..0eb49ee9 100644
              .env(
                  "RUSTDOC_REAL",
                  if cmd == "doc" || cmd == "rustdoc" || (cmd == "test" && want_rustdoc) {
-@@ -1137,7 +1139,7 @@ pub fn cargo(
+@@ -1237,7 +1239,7 @@ pub fn cargo(
          // Clippy support is a hack and uses the default `cargo-clippy` in path.
          // Don't override RUSTC so that the `cargo-clippy` in path will be run.
          if cmd != "clippy" {
@@ -110,5 +88,5 @@ index 6ba1b1b6..0eb49ee9 100644
  
          // Dealing with rpath here is a little special, so let's go into some
 -- 
-2.35.1
+2.35.2
 

--- a/scripts/cross-llvm-config
+++ b/scripts/cross-llvm-config
@@ -4,7 +4,7 @@ import argparse
 import sys
 import os
 
-our_version = 13
+our_version = 14
 
 def do_version():
 	return '{}.0.1'.format(our_version)

--- a/scripts/meson-clang-aarch64-managarm.cross-file
+++ b/scripts/meson-clang-aarch64-managarm.cross-file
@@ -6,9 +6,9 @@ strip = 'aarch64-managarm-strip'
 pkgconfig = 'pkg-config'
 
 [built-in options]
-c_args = ['-target', 'aarch64-managarm', '-gcc-toolchain', '_BUILD_ROOT_/tools/system-gcc']
-cpp_args = ['-DLIBASYNC_FORCE_USE_EXPERIMENTAL', '-fsized-deallocation', '-target', 'aarch64-managarm', '-gcc-toolchain', '_BUILD_ROOT_/tools/system-gcc']
-cpp_link_args = [ '-fsized-deallocation', '-target', 'aarch64-managarm', '-gcc-toolchain', '_BUILD_ROOT_/tools/system-gcc']
+c_args = ['-target', 'aarch64-managarm', '-fdebug-default-version=4', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']
+cpp_args = ['-DLIBASYNC_FORCE_USE_EXPERIMENTAL', '-fsized-deallocation', '-fdebug-default-version=4', '-target', 'aarch64-managarm', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']
+cpp_link_args = [ '-fsized-deallocation', '-fdebug-default-version=4', '-target', 'aarch64-managarm', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']
 
 [host_machine]
 system = 'managarm'

--- a/scripts/meson-clang-x86_64-managarm.cross-file
+++ b/scripts/meson-clang-x86_64-managarm.cross-file
@@ -7,8 +7,8 @@ strip = 'x86_64-managarm-strip'
 pkgconfig = 'pkg-config'
 
 [built-in options]
-cpp_args = ['-DLIBASYNC_FORCE_USE_EXPERIMENTAL', '-fsized-deallocation', '-target', 'x86_64-managarm', '-gcc-toolchain', '_BUILD_ROOT_/tools/system-gcc']
-cpp_link_args = ['-fsized-deallocation', '-target', 'x86_64-managarm', '-gcc-toolchain', '_BUILD_ROOT_/tools/system-gcc']
+cpp_args = ['-DLIBASYNC_FORCE_USE_EXPERIMENTAL', '-fsized-deallocation', '-fdebug-default-version=4', '-target', 'x86_64-managarm', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']
+cpp_link_args = ['-fsized-deallocation', '-fdebug-default-version=4', '-target', 'x86_64-managarm', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']
 
 [host_machine]
 system = 'managarm'

--- a/scripts/meson-kernel-aarch64-managarm.cross-file
+++ b/scripts/meson-kernel-aarch64-managarm.cross-file
@@ -7,7 +7,7 @@ pkgconfig = 'pkgconfig'
 
 [constants]
 # clang needs an additional flag to enable sized allocation/deallocation.
-args = [ '-fsized-deallocation', '-ffreestanding', '-target', 'aarch64-managarm-kernel', '-gcc-toolchain', '_BUILD_ROOT_/tools/kernel-gcc']
+args = [ '-fsized-deallocation', '-fdebug-default-version=4', '-ffreestanding', '-target', 'aarch64-managarm-kernel', '--gcc-toolchain=_BUILD_ROOT_/tools/kernel-gcc']
 
 [built-in options]
 c_args = args

--- a/scripts/meson-kernel-riscv64-managarm.cross-file
+++ b/scripts/meson-kernel-riscv64-managarm.cross-file
@@ -7,7 +7,7 @@ pkgconfig = 'pkgconfig'
 
 [constants]
 # clang needs an additional flag to enable sized allocation/deallocation.
-args = [ '-fsized-deallocation', '-ffreestanding', '-target', 'riscv64-managarm-kernel', '-march=rv64gc', '-mabi=lp64d', '-mcmodel=medany', '-gcc-toolchain', '_BUILD_ROOT_/tools/kernel-gcc']
+args = [ '-fsized-deallocation', '-fdebug-default-version=4', '-ffreestanding', '-target', 'riscv64-managarm-kernel', '-march=rv64gc', '-mabi=lp64d', '-mcmodel=medany', '--gcc-toolchain=_BUILD_ROOT_/tools/kernel-gcc']
 
 [built-in options]
 c_args = args

--- a/scripts/meson-kernel-x86_64-managarm.cross-file
+++ b/scripts/meson-kernel-x86_64-managarm.cross-file
@@ -7,7 +7,7 @@ pkgconfig = 'pkg-config'
 
 [constants]
 # common args that c and cxx need
-args = ['-ffreestanding', '-target', 'x86_64-managarm-kernel', '-gcc-toolchain', '_BUILD_ROOT_/tools/kernel-gcc' ]
+args = ['-ffreestanding', '-fdebug-default-version=4', '-target', 'x86_64-managarm-kernel', '--gcc-toolchain=_BUILD_ROOT_/tools/kernel-gcc' ]
 # cxx specific arguments
 cxx = args + [ '-fsized-deallocation' ]
 


### PR DESCRIPTION
LLVM 14 has dropped, and that can mean only one thing, toolchain update time!