### PR TITLE
Add an initial port of a subset of Qt6

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -1,4 +1,35 @@
 packages:
+  - name: brotli
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Generic-purpose lossless compression algorithm
+      description: This package contains a compressor and decompressor for the brotli compression format.
+      spdx: 'MIT'
+      website: 'https://github.com/google/brotli'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-arch']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/google/brotli.git'
+      tag: 'v1.0.9'
+      version: '1.0.9'
+    tools_required:
+      - system-gcc
+      - host-cmake
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_BUILD_TYPE=Release'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: bzip2
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -164,6 +164,41 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: double-conversion
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles
+      description: This package provides a library with conversion routines for binary to decimal and decimal to binary with IEEE doubles.
+      spdx: 'BSD-3-Clause'
+      website: 'https://github.com/google/double-conversion'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/google/double-conversion.git'
+      tag: 'v3.1.5'
+      version: '3.1.5'
+    tools_required:
+      - host-cmake
+      - system-gcc
+    pkgs_required:
+      - mlibc
+    configure:
+      - args:
+        - 'cmake'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DBUILD_SHARED_LIBS=ON'
+        - '@THIS_SOURCE_DIR@'
+        environ:
+          CC: '@OPTION:arch-triple@-gcc'
+          CXX: '@OPTION:arch-triple@-g++'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: fribidi
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -1142,6 +1142,56 @@ packages:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
 
+  - name: pcre2
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Perl-compatible regular expression library
+      description: This package contains a new generation of the Perl Compatible Regular Expression libraries. These are useful for implementing regular expression pattern matching using the same syntax and semantics as Perl.
+      spdx: 'BSD-3-Clause'
+      website: 'https://www.pcre.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/PhilipHazel/pcre2.git'
+      tag: 'pcre2-10.39'
+      version: '10.39'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - bzip2
+      - ncurses
+      - readline
+      - zlib
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
+        - '--docdir=/usr/share/doc/pcre2-10.39'
+        - '--enable-unicode'
+        - '--enable-jit'
+        - '--enable-pcre2-16'
+        - '--enable-pcre2-32'
+        - '--enable-pcre2grep-libz'
+        - '--enable-pcre2grep-libbz2'
+        - '--enable-pcre2test-libreadline'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: popt
     source:
       subdir: 'ports'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -153,6 +153,42 @@ packages:
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/macos/.keep']
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/ios/.keep']
 
+  - name: qtlanguageserver6
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: The Qt6 LSP library
+      description: This package provides the Qt6 LSP (Language Server Protocol) library, giving Qt6 support for LSP.
+      spdx: 'GPL-2.0-only GPL-3.0-only LGPL-3.0-only GFDL-1.3-only'
+      website: 'https://code.qt.io/cgit/qt/qtlanguageserver.git/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-qt']
+    source:
+      subdir: 'ports'
+      git: 'http://code.qt.io/qt/qtlanguageserver.git'
+      tag: 'v6.3.0'
+      version: '6.3.0'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+    pkgs_required:
+      - mlibc
+      - qtbase6
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_BUILD_TYPE=Debug'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: qtsvg6
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -152,3 +152,40 @@ packages:
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/QtBuildInternals/QtStandaloneTestTemplateProject/.keep']
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/macos/.keep']
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/ios/.keep']
+
+  - name: qtsvg6
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: The Qt6 SVG library
+      description: This package provides the Qt6 SVG library, giving Qt6 SVG support.
+      spdx: 'GPL-2.0-only GPL-3.0-only LGPL-3.0-only GFDL-1.3-only'
+      website: 'https://code.qt.io/cgit/qt/qtsvg.git/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-qt']
+    source:
+      subdir: 'ports'
+      git: 'http://code.qt.io/qt/qtsvg.git'
+      tag: 'v6.3.0'
+      version: '6.3.0'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+    pkgs_required:
+      - mlibc
+      - qtbase6
+      - zlib
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_BUILD_TYPE=Debug'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -26,3 +26,129 @@ tools:
       - args: ['cmake', '--build', '.', '--parallel', '@PARALLELISM@']
     install:
       - args: ['cmake', '--install', '.']
+
+packages:
+  - name: qtbase6
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: The Qt6 base libraries
+      description: This package provides the Qt6 base libraries, including QtCore, QtGui, QtWidgets and QtNetwork.
+      spdx: 'GPL-2.0-only GPL-3.0-only LGPL-3.0-only GFDL-1.3-only'
+      website: 'https://code.qt.io/cgit/qt/qtbase.git/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-qt']
+    source:
+      subdir: 'ports'
+      git: 'https://code.qt.io/qt/qtbase.git'
+      tag: 'v6.3.0'
+      version: '6.3.0'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - zlib
+      - zstd
+      - pcre2
+      - double-conversion
+      - libiconv
+      - icu
+      - glib
+      - libxkbcommon
+      - libinput
+      - libevdev
+      - mtdev
+      - mesa
+      - freetype
+      - fontconfig
+      - libpng
+      - harfbuzz
+      - libx11
+      - libjpeg-turbo
+      - libsm
+      - libice
+      - libdrm
+      - libxcb
+      - xcb-util-image
+      - xcb-util-keysyms
+      - xcb-util-wm
+      - xcb-util-render-util
+      - openssl
+      - wayland
+      - wayland-protocols
+      - libxcursor
+      - libxinerama
+      - libxrender
+      - libxi
+      - sqlite
+      - brotli
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
+        - '-DCMAKE_INSTALL_PREFIX=@THIS_COLLECT_DIR@/usr'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_BUILD_TYPE=Debug'
+        - '-DINSTALL_BINDIR=bin'
+        - '-DINSTALL_INCLUDEDIR=include/qt6'
+        - '-DINSTALL_LIBDIR=lib'
+        - '-DINSTALL_ARCHDATADIR=lib/qt6'
+        - '-DINSTALL_PLUGINSDIR=lib/qt6/plugins'
+        - '-DINSTALL_LIBEXECDIR=lib/qt6/libexec'
+        - '-DINSTALL_QMLDIR=lib/qt6/qml'
+        - '-DINSTALL_DATADIR=share/qt6'
+        - '-DINSTALL_DOCDIR=share/qt6-doc'
+        - '-DINSTALL_TRANSLATIONSDIR=share/qt6/translations'
+        - '-DINSTALL_SYSCONFDIR=/etc/xdg'
+        - '-DINSTALL_MKSPECSDIR=lib/qt6/mkspecs'
+        - '-DINSTALL_EXAMPLESDIR=share/qt6/examples'
+        - '-DBUILD_SHARED_LIBS=ON'
+        - '-DQT_BUILD_EXAMPLES=OFF'
+        - '-DQT_BUILD_TESTS=OFF'
+        - '-DFEATURE_concurrent=ON'
+        - '-DFEATURE_dbus=OFF'
+        - '-DFEATURE_gui=ON'
+        - '-DFEATURE_network=ON'
+        - '-DFEATURE_printsupport=ON'
+        - '-DFEATURE_sql=ON'
+        - '-DFEATURE_testlib=ON'
+        - '-DFEATURE_widgets=ON'
+        - '-DFEATURE_libudev=ON'
+        - '-DFEATURE_icu=ON'
+        - '-DFEATURE_glib=ON'
+        - '-DFEATURE_pcre2=ON'
+        - '-DFEATURE_xml=ON'
+        - '-DFEATURE_harfbuzz=ON'
+        - '-DFEATURE_xkbcommon=ON'
+        - '-DFEATURE_xkbcommon_x11=ON'
+        - '-DFEATURE_libinput=ON'
+        - '-DFEATURE_evdev=ON'
+        - '-DFEATURE_mtdev=ON'
+        - '-DFEATURE_egl=ON'
+        - '-DFEATURE_opengl=ON'
+        - '-DFEATURE_accessibility=OFF'
+        - '-DFEATURE_xlib=ON'
+        - '-DFEATURE_xcb=ON'
+        - '-DFEATURE_xcb_xlib=ON'
+        - '-DFEATURE_eglfs_gbm=ON'
+        - '-DFEATURE_eglfs_egldevice=ON'
+        - '-DFEATURE_gtk3=OFF'
+        - '-DFEATURE_system_sqlite=ON'
+        - '-DFEATURE_cups=OFF'
+        - '-DFEATURE_ssl=ON'
+        - '@THIS_SOURCE_DIR@'
+        environ:
+          PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'
+          PKG_CONFIG_LIBDIR: '@BUILD_ROOT@/system-root/usr/lib/pkgconfig:@BUILD_ROOT@/system-root/usr/share/pkgconfig'
+    build:
+      - args: ['cmake', '--build', '.', '--parallel', '@PARALLELISM@']
+      - args: ['cmake', '--install', '.']
+      # Touch a file in empty directories to keep xbps happy
+      - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/QtBuildInternals/QtStandaloneTestTemplateProject/.keep']
+      - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/macos/.keep']
+      - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/ios/.keep']

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -1,0 +1,28 @@
+sources:
+  - name: qt6
+    subdir: 'ports'
+    # This may seem strange, but is actually correct
+    git: 'https://code.qt.io/qt/qt5.git'
+    tag: 'v6.3.0'
+    version: '6.3.0'
+    regenerate:
+      # Get the submodules that we'll need as a host tool
+      - args: ['./init-repository', '-f', '--module-subset', 'qtbase,qtsvg,qtimageformats,qtshadertools,qtlanguageserver,qtdeclarative,qtwayland,qtmultimedia']
+
+tools:
+  # We do a limited superbuild with only the needed modules of Qt6 to satisfy host tooling.
+  - name: host-qt6
+    from_source: qt6
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DCMAKE_INSTALL_PREFIX=@PREFIX@'
+        - '-DBUILD_SHARED_LIBS=ON'
+        - '-DQT_BUILD_EXAMPLES=OFF'
+        - '-DQT_BUILD_TESTS=OFF'
+        - '@THIS_SOURCE_DIR@'
+    compile:
+      - args: ['cmake', '--build', '.', '--parallel', '@PARALLELISM@']
+    install:
+      - args: ['cmake', '--install', '.']

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -153,6 +153,48 @@ packages:
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/macos/.keep']
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/ios/.keep']
 
+  - name: qtdeclarative6
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: The Qt6 declarative library
+      description: This package provides the Qt6 declarative library, containing support for QML and QtQuick.
+      spdx: 'GPL-2.0-only GPL-3.0-only LGPL-3.0-only GFDL-1.3-only'
+      website: 'https://code.qt.io/cgit/qt/qtdeclarative.git/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-qt']
+    source:
+      subdir: 'ports'
+      git: 'http://code.qt.io/qt/qtdeclarative.git'
+      tag: 'v6.3.0'
+      version: '6.3.0'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+    pkgs_required:
+      - mlibc
+      - qtbase6
+      - qtimageformats6
+      - qtlanguageserver6
+      - qtshadertools6
+      - qtsvg6
+      - libxkbcommon
+      - mesa
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_BUILD_TYPE=Debug'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: qtimageformats6
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -153,6 +153,49 @@ packages:
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/macos/.keep']
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/lib/cmake/Qt6/ios/.keep']
 
+  - name: qtimageformats6
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: The Qt6 imageformats library
+      description: This package provides the Qt6 imageformats library, giving Qt6 support for several image formats.
+      spdx: 'GPL-2.0-only GPL-3.0-only LGPL-3.0-only GFDL-1.3-only'
+      website: 'https://code.qt.io/cgit/qt/qtimageformats.git/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-qt']
+    source:
+      subdir: 'ports'
+      git: 'http://code.qt.io/qt/qtimageformats.git'
+      tag: 'v6.3.0'
+      version: '6.3.0'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+    pkgs_required:
+      - mlibc
+      - qtbase6
+      - mesa
+      - libjpeg-turbo
+      - libwebp
+      - libtiff
+      - zlib
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_BUILD_TYPE=Debug'
+        - '-DINPUT_webp=system'
+        - '-DINPUT_tiff=system'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: qtlanguageserver6
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -274,6 +274,50 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: qtmultimedia6
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: The Qt6 multimedia library
+      description: This package provides the Qt6 multimedia library, containing support for multimedia (audio, video, radio and camera's) in Qt6.
+      spdx: 'GPL-2.0-only GPL-3.0-only LGPL-3.0-only GFDL-1.3-only'
+      website: 'https://code.qt.io/cgit/qt/qtmultimedia.git/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-qt']
+    source:
+      subdir: 'ports'
+      git: 'http://code.qt.io/qt/qtmultimedia.git'
+      tag: 'v6.3.0'
+      version: '6.3.0'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+    pkgs_required:
+      - mlibc
+      - qtbase6
+      - qtdeclarative6
+      - qtshadertools6
+      - libglvnd
+      - gstreamer
+      - gst-plugins-base
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_BUILD_TYPE=Debug'
+        - '-DFEATURE_gstreamer=ON'
+        - '-DFEATURE_alsa=OFF'
+        - '-DFEATURE_pulseaudio=OFF'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: qtshadertools6
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -189,6 +189,45 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: qtshadertools6
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: The Qt6 shadertools library
+      description: This package provides the Qt6 shadertools library, giving Qt6 shader support.
+      spdx: 'GPL-2.0-only GPL-3.0-only LGPL-3.0-only GFDL-1.3-only'
+      website: 'https://code.qt.io/cgit/qt/qtshadertools.git/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-qt']
+    source:
+      subdir: 'ports'
+      git: 'http://code.qt.io/qt/qtshadertools.git'
+      tag: 'v6.3.0'
+      version: '6.3.0'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+    pkgs_required:
+      - mlibc
+      - qtbase6
+      - mesa
+      - libxkbcommon
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
+        - '-DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_BUILD_TYPE=Debug'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: qtsvg6
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/games-board.yml
+++ b/bootstrap.d/games-board.yml
@@ -38,3 +38,41 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: libremines
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Qt based minesweeper
+      description: This package provides a Free/Libre and Open Source Software Qt based Minesweeper game available for GNU/Linux, FreeBSD, Windows and Managarm systems.
+      spdx: 'GPL-3.0-or-later'
+      website: 'https://github.com/Bollos00/LibreMines'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['games-board']
+    source:
+      subdir: ports
+      git: 'https://github.com/Bollos00/LibreMines.git'
+      tag: 'v1.9.1'
+      version: '1.9.1'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+    pkgs_required:
+      - mlibc
+      - qtbase6
+      - qtsvg6
+      - qtmultimedia6
+    configure:
+      - args:
+        - 'cmake'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_SYSTEM_PROCESSOR=@OPTION:arch@'
+        - '-DUSE_QT6=ON'
+        - '-Wno-dev'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -10,6 +10,7 @@ imports:
   - file: bootstrap.d/dev-lang.yml
   - file: bootstrap.d/dev-libs.yml
   - file: bootstrap.d/dev-util.yml
+  - file: bootstrap.d/dev-qt.yml
   - file: bootstrap.d/games-board.yml
   - file: bootstrap.d/games-fps.yml
   - file: bootstrap.d/games-misc.yml

--- a/patches/qtbase6/0001-Add-Managarm-support.patch
+++ b/patches/qtbase6/0001-Add-Managarm-support.patch
@@ -1,0 +1,321 @@
+From 8752a394dc6eba4d0e4d39f19da6898f9ee4c925 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 12 Apr 2022 15:50:25 +0200
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ cmake/QtBuild.cmake                           |  6 ++
+ cmake/QtPlatformSupport.cmake                 |  1 +
+ mkspecs/common/managarm.conf                  | 52 +++++++++++
+ mkspecs/common/posix/qplatformdefs.h          |  4 +-
+ mkspecs/managarm-g++/qmake.conf               | 12 +++
+ mkspecs/managarm-g++/qplatformdefs.h          | 88 +++++++++++++++++++
+ src/corelib/global/qsystemdetection.h         |  2 +
+ src/corelib/io/qstorageinfo_unix.cpp          |  3 +
+ src/gui/configure.cmake                       |  4 +-
+ src/network/kernel/qdnslookup_unix.cpp        |  2 +-
+ .../kmsconvenience/qkmsdevice.cpp             |  1 +
+ 11 files changed, 170 insertions(+), 5 deletions(-)
+ create mode 100644 mkspecs/common/managarm.conf
+ create mode 100644 mkspecs/managarm-g++/qmake.conf
+ create mode 100644 mkspecs/managarm-g++/qplatformdefs.h
+
+diff --git a/cmake/QtBuild.cmake b/cmake/QtBuild.cmake
+index 3d10fc38..d78d0e01 100644
+--- a/cmake/QtBuild.cmake
++++ b/cmake/QtBuild.cmake
+@@ -316,6 +316,12 @@ elseif(LINUX)
+     elseif(CLANG)
+         set(QT_DEFAULT_MKSPEC linux-clang)
+     endif()
++elseif(MANAGARM)
++    if(GCC)
++        set(QT_DEFAULT_MKSPEC managarm-g++)
++    else()
++        message(FATAL_ERROR "Unknown compiler in use!")
++    endif()
+ elseif(ANDROID)
+     if(GCC)
+         set(QT_DEFAULT_MKSPEC android-g++)
+diff --git a/cmake/QtPlatformSupport.cmake b/cmake/QtPlatformSupport.cmake
+index 11b31641..b54352b9 100644
+--- a/cmake/QtPlatformSupport.cmake
++++ b/cmake/QtPlatformSupport.cmake
+@@ -7,6 +7,7 @@ function(qt_set01 result)
+ endfunction()
+ 
+ qt_set01(LINUX CMAKE_SYSTEM_NAME STREQUAL "Linux")
++qt_set01(MANAGARM CMAKE_SYSTEM_NAME STREQUAL "managarm")
+ qt_set01(HPUX CMAKE_SYSTEM_NAME STREQUAL "HPUX")
+ qt_set01(ANDROID CMAKE_SYSTEM_NAME STREQUAL "Android")  # FIXME: How to identify this?
+ qt_set01(NACL CMAKE_SYSTEM_NAME STREQUAL "NaCl") # FIXME: How to identify this?
+diff --git a/mkspecs/common/managarm.conf b/mkspecs/common/managarm.conf
+new file mode 100644
+index 00000000..e7ea7d13
+--- /dev/null
++++ b/mkspecs/common/managarm.conf
+@@ -0,0 +1,52 @@
++#
++# qmake configuration for common managarm
++#
++
++QMAKE_PLATFORM         += managarm
++
++include(unix.conf)
++
++QMAKE_CFLAGS_THREAD    += -D_REENTRANT
++QMAKE_CXXFLAGS_THREAD  += $$QMAKE_CFLAGS_THREAD
++QMAKE_LFLAGS_GCSECTIONS = -Wl,--gc-sections
++
++QMAKE_LFLAGS_REL_RPATH  = -Wl,-z,origin
++QMAKE_REL_RPATH_BASE    = $ORIGIN
++
++QMAKE_INCDIR            =
++QMAKE_LIBDIR            =
++QMAKE_INCDIR_X11        =
++QMAKE_LIBDIR_X11        =
++QMAKE_INCDIR_OPENGL     =
++QMAKE_LIBDIR_OPENGL     =
++QMAKE_INCDIR_OPENGL_ES2 = $$QMAKE_INCDIR_OPENGL
++QMAKE_LIBDIR_OPENGL_ES2 = $$QMAKE_LIBDIR_OPENGL
++QMAKE_INCDIR_EGL        =
++QMAKE_LIBDIR_EGL        =
++QMAKE_INCDIR_OPENVG     =
++QMAKE_LIBDIR_OPENVG     =
++
++QMAKE_LIBS              =
++QMAKE_LIBS_DYNLOAD      = -ldl
++QMAKE_LIBS_X11          = -lXext -lX11 -lm
++QMAKE_LIBS_EGL          = -lEGL
++QMAKE_LIBS_OPENGL       = -lGL
++QMAKE_LIBS_OPENGL_ES2   = -lGLESv2
++QMAKE_LIBS_OPENVG       = -lOpenVG
++QMAKE_LIBS_THREAD       = -lpthread
++QMAKE_LIBS_VULKAN       =
++
++QMAKE_INCDIR_WAYLAND    =
++QMAKE_LIBS_WAYLAND_CLIENT = -lwayland-client
++QMAKE_LIBS_WAYLAND_SERVER = -lwayland-server
++QMAKE_LIBDIR_WAYLAND    =
++QMAKE_DEFINES_WAYLAND   =
++QMAKE_WAYLAND_SCANNER   = wayland-scanner
++
++QMAKE_AR                = ar cqs
++QMAKE_OBJCOPY           = objcopy
++QMAKE_NM                = nm -P
++QMAKE_RANLIB            =
++
++QMAKE_STRIP             = strip
++QMAKE_STRIPFLAGS_LIB   += --strip-unneeded
+diff --git a/mkspecs/common/posix/qplatformdefs.h b/mkspecs/common/posix/qplatformdefs.h
+index 3ebc5233..8a8cff25 100644
+--- a/mkspecs/common/posix/qplatformdefs.h
++++ b/mkspecs/common/posix/qplatformdefs.h
+@@ -48,7 +48,7 @@
+ #endif
+ #include <sys/stat.h>
+ 
+-#if defined(QT_USE_XOPEN_LFS_EXTENSIONS) && defined(QT_LARGEFILE_SUPPORT)
++#if defined(QT_USE_XOPEN_LFS_EXTENSIONS) && defined(QT_LARGEFILE_SUPPORT) && !defined(__managarm__)
+ 
+ #define QT_STATBUF              struct stat64
+ #define QT_FPOS_T               fpos64_t
+@@ -141,7 +141,7 @@
+ 
+ #if defined(QT_LARGEFILE_SUPPORT) \
+         && defined(QT_USE_XOPEN_LFS_EXTENSIONS) \
+-        && !defined(QT_NO_READDIR64)
++        && !defined(QT_NO_READDIR64) && !defined(__managarm__)
+ #define QT_DIRENT               struct dirent64
+ #define QT_READDIR              ::readdir64
+ #define QT_READDIR_R            ::readdir64_r
+diff --git a/mkspecs/managarm-g++/qmake.conf b/mkspecs/managarm-g++/qmake.conf
+new file mode 100644
+index 00000000..8dc4ff15
+--- /dev/null
++++ b/mkspecs/managarm-g++/qmake.conf
+@@ -0,0 +1,12 @@
++#
++# qmake configuration for managarm-g++
++#
++
++MAKEFILE_GENERATOR      = UNIX
++CONFIG                 += incremental
++QMAKE_INCREMENTAL_STYLE = sublib
++
++include(../common/linux.conf)
++include(../common/gcc-base-unix.conf)
++include(../common/g++-unix.conf)
++load(qt_config)
+diff --git a/mkspecs/managarm-g++/qplatformdefs.h b/mkspecs/managarm-g++/qplatformdefs.h
+new file mode 100644
+index 00000000..91654548
+--- /dev/null
++++ b/mkspecs/managarm-g++/qplatformdefs.h
+@@ -0,0 +1,88 @@
++/****************************************************************************
++**
++** Copyright (C) 2016 The Qt Company Ltd.
++** Contact: https://www.qt.io/licensing/
++**
++** This file is part of the qmake spec of the Qt Toolkit.
++**
++** $QT_BEGIN_LICENSE:LGPL$
++** Commercial License Usage
++** Licensees holding valid commercial Qt licenses may use this file in
++** accordance with the commercial license agreement provided with the
++** Software or, alternatively, in accordance with the terms contained in
++** a written agreement between you and The Qt Company. For licensing terms
++** and conditions see https://www.qt.io/terms-conditions. For further
++** information use the contact form at https://www.qt.io/contact-us.
++**
++** GNU Lesser General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU Lesser
++** General Public License version 3 as published by the Free Software
++** Foundation and appearing in the file LICENSE.LGPL3 included in the
++** packaging of this file. Please review the following information to
++** ensure the GNU Lesser General Public License version 3 requirements
++** will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
++**
++** GNU General Public License Usage
++** Alternatively, this file may be used under the terms of the GNU
++** General Public License version 2.0 or (at your option) the GNU General
++** Public license version 3 or any later version approved by the KDE Free
++** Qt Foundation. The licenses are as published by the Free Software
++** Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
++** included in the packaging of this file. Please review the following
++** information to ensure the GNU General Public License requirements will
++** be met: https://www.gnu.org/licenses/gpl-2.0.html and
++** https://www.gnu.org/licenses/gpl-3.0.html.
++**
++** $QT_END_LICENSE$
++**
++****************************************************************************/
++
++#ifndef QPLATFORMDEFS_H
++#define QPLATFORMDEFS_H
++
++// Get Qt defines/settings
++
++#include "qglobal.h"
++
++// Set any POSIX/XOPEN defines at the top of this file to turn on specific APIs
++
++// 1) need to reset default environment if _BSD_SOURCE is defined
++// 2) need to specify POSIX thread interfaces explicitly in glibc 2.0
++// 3) it seems older glibc need this to include the X/Open stuff
++#ifndef _GNU_SOURCE
++#  define _GNU_SOURCE
++#endif
++
++#include <unistd.h>
++
++
++// We are hot - unistd.h should have turned on the specific APIs we requested
++
++// mlibc doesn't do features.h
++//#include <features.h>
++#include <pthread.h>
++#include <dirent.h>
++#include <fcntl.h>
++#include <grp.h>
++#include <pwd.h>
++#include <signal.h>
++
++#include <sys/types.h>
++#include <sys/ioctl.h>
++#include <sys/ipc.h>
++#include <sys/time.h>
++#include <sys/shm.h>
++#include <sys/socket.h>
++#include <sys/stat.h>
++#include <sys/wait.h>
++#include <netinet/in.h>
++
++#define QT_USE_XOPEN_LFS_EXTENSIONS
++#include "../common/posix/qplatformdefs.h"
++
++#if defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 500)
++#define QT_SNPRINTF             ::snprintf
++#define QT_VSNPRINTF            ::vsnprintf
++#endif
++
++#endif // QPLATFORMDEFS_H
+diff --git a/src/corelib/global/qsystemdetection.h b/src/corelib/global/qsystemdetection.h
+index c8f98042..550d819b 100644
+--- a/src/corelib/global/qsystemdetection.h
++++ b/src/corelib/global/qsystemdetection.h
+@@ -165,6 +165,8 @@
+ #  define Q_OS_VXWORKS
+ #elif defined(__HAIKU__)
+ #  define Q_OS_HAIKU
++#elif defined(__managarm__)
++#  define Q_OS_MANAGARM
+ #elif defined(__MAKEDEPEND__)
+ #else
+ #  error "Qt has not been ported to this OS - see http://www.qt-project.org/"
+diff --git a/src/corelib/io/qstorageinfo_unix.cpp b/src/corelib/io/qstorageinfo_unix.cpp
+index 2b635f63..ef151f7b 100644
+--- a/src/corelib/io/qstorageinfo_unix.cpp
++++ b/src/corelib/io/qstorageinfo_unix.cpp
+@@ -100,6 +100,9 @@
+ #elif defined(Q_OS_HAIKU)
+ #  define QT_STATFSBUF struct statvfs
+ #  define QT_STATFS    ::statvfs
++#elif defined(Q_OS_MANAGARM)
++#  define QT_STATFSBUF struct statvfs
++#  define QT_STATFS    ::statvfs
+ #else
+ #  if defined(QT_LARGEFILE_SUPPORT)
+ #    define QT_STATFSBUF struct statvfs64
+diff --git a/src/gui/configure.cmake b/src/gui/configure.cmake
+index f59f0ab2..5af332df 100644
+--- a/src/gui/configure.cmake
++++ b/src/gui/configure.cmake
+@@ -25,7 +25,7 @@ set_property(CACHE INPUT_libpng PROPERTY STRINGS undefined no qt system)
+ 
+ 
+ #### Libraries
+-qt_set01(X11_SUPPORTED LINUX OR HPUX OR FREEBSD OR NETBSD OR OPENBSD OR SOLARIS) # special case
++qt_set01(X11_SUPPORTED LINUX OR HPUX OR FREEBSD OR NETBSD OR OPENBSD OR SOLARIS OR MANAGARM) # special case
+ qt_find_package(ATSPI2 PROVIDED_TARGETS PkgConfig::ATSPI2 MODULE_NAME gui QMAKE_LIB atspi)
+ qt_find_package(DirectFB PROVIDED_TARGETS PkgConfig::DirectFB MODULE_NAME gui QMAKE_LIB directfb)
+ qt_find_package(Libdrm PROVIDED_TARGETS Libdrm::Libdrm MODULE_NAME gui QMAKE_LIB drm)
+@@ -51,7 +51,7 @@ qt_find_package(WrapOpenGL PROVIDED_TARGETS WrapOpenGL::WrapOpenGL MODULE_NAME g
+ qt_find_package(GLESv2 PROVIDED_TARGETS GLESv2::GLESv2 MODULE_NAME gui QMAKE_LIB opengl_es2)
+ qt_find_package(Tslib PROVIDED_TARGETS PkgConfig::Tslib MODULE_NAME gui QMAKE_LIB tslib)
+ qt_find_package(WrapVulkanHeaders PROVIDED_TARGETS WrapVulkanHeaders::WrapVulkanHeaders MODULE_NAME gui QMAKE_LIB vulkan MARK_OPTIONAL) # special case
+-if((LINUX) OR QT_FIND_ALL_PACKAGES_ALWAYS)
++if((LINUX OR MANAGARM) OR QT_FIND_ALL_PACKAGES_ALWAYS)
+     qt_find_package(Wayland PROVIDED_TARGETS Wayland::Server MODULE_NAME gui QMAKE_LIB wayland_server)
+ endif()
+ if((X11_SUPPORTED) OR QT_FIND_ALL_PACKAGES_ALWAYS)
+diff --git a/src/network/kernel/qdnslookup_unix.cpp b/src/network/kernel/qdnslookup_unix.cpp
+index 1449c329..88fcd997 100644
+--- a/src/network/kernel/qdnslookup_unix.cpp
++++ b/src/network/kernel/qdnslookup_unix.cpp
+@@ -50,7 +50,7 @@
+ #include <sys/types.h>
+ #include <netinet/in.h>
+ #include <arpa/nameser.h>
+-#if !defined(Q_OS_OPENBSD)
++#if !defined(Q_OS_OPENBSD) && !defined(Q_OS_MANAGARM)
+ #  include <arpa/nameser_compat.h>
+ #endif
+ #include <resolv.h>
+diff --git a/src/platformsupport/kmsconvenience/qkmsdevice.cpp b/src/platformsupport/kmsconvenience/qkmsdevice.cpp
+index 4206b20a..71127dd8 100644
+--- a/src/platformsupport/kmsconvenience/qkmsdevice.cpp
++++ b/src/platformsupport/kmsconvenience/qkmsdevice.cpp
+@@ -48,6 +48,7 @@
+ #include <QtCore/QLoggingCategory>
+ 
+ #include <errno.h>
++#include <strings.h>
+ 
+ #define ARRAY_LENGTH(a) (sizeof (a) / sizeof (a)[0])
+ 
+-- 
+2.35.1
+

--- a/patches/qtdeclarative6/0001-Add-Managarm-support.patch
+++ b/patches/qtdeclarative6/0001-Add-Managarm-support.patch
@@ -1,0 +1,26 @@
+From 0f621751720c979e6b792ed4f087860a06efd5f8 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 18 Apr 2022 21:23:04 +0200
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ src/qml/jit/qv4assemblercommon_p.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/qml/jit/qv4assemblercommon_p.h b/src/qml/jit/qv4assemblercommon_p.h
+index c91a61a0..bcf477bb 100644
+--- a/src/qml/jit/qv4assemblercommon_p.h
++++ b/src/qml/jit/qv4assemblercommon_p.h
+@@ -66,7 +66,7 @@ namespace QV4 {
+ namespace JIT {
+ 
+ #if defined(Q_PROCESSOR_X86_64) || defined(ENABLE_ALL_ASSEMBLERS_FOR_REFACTORING_PURPOSES)
+-#if defined(Q_OS_LINUX) || defined(Q_OS_QNX) || defined(Q_OS_FREEBSD) || defined(Q_OS_DARWIN)
++#if defined(Q_OS_LINUX) || defined(Q_OS_QNX) || defined(Q_OS_FREEBSD) || defined(Q_OS_DARWIN) || defined(Q_OS_MANAGARM)
+ 
+ class PlatformAssembler_X86_64_SysV : public JSC::MacroAssembler<JSC::MacroAssemblerX86_64>
+ {
+-- 
+2.35.2
+


### PR DESCRIPTION
This PR adds the following ports:

- `double-conversion`;
- `brotli`;
- `pcre2`;
- `qtbase`;
- `qtsvg`;
- `qtlanguageserver`;
- `qtshadertools`;
- `qtimageformats`;
- `qtdeclarative`;
- `qtmultimedia`;
- `libremines`.

Blocked on managarm/mlibc#406
Blocked on #176 