### PR TITLE
Add several libraries to be used by Qt and GTK

### DIFF
--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -210,6 +210,64 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: gst-plugins-base
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Basepack of plugins for GStreamer
+      description: The GStreamer Base Plug-ins is a well-groomed and well-maintained collection of GStreamer plug-ins and elements, spanning the range of possible types of elements one would want to write for GStreamer.
+      spdx: 'LGPL-2.0-or-later GPL-2.0-or-later'
+      website: 'https://gstreamer.freedesktop.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['media-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git'
+      tag: '1.19.1'
+      version: '1.19.1'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - wayland-scanner
+    pkgs_required:
+      - mlibc
+      - gstreamer
+      - mesa
+      - wayland-protocols
+      - libogg
+      - libtheora
+      - libvorbis
+      - libjpeg-turbo
+      - libpng
+      - libx11
+      - glib
+      - zlib
+      - libdrm
+      - wayland
+      - pango
+      - libxext
+    configure:
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        - '--buildtype=debugoptimized'
+        - '-Dintrospection=disabled'
+        - '--wrap-mode=nodownload'
+        - '-Dorc=disabled'
+        - '-Dexamples=disabled'
+        - '-Dpackage-origin=https://managarm.org/'
+        - '-Dpackage-name="GStreamer 1.19.1 Managarm"'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: gstreamer
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -210,6 +210,53 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: gstreamer
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Open source multimedia framework
+      description: This package contains a streaming media framework that enables applications to share a common set of plugins for tasks such as video encoding and decoding, audio encoding and decoding, audio and video filters, audio visualisation, web streaming and anything else that streams in real-time or otherwise. This package only provides base functionality and libraries of the GStreamer stack.
+      spdx: 'LGPL-2.0-or-later'
+      website: 'https://gstreamer.freedesktop.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['media-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.freedesktop.org/gstreamer/gstreamer.git'
+      tag: '1.19.1'
+      version: '1.19.1'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+    configure:
+      - args:
+        - 'meson'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        - '--buildtype=debugoptimized'
+        - '-Dintrospection=disabled'
+        - '-Dptp-helper-setuid-user=false'
+        - '-Dptp-helper-setuid-group=false'
+        - '-Dptp-helper-permissions=none'
+        - '-Dlibunwind=disabled'
+        - '-Dlibdw=disabled'
+        - '-Dgst_debug=false'
+        - '-Dcheck=disabled'
+        - '-Dpackage-origin=https://managarm.org/'
+        - '-Dpackage-name="GStreamer 1.19.1 Managarm"'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: harfbuzz
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -457,6 +457,58 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libtiff
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Tag Image File Format (TIFF) library
+      description: This package contains the TIFF libraries and associated utilities. The libraries are used by many programs for reading and writing TIFF files and the utilities are used for general work with TIFF files.
+      spdx: 'libtiff'
+      website: 'http://libtiff.maptools.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['media-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.com/libtiff/libtiff.git'
+      tag: 'v4.3.0'
+      version: '4.3.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - host-cmake
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - freeglut
+      - libjpeg-turbo
+      - zlib
+      - zstd
+      - xz-utils
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--enable-shared'
+        - '--with-docdir=/usr/share/doc/libtiff-4.3.0'
+        - '--without-x'
+        - '--enable-zlib'
+        - '--enable-zstd'
+        - '--enable-jpeg'
+        - '--enable-lzma'
+        - '--disable-webp'
+        - '--enable-cxx'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libtheora
     source:
       subdir: 'ports'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -580,6 +580,53 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libwebp
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: A lossy image compression format
+      description: This package contains a library and support programs to encode and decode images in WebP format.
+      spdx: 'BSD-3-Clause'
+      website: 'https://github.com/webmproject/libwebp'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['media-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/webmproject/libwebp.git'
+      tag: 'v1.2.2'
+      version: '1.2.2'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - libjpeg-turbo
+      - libpng
+      - freeglut
+      - sdl2
+      - libtiff
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--enable-libwebpmux'
+        - '--enable-libwebpdemux'
+        - '--enable-libwebpdecoder'
+        - '--enable-libwebpextras'
+        - '--enable-swap-16bit-csp'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: mesa
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/patches/libtiff/0001-Don-t-fetch-new-versions-of-config.guess-and-config..patch
+++ b/patches/libtiff/0001-Don-t-fetch-new-versions-of-config.guess-and-config..patch
@@ -1,0 +1,36 @@
+From b5f632aa5df4e20361367fb3df6d768ca34a539e Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 19 Apr 2022 20:57:12 +0200
+Subject: [PATCH] Don't fetch new versions of config.guess and config.sub by
+ default
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ autogen.sh | 14 +-------------
+ 1 file changed, 1 insertion(+), 13 deletions(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index 9ef71b5..5633885 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -5,16 +5,4 @@ aclocal -I ./m4
+ autoheader
+ automake --foreign --add-missing --copy
+ autoconf
+-# Get latest config.guess and config.sub from upstream master since
+-# these are often out of date.
+-for file in config.guess config.sub
+-do
+-    echo "$0: getting $file..."
+-    wget -q --timeout=5 -O config/$file.tmp \
+-      "https://git.savannah.gnu.org/cgit/config.git/plain/${file}" \
+-      && mv config/$file.tmp config/$file \
+-      && chmod a+x config/$file
+-    retval=$?
+-    rm -f config/$file.tmp
+-    test $retval -eq 0 || exit $retval
+-done
++
+-- 
+2.35.2
+


### PR DESCRIPTION
This PR splits off the `libwebp` port from #169, the `gstreamer` and `gst-plugins-base` ports from #152 and adds a port of `libtiff`, in preparation of `Qt6` and `GTK` to use them.

Blocked on managarm/mlibc#406