### PR TITLE
Add NSPR and NSS ports

### DIFF
--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -15,7 +15,7 @@ packages:
       tag: 'v1.7'
       # While unusual, version will be the date of the last bump + the NSS version used.
       # If needed, we can always fetch a set NSS commit past the last release to fix critical bugs.
-      version: '20211107.3.72'
+      version: '20220427.3.77'
     tools_required:
       - system-gcc
     pkgs_required:

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -1115,6 +1115,115 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: nss
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Mozilla's Network Security Services library that implements PKI support
+      description: This package provides a set of libraries designed to support cross-platform development of security-enabled client and server applications.
+      spdx: 'MPL-2.0 GPL-2.0-only LGPL-2.1-only'
+      website: 'https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    from_source: nss
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - nspr
+      - sqlite
+      - zlib
+    configure:
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
+    build:
+      # First, build a host version of nsinstall.
+      - args: ['make', '-C', '@THIS_BUILD_DIR@/coreconf/']
+        environ:
+          CC: 'gcc'
+          BUILD_OPT: '1'
+          NSPR_INCLUDE_DIR: '/usr/include/nspr'
+          USE_SYSTEM_ZLIB: '1'
+          ZLIB_LIBS: '-lz'
+          NSS_ENABLE_WERROR: '0'
+          USE_64: '1'
+          NSS_USE_SYSTEM_SQLITE: '1'
+          NS_USE_GCC: '1'
+          CC_IS_GCC: '1'
+          NSDISTMODE: 'copy'
+      # Then, build some configuration items courtesy of BLFS (see the patches).
+      - args: |
+            make V=1 -C @THIS_BUILD_DIR@/config NSINSTALL=@THIS_BUILD_DIR@/$(find -type f -name nsinstall) -j1
+        environ:
+          # Optimized builds.
+          BUILD_OPT: '1'
+          # NSPR is here.
+          NSPR_INCLUDE_DIR: '@SYSROOT_DIR@/usr/include/nspr'
+          # Use our zlib.
+          USE_SYSTEM_ZLIB: '1'
+          # Freestanding freebl yes please.
+          FREEBL_NO_DEPEND: '1'
+          FREEBL_LOWHASH: '1'
+          NSS_SEED_ONLY_DEV_URANDOM: '1'
+          # Link with zlib.
+          ZLIB_LIBS: '-lz'
+          # Do not enable Werror.
+          NSS_ENABLE_WERROR: '0'
+          # We are 64 bit.
+          USE_64: '1'
+          # Use system sqlite.
+          NSS_USE_SYSTEM_SQLITE: '1'
+          # We're using gcc.
+          NS_USE_GCC: '1'
+          CC_IS_GCC: '1'
+          # We're cross compiling.
+          CROSS_COMPILE: '1'
+          # Don't symlink files, copy them.
+          NSDISTMODE: 'copy'
+          # Do not build the tests.
+          NSS_DISABLE_GTESTS: '1'
+          # Put the libs and binaries here.
+          SOURCE_PREFIX: '@THIS_BUILD_DIR@/dist'
+          # Specify the compiler.
+          CC: 'x86_64-managarm-gcc'
+          CXX: 'x86_64-managarm-g++'
+      # Then build the main libraries and binaries.
+      - args: |
+            make V=1 -C @THIS_BUILD_DIR@/. NSINSTALL=@THIS_BUILD_DIR@/$(find -type f -name nsinstall) -j1
+        environ:
+          BUILD_OPT: '1'
+          NSPR_INCLUDE_DIR: '@SYSROOT_DIR@/usr/include/nspr'
+          USE_SYSTEM_ZLIB: '1'
+          FREEBL_NO_DEPEND: '1'
+          FREEBL_LOWHASH: '1'
+          NSS_SEED_ONLY_DEV_URANDOM: '1'
+          ZLIB_LIBS: '-lz'
+          NSS_ENABLE_WERROR: '0'
+          USE_64: '1'
+          NSS_USE_SYSTEM_SQLITE: '1'
+          NS_USE_GCC: '1'
+          CC_IS_GCC: '1'
+          CROSS_COMPILE: '1'
+          NSDISTMODE: 'copy'
+          NSS_DISABLE_GTESTS: '1'
+          SOURCE_PREFIX: '@THIS_BUILD_DIR@/dist'
+          CC: 'x86_64-managarm-gcc'
+          CXX: 'x86_64-managarm-g++'
+      # Create some directories to install into.
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/lib/pkgconfig']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/bin']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/include']
+      # And install everything, this _will_ break on a non Linux box, but unfortunately NSS hardcodes kernel names and versions.
+      # If someone wants to patch NSS to not do that, greatly appreciated.
+      # These install instructions are adapted from BLFS, and not Gentoo as I usually do.
+      - args: |
+            cd dist
+            install -v -m755 Linux*/lib/*.so @THIS_COLLECT_DIR@/usr/lib
+            install -v -m644 Linux*/lib/{*.chk,libcrmf.a} @THIS_COLLECT_DIR@/usr/lib
+            install -v -m755 -d @THIS_COLLECT_DIR@/usr/include/nss
+            cp -v -RL {public,private}/nss/* @THIS_COLLECT_DIR@/usr/include/nss
+            chmod -v 644 @THIS_COLLECT_DIR@/usr/include/nss/*
+            install -v -m755 Linux*/bin/{certutil,nss-config,pk12util} @THIS_COLLECT_DIR@/usr/bin
+            install -v -m644 Linux*/lib/pkgconfig/nss.pc @THIS_COLLECT_DIR@/usr/lib/pkgconfig
+
   - name: openssl
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -1060,6 +1060,61 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: nspr
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Netscape Portable Runtime (NSPR)
+      description: This package provides a platform-neutral API for system level and libc like functions.
+      spdx: 'MPL-2.0 GPL-2.0-only LGPL-2.1-only'
+      website: 'https://www.mozilla.org/projects/nspr/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: 'ports'
+      hg: 'https://hg.mozilla.org/projects/nspr/'
+      tag: 'NSPR_4_33_RTM'
+      version: '4.33'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/build/autoconf/']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+    configure:
+      # Disable installing two unneeded scripts.
+      - args: ['sed', '-ri', '/^RELEASE/s/^/#/', '@THIS_SOURCE_DIR@/pr/src/misc/Makefile.in']
+      # Disable installing static libraries.
+      - args: ['sed', '-i', 's#$(LIBRARY) ##', '@THIS_SOURCE_DIR@/config/rules.mk']
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=x86_64-linux'
+        - '--build=x86_64-linux'
+        - '--prefix=/usr'
+        - '--with-mozilla'
+        - '--with-pthreads'
+        - '--enable-64bit'
+        environ:
+          CROSS_COMPILE: '1'
+    build:
+      # We first build a native nsinstall that the build can use later on.
+      - args: ['make', 'CC=gcc', 'CXX=g++', '-C', '@THIS_BUILD_DIR@/config/']
+      - args: ['mv', '-v', '@THIS_BUILD_DIR@/config/nsinstall', '@THIS_BUILD_DIR@/config/native-nsinstall']
+      - args: ['sed', '-s', 's#/nsinstall$#/native-nsinstall#', '-i', '@THIS_BUILD_DIR@/config/autoconf.mk']
+      - args: ['rm', '-v', '@THIS_BUILD_DIR@/config/nsinstall.o']
+      # Then build the real deal
+      - args: ['make', 'CC=x86_64-managarm-gcc', 'CXX=x86_64-managarm-g++', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: openssl
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -30,8 +30,8 @@ sources:
   - name: nss
     subdir: 'ports'
     git: 'https://github.com/nss-dev/nss.git'
-    tag: 'NSS_3_72_RTM'
-    version: 'NSS_3_72_RTM'
+    tag: 'NSS_3_77_RTM'
+    version: '3.77.RTM'
 
 tools:
   - name: host-glib

--- a/patches/nss/0001-Add-a-missing-include.patch
+++ b/patches/nss/0001-Add-a-missing-include.patch
@@ -1,0 +1,25 @@
+From 8c7f96493b8706d43b30f49d56e0e84ee27fe65e Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 27 Apr 2022 20:27:21 +0200
+Subject: [PATCH 1/2] Add a missing include
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ lib/dbm/src/h_page.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/lib/dbm/src/h_page.c b/lib/dbm/src/h_page.c
+index d4e4ff6..7b3271e 100644
+--- a/lib/dbm/src/h_page.c
++++ b/lib/dbm/src/h_page.c
+@@ -81,6 +81,7 @@ static char sccsid[] = "@(#)hash_page.c 8.7 (Berkeley) 8/16/94";
+ #endif
+ 
+ #include <assert.h>
++#include <endian.h>
+ 
+ #include "mcom_db.h"
+ #include "hash.h"
+-- 
+2.36.0
+

--- a/patches/nss/0002-NSS-Standalone-patch.patch
+++ b/patches/nss/0002-NSS-Standalone-patch.patch
@@ -1,0 +1,259 @@
+From ee4b3e43e0143f94289c418c0db5f803119e8be6 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 27 Apr 2022 20:35:40 +0200
+Subject: [PATCH 2/2] NSS Standalone patch
+
+Taken from Beyond Linux From Scratch (https://www.linuxfromscratch.org/patches/blfs/svn/nss-3.77-standalone-1.patch)
+
+Adds auto-generated nss.pc and nss-config script, and allows building without nspr in the source tree.
+Minimum NSPR version is now read out from package, instead of hardcoded value in the patch.
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ config/Makefile      |  41 ++++++++++++
+ config/nss-config.in | 152 +++++++++++++++++++++++++++++++++++++++++++
+ config/nss.pc.in     |  11 ++++
+ manifest.mn          |   2 +-
+ 4 files changed, 205 insertions(+), 1 deletion(-)
+ create mode 100644 config/Makefile
+ create mode 100644 config/nss-config.in
+ create mode 100644 config/nss.pc.in
+
+diff --git a/config/Makefile b/config/Makefile
+new file mode 100644
+index 0000000..662020a
+--- /dev/null
++++ b/config/Makefile
+@@ -0,0 +1,41 @@
++CORE_DEPTH = ..
++DEPTH      = ..
++
++include $(CORE_DEPTH)/coreconf/config.mk
++
++NSS_MAJOR_VERSION = `grep "NSS_VMAJOR" ../lib/nss/nss.h | awk '{print $$3}'`
++NSS_MINOR_VERSION = `grep "NSS_VMINOR" ../lib/nss/nss.h | awk '{print $$3}'`
++NSS_PATCH_VERSION = `grep "NSS_VPATCH" ../lib/nss/nss.h | awk '{print $$3}'`
++NSS_NSPR_MINIMUM = `head -n1 ../automation/release/nspr-version.txt`
++PREFIX = /usr
++
++all: export libs
++
++export:
++	# Create the nss.pc file
++	mkdir -p $(DIST)/lib/pkgconfig
++	sed -e "s,@prefix@,$(PREFIX)," \
++	    -e "s,@exec_prefix@,\$${prefix}," \
++	    -e "s,@libdir@,\$${prefix}/lib," \
++	    -e "s,@includedir@,\$${prefix}/include/nss," \
++	    -e "s,@NSS_MAJOR_VERSION@,$(NSS_MAJOR_VERSION),g" \
++	    -e "s,@NSS_MINOR_VERSION@,$(NSS_MINOR_VERSION)," \
++	    -e "s,@NSS_PATCH_VERSION@,$(NSS_PATCH_VERSION)," \
++	    -e "s,@NSS_NSPR_MINIMUM@,$(NSS_NSPR_MINIMUM)," \
++	    nss.pc.in > nss.pc
++	chmod 0644 nss.pc
++	cp -v nss.pc $(DIST)/lib/pkgconfig
++
++	# Create the nss-config script
++	mkdir -p $(DIST)/bin
++	sed -e "s,@prefix@,$(PREFIX)," \
++	    -e "s,@NSS_MAJOR_VERSION@,$(NSS_MAJOR_VERSION)," \
++	    -e "s,@NSS_MINOR_VERSION@,$(NSS_MINOR_VERSION)," \
++	    -e "s,@NSS_PATCH_VERSION@,$(NSS_PATCH_VERSION)," \
++	    nss-config.in > nss-config
++	chmod 0755 nss-config
++	cp -v nss-config $(DIST)/bin
++
++libs:
++
++dummy: all export libs
+diff --git a/config/nss-config.in b/config/nss-config.in
+new file mode 100644
+index 0000000..7e3750d
+--- /dev/null
++++ b/config/nss-config.in
+@@ -0,0 +1,152 @@
++#!/bin/sh
++
++prefix=@prefix@
++
++major_version=@NSS_MAJOR_VERSION@
++minor_version=@NSS_MINOR_VERSION@
++patch_version=@NSS_PATCH_VERSION@
++
++usage()
++{
++	cat <<EOF
++Usage: nss-config [OPTIONS] [LIBRARIES]
++Options:
++	[--prefix[=DIR]]
++	[--exec-prefix[=DIR]]
++	[--includedir[=DIR]]
++	[--libdir[=DIR]]
++	[--version]
++	[--libs]
++	[--cflags]
++Dynamic Libraries:
++	nss
++	nssutil
++	smime
++	ssl
++	softokn
++EOF
++	exit $1
++}
++
++if test $# -eq 0; then
++	usage 1 1>&2
++fi
++
++lib_nss=yes
++lib_nssutil=yes
++lib_smime=yes
++lib_ssl=yes
++lib_softokn=yes
++
++while test $# -gt 0; do
++  case "$1" in
++  -*=*) optarg=`echo "$1" | sed 's/[-_a-zA-Z0-9]*=//'` ;;
++  *) optarg= ;;
++  esac
++
++  case $1 in
++    --prefix=*)
++      prefix=$optarg
++      ;;
++    --prefix)
++      echo_prefix=yes
++      ;;
++    --exec-prefix=*)
++      exec_prefix=$optarg
++      ;;
++    --exec-prefix)
++      echo_exec_prefix=yes
++      ;;
++    --includedir=*)
++      includedir=$optarg
++      ;;
++    --includedir)
++      echo_includedir=yes
++      ;;
++    --libdir=*)
++      libdir=$optarg
++      ;;
++    --libdir)
++      echo_libdir=yes
++      ;;
++    --version)
++      echo ${major_version}.${minor_version}.${patch_version}
++      ;;
++    --cflags)
++      echo_cflags=yes
++      ;;
++    --libs)
++      echo_libs=yes
++      ;;
++    nss)
++      lib_nss=yes
++      ;;
++    nssutil)
++      lib_nssutil=yes
++      ;;
++    smime)
++      lib_smime=yes
++      ;;
++    ssl)
++      lib_ssl=yes
++      ;;
++    softokn)
++      lib_softokn=yes
++      ;;
++    *)
++      usage 1 1>&2
++      ;;
++  esac
++  shift
++done
++
++# Set variables that may be dependent upon other variables
++if test -z "$exec_prefix"; then
++    exec_prefix=`pkg-config --variable=exec_prefix nss`
++fi
++if test -z "$includedir"; then
++    includedir=`pkg-config --variable=includedir nss`
++fi
++if test -z "$libdir"; then
++    libdir=`pkg-config --variable=libdir nss`
++fi
++
++if test "$echo_prefix" = "yes"; then
++    echo $prefix
++fi
++
++if test "$echo_exec_prefix" = "yes"; then
++    echo $exec_prefix
++fi
++
++if test "$echo_includedir" = "yes"; then
++    echo $includedir
++fi
++
++if test "$echo_libdir" = "yes"; then
++    echo $libdir
++fi
++
++if test "$echo_cflags" = "yes"; then
++    echo -I$includedir
++fi
++
++if test "$echo_libs" = "yes"; then
++      libdirs="-L$libdir"
++      if test -n "$lib_nss"; then
++	libdirs="$libdirs -lnss${major_version}"
++      fi
++      if test -n "$lib_nssutil"; then
++        libdirs="$libdirs -lnssutil${major_version}"
++      fi
++      if test -n "$lib_smime"; then
++	libdirs="$libdirs -lsmime${major_version}"
++      fi
++      if test -n "$lib_ssl"; then
++	libdirs="$libdirs -lssl${major_version}"
++      fi
++      if test -n "$lib_softokn"; then
++        libdirs="$libdirs -lsoftokn${major_version}"
++      fi
++      echo $libdirs
++fi
+diff --git a/config/nss.pc.in b/config/nss.pc.in
+new file mode 100644
+index 0000000..c8c263d
+--- /dev/null
++++ b/config/nss.pc.in
+@@ -0,0 +1,11 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++
++Name: NSS
++Description: Network Security Services
++Version: @NSS_MAJOR_VERSION@.@NSS_MINOR_VERSION@.@NSS_PATCH_VERSION@
++Requires: nspr >= @NSS_NSPR_MINIMUM@
++Libs: -L@libdir@ -lnss@NSS_MAJOR_VERSION@ -lnssutil@NSS_MAJOR_VERSION@ -lsmime@NSS_MAJOR_VERSION@ -lssl@NSS_MAJOR_VERSION@ -lsoftokn@NSS_MAJOR_VERSION@
++Cflags: -I${includedir}
+diff --git a/manifest.mn b/manifest.mn
+index fbc420a..b983d88 100644
+--- a/manifest.mn
++++ b/manifest.mn
+@@ -10,7 +10,7 @@ IMPORTS =	nspr20/v4.8 \
+ 
+ RELEASE = nss
+ 
+-DIRS = coreconf lib cmd cpputil gtests
++DIRS = coreconf lib cmd cpputil gtests config
+ 
+ HAVE_ALL_TARGET := 1
+ 
+-- 
+2.36.0
+


### PR DESCRIPTION
This PR updates ca-certs to the version from NSS 3.77, and adds ports for NSPR and NSS.

Blocked on managarm/mlibc#415