### PR TITLE
rust: port alacritty

### DIFF
--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -2,8 +2,8 @@ sources:
   - name: rust-libc
     subdir: 'ports'
     git: 'https://github.com/rust-lang/libc.git'
-    tag: '0.2.117'
-    version: '0.2.117'
+    tag: '0.2.125'
+    version: '0.2.125'
 
   - name: rust-num-cpus
     subdir: 'ports'
@@ -23,17 +23,83 @@ sources:
     tag: '0.3.64'
     version: '0.3.64'
 
+  - name: rust-calloop
+    subdir: 'ports'
+    git: 'https://github.com/Smithay/calloop.git'
+    tag: 'v0.9.3'
+    version: '0.9.3'
+
+  - name: rust-libloading
+    subdir: 'ports'
+    git: 'https://github.com/nagisa/rust_libloading.git'
+    tag: '0.7.3'
+    version: '0.7.3'
+
+  - name: rust-mio-0.6
+    subdir: 'ports'
+    git: 'https://github.com/tokio-rs/mio.git'
+    tag: 'v0.6.23'
+    version: '0.6.23'
+
+  - name: rust-mio-0.8
+    subdir: 'ports'
+    git: 'https://github.com/tokio-rs/mio.git'
+    tag: 'v0.8.3'
+    version: '0.8.3'
+
+  - name: rust-nix
+    subdir: 'ports'
+    git: 'https://github.com/nix-rust/nix.git'
+    tag: 'v0.22.3'
+    version: '0.22.3'
+
+  - name: rust-winit
+    subdir: 'ports'
+    git: 'https://github.com/rust-windowing/winit.git'
+    tag: 'v0.26.1'
+    version: '0.26.1'
+
+  - name: rust-glutin
+    subdir: 'ports'
+    git: 'https://github.com/rust-windowing/glutin.git'
+    tag: 'v0.28.0'
+    version: '0.28.0'
+
+  - name: rust-shared-library
+    subdir: 'ports'
+    git: 'https://github.com/tomaka/shared_library.git'
+    commit: 'f09e038246a559650c8505b3b3831b820d1a5689'
+    branch: 'master'
+    version: '0.1.9'
+
   - name: rust-patched-libs
     subdir: 'ports'
     sources_required:
+      - name: rust-backtrace
+        recursive: true
+      - name: rust-calloop
+        recursive: true
       - name: rust-libc
+        recursive: true
+      - name: rust-libloading
+        recursive: true
+      - name: rust-mio-0.6
+        recursive: true
+      - name: rust-mio-0.8
+        recursive: true
+      - name: rust-nix
         recursive: true
       - name: rust-num-cpus
         recursive: true
       - name: rust-users
         recursive: true
-      - name: rust-backtrace
+      - name: rust-winit
         recursive: true
+      - name: rust-glutin
+        recursive: true
+      - name: rust-shared-library
+        recursive: true
+
 
 packages:
   - name: gdbm

--- a/bootstrap.d/x11-terms.yml
+++ b/bootstrap.d/x11-terms.yml
@@ -1,0 +1,40 @@
+packages:
+  - name: alacritty
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: GPU-accelerated terminal emulator
+      description: Alacritty is a GPU-accelerated terminal emulator, written in Rust.
+      spdx: 'Apache-2.0'
+      website: 'https://github.com/alacritty/alacritty'
+      maintainer: "Matt Taylor <mstaveleytaylor@gmail.com>"
+      categories: ['x11-terms']
+    source:
+      subdir: ports
+      git: 'https://github.com/alacritty/alacritty'
+      tag: 'v0.10.0'
+      version: '0.10.0'
+    tools_required:
+      - host-cargo
+      - system-gcc
+    sources_required:
+      - rust-patched-libs
+    pkgs_required:
+      - mlibc
+      - fontconfig
+    configure:
+      - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
+    build:
+      - args: ['install', '-D', '@THIS_SOURCE_DIR@/alacritty.yml', '@THIS_COLLECT_DIR@/root/.alacritty.yml']
+      - args:
+        - 'cargo'
+        - 'install'
+        - '--locked'
+        - '--target-dir'
+        - '@THIS_BUILD_DIR@'
+        - '--path'
+        - '@THIS_SOURCE_DIR@/alacritty'
+        - '--root'
+        - '@THIS_COLLECT_DIR@/usr'
+        - '-j@PARALLELISM@'
+        environ: # Required to build libgit2
+          CC: x86_64-managarm-gcc

--- a/bootstrap.d/x11-terms.yml
+++ b/bootstrap.d/x11-terms.yml
@@ -11,8 +11,8 @@ packages:
     source:
       subdir: ports
       git: 'https://github.com/alacritty/alacritty'
-      tag: 'v0.10.0'
-      version: '0.10.0'
+      tag: 'v0.10.1'
+      version: '0.10.1'
     tools_required:
       - host-cargo
       - system-gcc
@@ -21,6 +21,8 @@ packages:
     pkgs_required:
       - mlibc
       - fontconfig
+      - freetype
+      - wayland
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
@@ -28,6 +30,9 @@ packages:
       - args:
         - 'cargo'
         - 'install'
+        - '--no-default-features'
+        - '--features'
+        - 'wayland'
         - '--locked'
         - '--target-dir'
         - '@THIS_BUILD_DIR@'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -32,6 +32,7 @@ imports:
   - file: bootstrap.d/x11-base.yml
   - file: bootstrap.d/x11-libs.yml
   - file: bootstrap.d/x11-misc.yml
+  - file: bootstrap.d/x11-terms.yml
   - file: bootstrap.d/x11-themes.yml
 
 general:

--- a/extrafiles/config.toml
+++ b/extrafiles/config.toml
@@ -9,7 +9,17 @@ target = "x86_64-unknown-managarm-system"
 linker = "@BUILD_ROOT@/tools/system-gcc/bin/x86_64-managarm-gcc"
 
 [patch.crates-io]
+backtrace = { path = "@SOURCE_ROOT@/ports/rust-backtrace" }
+calloop = { path = "@SOURCE_ROOT@/ports/rust-calloop" }
 libc = { path = "@SOURCE_ROOT@/ports/rust-libc" }
+libloading = { path = "@SOURCE_ROOT@/ports/rust-libloading" }
+mio-06 = { path = "@SOURCE_ROOT@/ports/rust-mio-0.6", package = "mio" }
+mio-08 = { path = "@SOURCE_ROOT@/ports/rust-mio-0.8", package = "mio" }
+nix = { path = "@SOURCE_ROOT@/ports/rust-nix" }
 num_cpus = { path = "@SOURCE_ROOT@/ports/rust-num-cpus" }
 users = { path = "@SOURCE_ROOT@/ports/rust-users" }
-backtrace = { path = "@SOURCE_ROOT@/ports/rust-backtrace" }
+winit = { path = "@SOURCE_ROOT@/ports/rust-winit" }
+glutin = { path = "@SOURCE_ROOT@/ports/rust-glutin/glutin" }
+glutin_egl_sys = { path = "@SOURCE_ROOT@/ports/rust-glutin/glutin_egl_sys" }
+glutin_glx_sys = { path = "@SOURCE_ROOT@/ports/rust-glutin/glutin_glx_sys" }
+shared_library = { path = "@SOURCE_ROOT@/ports/rust-shared-library" }

--- a/patches/rust-calloop/0001-managarm-initial-port.patch
+++ b/patches/rust-calloop/0001-managarm-initial-port.patch
@@ -1,0 +1,27 @@
+From 74b9be01f8ec0ff26d674d265a23a80d4e733d0f Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 02:40:50 +0000
+Subject: [PATCH] managarm: initial port
+
+---
+ src/sys/mod.rs | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/sys/mod.rs b/src/sys/mod.rs
+index dd103a5..9cfa07f 100644
+--- a/src/sys/mod.rs
++++ b/src/sys/mod.rs
+@@ -1,8 +1,8 @@
+ use std::{io, os::unix::io::RawFd};
+ 
+-#[cfg(target_os = "linux")]
++#[cfg(any(target_os = "linux", target_os = "managarm"))]
+ mod epoll;
+-#[cfg(target_os = "linux")]
++#[cfg(any(target_os = "linux", target_os = "managarm"))]
+ use epoll::Epoll as Poller;
+ 
+ #[cfg(any(
+-- 
+2.35.1
+

--- a/patches/rust-glutin/0001-managarm-initial-port.patch
+++ b/patches/rust-glutin/0001-managarm-initial-port.patch
@@ -1,0 +1,295 @@
+From 8f3d697d064e3112b933b40640959231a3abd945 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 12:20:00 +0000
+Subject: [PATCH] managarm: initial port
+
+---
+ glutin/Cargo.toml                    | 2 +-
+ glutin/src/api/dlloader.rs           | 1 +
+ glutin/src/api/egl/mod.rs            | 6 ++++++
+ glutin/src/api/glx/mod.rs            | 1 +
+ glutin/src/api/osmesa/mod.rs         | 1 +
+ glutin/src/lib.rs                    | 4 ++++
+ glutin/src/platform/mod.rs           | 1 +
+ glutin/src/platform/unix.rs          | 1 +
+ glutin/src/platform_impl/mod.rs      | 1 +
+ glutin/src/platform_impl/unix/mod.rs | 1 +
+ glutin/src/windowed.rs               | 2 ++
+ glutin_egl_sys/build.rs              | 1 +
+ glutin_egl_sys/src/lib.rs            | 2 ++
+ glutin_glx_sys/Cargo.toml            | 2 +-
+ glutin_glx_sys/build.rs              | 1 +
+ glutin_glx_sys/src/lib.rs            | 1 +
+ 16 files changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/glutin/Cargo.toml b/glutin/Cargo.toml
+index ddd23ee..8a0755f 100644
+--- a/glutin/Cargo.toml
++++ b/glutin/Cargo.toml
+@@ -56,7 +56,7 @@ glutin_wgl_sys = { version = "0.1.5", path = "../glutin_wgl_sys" }
+ glutin_egl_sys = { version = "0.1.5", path = "../glutin_egl_sys" }
+ parking_lot = "0.11"
+ 
+-[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
++[target.'cfg(any(target_os = "linux", target_os = "managarm", target_os = "freebsd", target_os = "dragonfly", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
+ osmesa-sys = "0.1"
+ wayland-client = { version = "0.29", features = ["dlopen"], optional = true }
+ wayland-egl = { version = "0.29", optional = true }
+diff --git a/glutin/src/api/dlloader.rs b/glutin/src/api/dlloader.rs
+index 9cfba93..af248f2 100644
+--- a/glutin/src/api/dlloader.rs
++++ b/glutin/src/api/dlloader.rs
+@@ -1,6 +1,7 @@
+ #![cfg(any(
+     target_os = "windows",
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+diff --git a/glutin/src/api/egl/mod.rs b/glutin/src/api/egl/mod.rs
+index d567678..590ed83 100644
+--- a/glutin/src/api/egl/mod.rs
++++ b/glutin/src/api/egl/mod.rs
+@@ -1,6 +1,7 @@
+ #![cfg(any(
+     target_os = "windows",
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "android",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+@@ -121,6 +122,7 @@ use parking_lot::Mutex;
+     target_os = "android",
+     target_os = "windows",
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+@@ -773,6 +775,7 @@ pub struct ContextPrototype<'a> {
+ #[cfg(any(
+     target_os = "linux",
+     target_os = "dragonfly",
++    target_os = "managarm",
+     target_os = "freebsd",
+     target_os = "netbsd",
+     target_os = "openbsd",
+@@ -804,6 +807,7 @@ impl<'a> ContextPrototype<'a> {
+     #[cfg(any(
+         target_os = "linux",
+         target_os = "dragonfly",
++        target_os = "managarm",
+         target_os = "freebsd",
+         target_os = "netbsd",
+         target_os = "openbsd",
+@@ -829,6 +833,7 @@ impl<'a> ContextPrototype<'a> {
+ 
+     #[cfg(any(
+         target_os = "linux",
++        target_os = "managarm",
+         target_os = "dragonfly",
+         target_os = "freebsd",
+         target_os = "netbsd",
+@@ -847,6 +852,7 @@ impl<'a> ContextPrototype<'a> {
+     #[cfg(any(
+         target_os = "android",
+         target_os = "windows",
++        target_os = "managarm",
+         target_os = "linux",
+         target_os = "dragonfly",
+         target_os = "freebsd",
+diff --git a/glutin/src/api/glx/mod.rs b/glutin/src/api/glx/mod.rs
+index 61968e6..67458f1 100644
+--- a/glutin/src/api/glx/mod.rs
++++ b/glutin/src/api/glx/mod.rs
+@@ -1,5 +1,6 @@
+ #![cfg(any(
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+diff --git a/glutin/src/api/osmesa/mod.rs b/glutin/src/api/osmesa/mod.rs
+index 89c0765..40b8402 100644
+--- a/glutin/src/api/osmesa/mod.rs
++++ b/glutin/src/api/osmesa/mod.rs
+@@ -1,5 +1,6 @@
+ #![cfg(any(
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+diff --git a/glutin/src/lib.rs b/glutin/src/lib.rs
+index 7ee1522..f2e6da2 100644
+--- a/glutin/src/lib.rs
++++ b/glutin/src/lib.rs
+@@ -43,6 +43,7 @@
+ #![cfg_attr(
+     not(any(
+         target_os = "linux",
++        target_os = "managarm",
+         target_os = "dragonfly",
+         target_os = "freebsd",
+         target_os = "netbsd",
+@@ -56,6 +57,7 @@
+ #![cfg_attr(
+     any(
+         target_os = "linux",
++        target_os = "managarm",
+         target_os = "dragonfly",
+         target_os = "freebsd",
+         target_os = "netbsd",
+@@ -73,6 +75,7 @@
+ #[cfg(any(
+     target_os = "windows",
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "android",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+@@ -298,6 +301,7 @@ pub enum CreationError {
+ impl CreationError {
+     #[cfg(any(
+         target_os = "linux",
++        target_os = "managarm",
+         target_os = "dragonfly",
+         target_os = "freebsd",
+         target_os = "netbsd",
+diff --git a/glutin/src/platform/mod.rs b/glutin/src/platform/mod.rs
+index e508519..c684a90 100644
+--- a/glutin/src/platform/mod.rs
++++ b/glutin/src/platform/mod.rs
+@@ -25,6 +25,7 @@ pub mod run_return {
+         target_os = "windows",
+         target_os = "macos",
+         target_os = "linux",
++        target_os = "managarm",
+         target_os = "dragonfly",
+         target_os = "freebsd",
+         target_os = "netbsd",
+diff --git a/glutin/src/platform/unix.rs b/glutin/src/platform/unix.rs
+index 66aed2c..6202645 100644
+--- a/glutin/src/platform/unix.rs
++++ b/glutin/src/platform/unix.rs
+@@ -1,5 +1,6 @@
+ #![cfg(any(
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+diff --git a/glutin/src/platform_impl/mod.rs b/glutin/src/platform_impl/mod.rs
+index 82affa7..2c0158e 100644
+--- a/glutin/src/platform_impl/mod.rs
++++ b/glutin/src/platform_impl/mod.rs
+@@ -5,6 +5,7 @@ pub use self::platform_impl::*;
+ mod platform_impl;
+ #[cfg(any(
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+diff --git a/glutin/src/platform_impl/unix/mod.rs b/glutin/src/platform_impl/unix/mod.rs
+index 510ec9c..6ad5e59 100644
+--- a/glutin/src/platform_impl/unix/mod.rs
++++ b/glutin/src/platform_impl/unix/mod.rs
+@@ -1,5 +1,6 @@
+ #![cfg(any(
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+diff --git a/glutin/src/windowed.rs b/glutin/src/windowed.rs
+index b603918..6fb70b9 100644
+--- a/glutin/src/windowed.rs
++++ b/glutin/src/windowed.rs
+@@ -57,6 +57,7 @@ pub type WindowedContext<T> = ContextWrapper<T, Window>;
+ #[cfg_attr(
+     not(any(
+         target_os = "linux",
++        target_os = "managarm",
+         target_os = "dragonfly",
+         target_os = "freebsd",
+         target_os = "netbsd",
+@@ -70,6 +71,7 @@ pub type WindowedContext<T> = ContextWrapper<T, Window>;
+     any(
+         target_os = "linux",
+         target_os = "dragonfly",
++        target_os = "managarm",
+         target_os = "freebsd",
+         target_os = "netbsd",
+         target_os = "openbsd",
+diff --git a/glutin_egl_sys/build.rs b/glutin_egl_sys/build.rs
+index 2920f3b..0d53258 100644
+--- a/glutin_egl_sys/build.rs
++++ b/glutin_egl_sys/build.rs
+@@ -11,6 +11,7 @@ fn main() {
+ 
+     if target.contains("linux")
+         || target.contains("dragonfly")
++        || target.contains("managarm")
+         || target.contains("freebsd")
+         || target.contains("netbsd")
+         || target.contains("openbsd")
+diff --git a/glutin_egl_sys/src/lib.rs b/glutin_egl_sys/src/lib.rs
+index fac07d2..2f05e8c 100644
+--- a/glutin_egl_sys/src/lib.rs
++++ b/glutin_egl_sys/src/lib.rs
+@@ -3,6 +3,7 @@
+     target_os = "linux",
+     target_os = "android",
+     target_os = "dragonfly",
++    target_os = "managarm",
+     target_os = "freebsd",
+     target_os = "netbsd",
+     target_os = "openbsd"
+@@ -44,6 +45,7 @@ pub type EGLNativeWindowType = *const raw::c_void;
+ pub type EGLNativeWindowType = *const raw::c_void;
+ #[cfg(any(
+     target_os = "dragonfly",
++    target_os = "managarm",
+     target_os = "freebsd",
+     target_os = "netbsd",
+     target_os = "openbsd"
+diff --git a/glutin_glx_sys/Cargo.toml b/glutin_glx_sys/Cargo.toml
+index a919dec..9d0398d 100644
+--- a/glutin_glx_sys/Cargo.toml
++++ b/glutin_glx_sys/Cargo.toml
+@@ -12,5 +12,5 @@ edition = "2018"
+ [build-dependencies]
+ gl_generator = "0.14"
+ 
+-[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os="dragonfly", target_os="netbsd", target_os="openbsd"))'.dependencies]
++[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "managarm", target_os="dragonfly", target_os="netbsd", target_os="openbsd"))'.dependencies]
+ x11-dl = "2.18.3"
+diff --git a/glutin_glx_sys/build.rs b/glutin_glx_sys/build.rs
+index 21e1cb3..36a90dd 100644
+--- a/glutin_glx_sys/build.rs
++++ b/glutin_glx_sys/build.rs
+@@ -11,6 +11,7 @@ fn main() {
+ 
+     if target.contains("linux")
+         || target.contains("dragonfly")
++        || target.contains("managarm")
+         || target.contains("freebsd")
+         || target.contains("netbsd")
+         || target.contains("openbsd")
+diff --git a/glutin_glx_sys/src/lib.rs b/glutin_glx_sys/src/lib.rs
+index fadb62a..89f18d7 100644
+--- a/glutin_glx_sys/src/lib.rs
++++ b/glutin_glx_sys/src/lib.rs
+@@ -1,6 +1,7 @@
+ #![cfg(any(
+     target_os = "linux",
+     target_os = "dragonfly",
++    target_os = "managarm",
+     target_os = "freebsd",
+     target_os = "netbsd",
+     target_os = "openbsd"
+-- 
+2.35.1
+

--- a/patches/rust-libc/0001-managarm-initial-port.patch
+++ b/patches/rust-libc/0001-managarm-initial-port.patch
@@ -1,7 +1,7 @@
-From ef9d4810eb3523785c789487c7c06548fd28ecbe Mon Sep 17 00:00:00 2001
+From 06857a052d3499c64e1ed48f338aab58fb8467ea Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Thu, 8 Apr 2021 22:08:55 +0100
-Subject: [PATCH 1/2] managarm: initial port
+Subject: [PATCH 1/3] managarm: initial port
 
 ---
  src/unix/mlibc/mod.rs | 722 ++++++++++++++++++++++++++++++++++++++++++
@@ -738,10 +738,10 @@ index 0000000..93bd66e
 +    pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
 +}
 diff --git a/src/unix/mod.rs b/src/unix/mod.rs
-index 5ff2294..7e6e68b 100644
+index 11b6119..748c52f 100644
 --- a/src/unix/mod.rs
 +++ b/src/unix/mod.rs
-@@ -1475,6 +1475,9 @@ cfg_if! {
+@@ -1500,6 +1500,9 @@ cfg_if! {
      } else if #[cfg(target_os = "redox")] {
          mod redox;
          pub use self::redox::*;
@@ -752,5 +752,5 @@ index 5ff2294..7e6e68b 100644
          // Unknown target_os
      }
 -- 
-2.35.1
+2.36.1
 

--- a/patches/rust-libc/0002-managarm-Add-missing-glue-for-memmap-num_cpus-and-us.patch
+++ b/patches/rust-libc/0002-managarm-Add-missing-glue-for-memmap-num_cpus-and-us.patch
@@ -1,7 +1,7 @@
-From f4581b8471f78615b394dfa0f1e929bc9f56efb2 Mon Sep 17 00:00:00 2001
+From d21c65247ac806366b2423296eb52018e394a394 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Sat, 8 May 2021 19:33:53 +0100
-Subject: [PATCH 2/2] managarm: Add missing glue for memmap, num_cpus and users
+Subject: [PATCH 2/3] managarm: Add missing glue for memmap, num_cpus and users
 
 ---
  src/unix/mlibc/mod.rs | 59 ++++++++++++++++++++++++++-----------------
@@ -121,5 +121,5 @@ index 93bd66e..f1e602a 100644
      pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
  }
 -- 
-2.35.1
+2.36.1
 

--- a/patches/rust-libc/0003-managarm-alacritty-updates.patch
+++ b/patches/rust-libc/0003-managarm-alacritty-updates.patch
@@ -1,14 +1,14 @@
-From 857d56fe50693fd52b43ed23d2df651ac4374a8c Mon Sep 17 00:00:00 2001
+From eb222332c7acb87eb1de375379a3a649c36390b4 Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Mon, 21 Feb 2022 00:37:40 +0000
 Subject: [PATCH 3/3] managarm: alacritty updates
 
 ---
- src/unix/mlibc/mod.rs | 392 +++++++++++++++++++++++++++++++++++++-----
- 1 file changed, 350 insertions(+), 42 deletions(-)
+ src/unix/mlibc/mod.rs | 387 +++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 344 insertions(+), 43 deletions(-)
 
 diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
-index f1e602a..ab5e33d 100644
+index f1e602a..7bfbb48 100644
 --- a/src/unix/mlibc/mod.rs
 +++ b/src/unix/mlibc/mod.rs
 @@ -26,11 +26,24 @@ pub const MAP_SHARED: ::c_int = 2;
@@ -29,7 +29,7 @@ index f1e602a..ab5e33d 100644
 +pub const MADV_SEQUENTIAL: ::c_int = 2;
 +pub const MADV_WILLNEED: ::c_int = 3;
 +pub const MADV_DONTNEED: ::c_int = 4;
-+pub const MADV_FREE: ::c_int = 5;
++pub const MADV_FREE: ::c_int = 8;
 +pub const MS_INVALIDATE: ::c_int = 4;
 +pub const MCL_CURRENT: ::c_int = 1;
 +pub const MCL_FUTURE: ::c_int = 2;
@@ -228,29 +228,23 @@ index f1e602a..ab5e33d 100644
          pub ibaud: speed_t,
          pub obaud: speed_t,
      }
-@@ -168,13 +274,15 @@ s! {
+@@ -168,13 +274,8 @@ s! {
  
  // options/posix/include/termios.h
  pub const TIOCGWINSZ: ::c_ulong = 0x5413;
-+pub const TIOCSCTTY: ::c_ulong = 0x540E;
-+pub const TIOCSWINSZ: ::c_ulong = 0x5414;
- 
+-
 -pub const CSTOPB: ::c_int = 0x0004;
 -pub const CREAD: ::c_int = 0x0008;
 -pub const PARENB: ::c_int = 0x0010;
 -pub const PARODD: ::c_int = 0x0020;
 -pub const HUPCL: ::c_int = 0x0040;
 -pub const CLOCAL: ::c_int = 0x0080;
-+// pub const CSTOPB: ::c_int = 0x0004;
-+// pub const CREAD: ::c_int = 0x0008;
-+// pub const PARENB: ::c_int = 0x0010;
-+// pub const PARODD: ::c_int = 0x0020;
-+// pub const HUPCL: ::c_int = 0x0040;
-+// pub const CLOCAL: ::c_int = 0x0080;
++pub const TIOCSCTTY: ::c_ulong = 0x540E;
++pub const TIOCSWINSZ: ::c_ulong = 0x5414;
  
  // abis/mlibc/ino_t.h
  pub type ino_t = ::c_long;
-@@ -200,6 +308,7 @@ pub const EXIT_SUCCESS: ::c_int = 0;
+@@ -200,6 +301,7 @@ pub const EXIT_SUCCESS: ::c_int = 0;
  
  // options/posix/include/dlfcn.h
  pub const RTLD_DEFAULT: *mut ::c_void = 0 as *mut ::c_void;
@@ -258,7 +252,7 @@ index f1e602a..ab5e33d 100644
  s! {
      pub struct Dl_info {
          pub dli_fname: *const ::c_char,
-@@ -210,30 +319,65 @@ s! {
+@@ -210,30 +312,65 @@ s! {
  }
  
  // options/posix/include/unistd.h
@@ -325,7 +319,7 @@ index f1e602a..ab5e33d 100644
  pub const SO_BROADCAST: ::c_int = 2;
  pub const SO_DEBUG: ::c_int = 3;
  pub const SO_DONTROUTE: ::c_int = 4;
-@@ -241,26 +385,61 @@ pub const SO_ERROR: ::c_int = 5;
+@@ -241,26 +378,61 @@ pub const SO_ERROR: ::c_int = 5;
  pub const SO_KEEPALIVE: ::c_int = 6;
  pub const SO_LINGER: ::c_int = 7;
  pub const SO_OOBINLINE: ::c_int = 8;
@@ -393,7 +387,7 @@ index f1e602a..ab5e33d 100644
  }
  
  // abis/mlibc/errno.h
-@@ -295,6 +474,7 @@ pub const ENOSYS: ::c_int = 1051;
+@@ -295,6 +467,7 @@ pub const ENOSYS: ::c_int = 1051;
  pub const ENOTCONN: ::c_int = 1052;
  pub const ENOTDIR: ::c_int = 1053;
  pub const ENOTEMPTY: ::c_int = 1054;
@@ -401,7 +395,7 @@ index f1e602a..ab5e33d 100644
  pub const EPERM: ::c_int = 1063;
  pub const EPIPE: ::c_int = 1064;
  pub const ERANGE: ::c_int = 3;
-@@ -305,25 +485,53 @@ pub const ETIMEDOUT: ::c_int = 1072;
+@@ -305,25 +478,53 @@ pub const ETIMEDOUT: ::c_int = 1072;
  pub const ETXTBSY: ::c_int = 1073;
  pub const EWOULDBLOCK: ::c_int = EAGAIN;
  pub const EXDEV: ::c_int = 1075;
@@ -455,7 +449,7 @@ index f1e602a..ab5e33d 100644
  
  // options/mlibc/seek-whence.h
  pub const SEEK_CUR: ::c_int = 1;
-@@ -406,19 +614,50 @@ safe_f! {
+@@ -406,19 +607,50 @@ safe_f! {
  }
  
  // options/linux/include/sys/poll.h
@@ -507,7 +501,7 @@ index f1e602a..ab5e33d 100644
  
  // options/elf/include/link.h
  pub type Elf64_Half = u16;
-@@ -469,6 +708,27 @@ s! {
+@@ -469,6 +701,27 @@ s! {
          pub sa_family: sa_family_t,
          pub sa_data: [::c_char; 14],
      }
@@ -535,7 +529,7 @@ index f1e602a..ab5e33d 100644
  }
  
  // options/posix/include/bits/posix/pthread_t.h
-@@ -535,6 +795,7 @@ s! {
+@@ -535,6 +788,7 @@ s! {
  }
  
  // options/ansi/include/locale.h
@@ -543,7 +537,7 @@ index f1e602a..ab5e33d 100644
  s! {
      pub struct lconv {
          pub decimal_point: *mut ::c_char,
-@@ -618,10 +879,14 @@ s! {
+@@ -618,10 +872,14 @@ s! {
  // abis/mlibc/in.h
  pub const IPV6_ADD_MEMBERSHIP: ::c_int = 1;
  pub const IPV6_DROP_MEMBERSHIP: ::c_int = 2;
@@ -558,7 +552,7 @@ index f1e602a..ab5e33d 100644
  pub const IP_MULTICAST_LOOP: ::c_int = 34;
  pub const IP_MULTICAST_TTL: ::c_int = 33;
  pub const IP_TTL: ::c_int = 2;
-@@ -637,7 +902,7 @@ s! {
+@@ -637,7 +895,7 @@ s! {
          pub sin_family: sa_family_t,
          pub sin_port: in_port_t,
          pub sin_addr: in_addr,
@@ -567,7 +561,7 @@ index f1e602a..ab5e33d 100644
      }
      pub struct sockaddr_in6 {
          pub sin6_family: sa_family_t,
-@@ -656,6 +921,8 @@ s! {
+@@ -656,6 +914,8 @@ s! {
  }
  
  extern "C" {
@@ -576,7 +570,7 @@ index f1e602a..ab5e33d 100644
      pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
      pub fn clock_gettime(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
      pub fn clock_settime(clk_id: clockid_t, tp: *const ::timespec) -> ::c_int;
-@@ -670,6 +937,24 @@ extern "C" {
+@@ -670,6 +930,24 @@ extern "C" {
          data: *mut ::c_void,
      ) -> ::c_int;
      pub fn endpwent();
@@ -601,7 +595,7 @@ index f1e602a..ab5e33d 100644
      pub fn getpwent() -> *mut passwd;
      pub fn getgrgid_r(
          gid: ::gid_t,
-@@ -705,9 +990,21 @@ extern "C" {
+@@ -705,9 +983,21 @@ extern "C" {
          buflen: ::size_t,
          result: *mut *mut passwd,
      ) -> ::c_int;
@@ -623,7 +617,7 @@ index f1e602a..ab5e33d 100644
      pub fn pthread_condattr_setclock(
          attr: *mut pthread_condattr_t,
          clock_id: ::clockid_t,
-@@ -729,7 +1026,18 @@ extern "C" {
+@@ -729,7 +1019,18 @@ extern "C" {
          addr: *mut ::sockaddr,
          addrlen: *mut ::socklen_t,
      ) -> ::ssize_t;

--- a/patches/rust-libc/0003-managarm-alacritty-updates.patch
+++ b/patches/rust-libc/0003-managarm-alacritty-updates.patch
@@ -1,4 +1,4 @@
-From eca15191c4c1bd15cac8dd77d64a68c8898d5c52 Mon Sep 17 00:00:00 2001
+From 857d56fe50693fd52b43ed23d2df651ac4374a8c Mon Sep 17 00:00:00 2001
 From: Matt Taylor <mstaveleytaylor@gmail.com>
 Date: Mon, 21 Feb 2022 00:37:40 +0000
 Subject: [PATCH 3/3] managarm: alacritty updates
@@ -8,7 +8,7 @@ Subject: [PATCH 3/3] managarm: alacritty updates
  1 file changed, 350 insertions(+), 42 deletions(-)
 
 diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
-index f1e602a..7b8aaed 100644
+index f1e602a..ab5e33d 100644
 --- a/src/unix/mlibc/mod.rs
 +++ b/src/unix/mlibc/mod.rs
 @@ -26,11 +26,24 @@ pub const MAP_SHARED: ::c_int = 2;
@@ -136,9 +136,9 @@ index f1e602a..7b8aaed 100644
 +pub const B9600: ::c_uint = 13;
 +pub const B19200: ::c_uint = 14;
 +pub const B38400: ::c_uint = 15;
-+pub const B57600: ::c_uint = 17;
-+pub const B115200: ::c_uint = 18;
-+pub const B230400: ::c_uint = 19;
++pub const B57600: ::c_uint = 16;
++pub const B115200: ::c_uint = 17;
++pub const B230400: ::c_uint = 18;
 +pub const BRKINT: ::c_uint = 0x0001;
 +pub const BS0: ::c_int = 0x0000;
 +pub const BS1: ::c_int = 0x1000;

--- a/patches/rust-libc/0003-managarm-alacritty-updates.patch
+++ b/patches/rust-libc/0003-managarm-alacritty-updates.patch
@@ -1,0 +1,647 @@
+From eca15191c4c1bd15cac8dd77d64a68c8898d5c52 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 00:37:40 +0000
+Subject: [PATCH 3/3] managarm: alacritty updates
+
+---
+ src/unix/mlibc/mod.rs | 392 +++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 350 insertions(+), 42 deletions(-)
+
+diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
+index f1e602a..7b8aaed 100644
+--- a/src/unix/mlibc/mod.rs
++++ b/src/unix/mlibc/mod.rs
+@@ -26,11 +26,24 @@ pub const MAP_SHARED: ::c_int = 2;
+ pub const PROT_EXEC: ::c_int = 4;
+ pub const PROT_READ: ::c_int = 1;
+ pub const PROT_WRITE: ::c_int = 2;
++pub const PROT_NONE: ::c_int = 0;
++pub const MAP_FIXED: ::c_int = 2;
++pub const MAP_NORESERVE: ::c_int = 0x10;
+ 
+ // options/posix/include/sys/mman.h
++pub const MAP_FILE : ::c_int = 0;
+ pub const MAP_FAILED: *mut ::c_void = usize::MAX as *mut ::c_void;
+ pub const MS_ASYNC: ::c_int = 1;
+ pub const MS_SYNC: ::c_int = 2;
++pub const MADV_NORMAL: ::c_int = 0;
++pub const MADV_RANDOM: ::c_int = 1;
++pub const MADV_SEQUENTIAL: ::c_int = 2;
++pub const MADV_WILLNEED: ::c_int = 3;
++pub const MADV_DONTNEED: ::c_int = 4;
++pub const MADV_FREE: ::c_int = 5;
++pub const MS_INVALIDATE: ::c_int = 4;
++pub const MCL_CURRENT: ::c_int = 1;
++pub const MCL_FUTURE: ::c_int = 2;
+ 
+ // options/ansi/include/time.h
+ pub const CLOCK_MONOTONIC: clockid_t = 1;
+@@ -77,43 +90,43 @@ pub type fsblkcnt_t = ::c_uint;
+ pub type fsfilcnt_t = ::c_uint;
+ 
+ // abis/mlibc/signal.h
+-pub const SIGHUP: ::c_int = 1;
+-pub const SIGINT: ::c_int = 2;
+-pub const SIGQUIT: ::c_int = 3;
+-pub const SIGILL: ::c_int = 4;
+-pub const SIGTRAP: ::c_int = 5;
+ pub const SIGABRT: ::c_int = 6;
++pub const SIGALRM: ::c_int = 14;
+ pub const SIGBUS: ::c_int = 7;
++pub const SIGCANCEL: ::c_int = 34;
++pub const SIGCHLD: ::c_int = 17;
++pub const SIGCONT: ::c_int = 18;
+ pub const SIGFPE: ::c_int = 8;
++pub const SIGHUP: ::c_int = 1;
++pub const SIGILL: ::c_int = 4;
++pub const SIGINT: ::c_int = 2;
++pub const SIGIO: ::c_int = 29;
+ pub const SIGKILL: ::c_int = 9;
+-pub const SIGUSR1: ::c_int = 10;
+-pub const SIGSEGV: ::c_int = 11;
+-pub const SIGUSR2: ::c_int = 12;
+ pub const SIGPIPE: ::c_int = 13;
+-pub const SIGALRM: ::c_int = 14;
+-pub const SIGTERM: ::c_int = 15;
++pub const SIGPOLL: ::c_int = SIGIO;
++pub const SIGPROF: ::c_int = 27;
++pub const SIGPWR: ::c_int = 30;
++pub const SIGQUIT: ::c_int = 3;
++pub const SIGRTMAX: ::c_int = 33;
++pub const SIGRTMIN: ::c_int = 32;
++pub const SIGSEGV: ::c_int = 11;
+ pub const SIGSTKFLT: ::c_int = 16;
+-pub const SIGCHLD: ::c_int = 17;
+-pub const SIGCONT: ::c_int = 18;
+ pub const SIGSTOP: ::c_int = 19;
++pub const SIGSYS: ::c_int = 31;
++pub const SIGTERM: ::c_int = 15;
++pub const SIGTRAP: ::c_int = 5;
+ pub const SIGTSTP: ::c_int = 20;
+ pub const SIGTTIN: ::c_int = 21;
+ pub const SIGTTOU: ::c_int = 22;
+ pub const SIGURG: ::c_int = 23;
+-pub const SIGXCPU: ::c_int = 24;
+-pub const SIGXFSZ: ::c_int = 25;
++pub const SIGUSR1: ::c_int = 10;
++pub const SIGUSR2: ::c_int = 12;
+ pub const SIGVTALRM: ::c_int = 26;
+-pub const SIGPROF: ::c_int = 27;
+ pub const SIGWINCH: ::c_int = 28;
+-pub const SIGIO: ::c_int = 29;
+-pub const SIGPOLL: ::c_int = SIGIO;
+-pub const SIGPWR: ::c_int = 30;
+-pub const SIGSYS: ::c_int = 31;
+-pub const SIGRTMIN: ::c_int = 32;
+-pub const SIGRTMAX: ::c_int = 33;
+-pub const SIGCANCEL: ::c_int = 34;
+-
++pub const SIGXCPU: ::c_int = 24;
++pub const SIGXFSZ: ::c_int = 25;
+ pub const SIG_SETMASK: ::c_int = 3;
++pub const SIG_UNBLOCK: ::c_int = 2;
+ 
+ 
+ pub const SA_NOCLDSTOP: ::c_int = 1 << 0;
+@@ -137,10 +150,10 @@ s! {
+         pub si_value: sigval,
+     }
+     pub struct sigaction {
+-        pub sa_handler: ::Option<extern fn(::c_int)>,
++        pub sa_handler: ::sighandler_t,
+         pub sa_mask: sigset_t,
+         pub sa_flags: ::c_int,
+-        pub sa_sigaction: ::Option<extern fn(::c_int, *mut siginfo_t, *mut ::c_void)>,
++        pub sa_sigaction: ::sighandler_t,
+     }
+ }
+ s! {
+@@ -150,8 +163,101 @@ s! {
+ }
+ 
+ // abis/mlibc/termios.h
++pub const B0: ::c_uint = 0;
++pub const B50: ::c_uint = 1;
++pub const B75: ::c_uint = 2;
++pub const B110: ::c_uint = 3;
++pub const B134: ::c_uint = 4;
++pub const B150: ::c_uint = 5;
++pub const B200: ::c_uint = 6;
++pub const B300: ::c_uint = 7;
++pub const B600: ::c_uint = 8;
++pub const B1200: ::c_uint = 9;
++pub const B1800: ::c_uint = 10;
++pub const B2400: ::c_uint = 11;
++pub const B4800: ::c_uint = 12;
++pub const B9600: ::c_uint = 13;
++pub const B19200: ::c_uint = 14;
++pub const B38400: ::c_uint = 15;
++pub const B57600: ::c_uint = 17;
++pub const B115200: ::c_uint = 18;
++pub const B230400: ::c_uint = 19;
++pub const BRKINT: ::c_uint = 0x0001;
++pub const BS0: ::c_int = 0x0000;
++pub const BS1: ::c_int = 0x1000;
++pub const BSDLY: ::c_int = 0x1000;
++pub const CLOCAL: ::c_int = 0x0080;
++pub const CR0: ::c_int = 0x0000;
++pub const CR1: ::c_int = 0x0100;
++pub const CR2: ::c_int = 0x0200;
++pub const CR3: ::c_int = 0x0300;
++pub const CRDLY: ::c_int = 0x0300;
++pub const CREAD: ::c_int = 0x0008;
++pub const CS5: ::c_uint = 0x0000;
++pub const CS6: ::c_int = 0x0001;
++pub const CS7: ::c_int = 0x0002;
++pub const CS8: ::c_int = 0x0003;
++pub const CSIZE: ::c_int = 0x0003;
++pub const CSTOPB: ::c_int = 0x0004;
++pub const ECHO: ::c_uint = 0x0001;
++pub const ECHOE: ::c_int = 0x0002;
++pub const ECHOK: ::c_int = 0x0004;
++pub const ECHONL: ::c_int = 0x0008;
++pub const ECHOPRT: ::c_int = 0x0200;
++pub const FF0: ::c_int = 0x0000;
++pub const FF1: ::c_int = 0x4000;
++pub const FFDLY: ::c_int = 0x4000;
++pub const HUPCL: ::c_int = 0x0040;
++pub const ICANON: ::c_int = 0x0010;
++pub const ICRNL: ::c_uint = 0x0002;
++pub const IEXTEN: ::c_int = 0x0020;
++pub const IGNBRK: ::c_uint = 0x0004;
++pub const IGNCR: ::c_uint = 0x0008;
++pub const IGNPAR: ::c_uint = 0x0010;
++pub const INLCR: ::c_uint = 0x0020;
++pub const INPCK: ::c_uint = 0x0040;
++pub const ISIG: ::c_int = 0x0040;
++pub const ISTRIP: ::c_uint = 0x0080;
++pub const IXANY: ::c_uint = 0x0100;
++pub const IXOFF: ::c_uint = 0x0200;
++pub const IXON: ::c_uint = 0x0400;
+ pub const NCCS: usize = 11;
+-pub type cc_t = ::c_uint;
++pub const NL0: ::c_int = 0x0000;
++pub const NL1: ::c_int = 0x0080;
++pub const NLDLY: ::c_int = 0x0080;
++pub const NOFLSH: ::c_int = 0x0080;
++pub const OCRNL: ::c_int = 0x0004;
++pub const OFDEL: ::c_int = 0x0020;
++pub const OFILL: ::c_int = 0x0040;
++pub const ONLCR: ::c_int = 0x0002;
++pub const ONLRET: ::c_int = 0x0010;
++pub const ONOCR: ::c_int = 0x0008;
++pub const OPOST: ::c_uint = 0x0001;
++pub const PARENB: ::c_int = 0x0010;
++pub const PARMRK: ::c_uint = 0x0800;
++pub const PARODD: ::c_int = 0x0020;
++pub const TAB0: ::c_int = 0x0000;
++pub const TAB1: ::c_int = 0x0400;
++pub const TAB2: ::c_int = 0x0800;
++pub const TAB3: ::c_int = 0x0C00;
++pub const TABDLY: ::c_int = 0x0C00;
++pub const TCIFLUSH: ::c_int = 1;
++pub const TCIOFF: ::c_int = 1;
++pub const TCIOFLUSH: ::c_int = 2;
++pub const TCION: ::c_int = 2;
++pub const TCOFLUSH: ::c_int = 3;
++pub const TCOOFF: ::c_int = 3;
++pub const TCOON: ::c_int = 4;
++pub const TCSADRAIN: ::c_int = 2;
++pub const TCSAFLUSH: ::c_int = 3;
++pub const TCSANOW: ::c_int = 1;
++pub const TOSTOP: ::c_int = 0x0100;
++pub const VT0: ::c_int = 0x0000;
++pub const VT1: ::c_int = 0x2000;
++
++// The following are usize since they are indices into termios.c_cc
++pub const VEOF: usize = 0;
++
+ pub type speed_t = ::c_uint;
+ pub type tcflag_t = ::c_uint;
+ s! {
+@@ -160,7 +266,7 @@ s! {
+         pub c_oflag: tcflag_t,
+         pub c_cflag: tcflag_t,
+         pub c_lflag: tcflag_t,
+-        pub c_cc: [cc_t; NCCS],
++        pub c_cc: [::cc_t; NCCS],
+         pub ibaud: speed_t,
+         pub obaud: speed_t,
+     }
+@@ -168,13 +274,15 @@ s! {
+ 
+ // options/posix/include/termios.h
+ pub const TIOCGWINSZ: ::c_ulong = 0x5413;
++pub const TIOCSCTTY: ::c_ulong = 0x540E;
++pub const TIOCSWINSZ: ::c_ulong = 0x5414;
+ 
+-pub const CSTOPB: ::c_int = 0x0004;
+-pub const CREAD: ::c_int = 0x0008;
+-pub const PARENB: ::c_int = 0x0010;
+-pub const PARODD: ::c_int = 0x0020;
+-pub const HUPCL: ::c_int = 0x0040;
+-pub const CLOCAL: ::c_int = 0x0080;
++// pub const CSTOPB: ::c_int = 0x0004;
++// pub const CREAD: ::c_int = 0x0008;
++// pub const PARENB: ::c_int = 0x0010;
++// pub const PARODD: ::c_int = 0x0020;
++// pub const HUPCL: ::c_int = 0x0040;
++// pub const CLOCAL: ::c_int = 0x0080;
+ 
+ // abis/mlibc/ino_t.h
+ pub type ino_t = ::c_long;
+@@ -200,6 +308,7 @@ pub const EXIT_SUCCESS: ::c_int = 0;
+ 
+ // options/posix/include/dlfcn.h
+ pub const RTLD_DEFAULT: *mut ::c_void = 0 as *mut ::c_void;
++pub const RTLD_LAZY: ::c_int = 0;
+ s! {
+     pub struct Dl_info {
+         pub dli_fname: *const ::c_char,
+@@ -210,30 +319,65 @@ s! {
+ }
+ 
+ // options/posix/include/unistd.h
++pub const F_OK: ::c_int = 1;
++pub const R_OK: ::c_int = 2;
+ pub const STDERR_FILENO: ::c_int = 2;
+ pub const STDIN_FILENO: ::c_int = 0;
+ pub const STDOUT_FILENO: ::c_int = 1;
++pub const W_OK: ::c_int = 4;
++pub const X_OK: ::c_int = 8;
++pub const _PC_NAME_MAX: ::c_int = 3;
++pub const _SC_GETGR_R_SIZE_MAX: ::c_int = 7;
+ pub const _SC_GETPW_R_SIZE_MAX: ::c_int = 1;
++pub const _SC_NGROUPS_MAX: ::c_int = 10;
+ pub const _SC_NPROCESSORS_ONLN: ::c_int = 6;
+ pub const _SC_PAGESIZE: ::c_int = _SC_PAGE_SIZE;
+ pub const _SC_PAGE_SIZE: ::c_int = 3;
+ 
+ // abis/mlibc/socket.h
++pub const AF_APPLETALK: ::c_int = PF_APPLETALK;
++pub const AF_BLUETOOTH: ::c_int = PF_BLUETOOTH;
++pub const AF_DECnet: ::c_int = PF_DECnet;
+ pub const AF_INET6: ::c_int = PF_INET6;
+ pub const AF_INET: ::c_int = PF_INET;
++pub const AF_IPX: ::c_int = PF_IPX;
++pub const AF_ISDN: ::c_int = PF_ISDN;
++pub const AF_PACKET: ::c_int = PF_PACKET;
++pub const AF_SNA: ::c_int = PF_SNA;
+ pub const AF_UNIX: ::c_int = 3;
++pub const AF_UNSPEC: ::c_int = PF_UNSPEC;
++pub const MSG_CTRUNC: ::c_int = 1;
++pub const MSG_CMSG_CLOEXEC: ::c_int = 0x2000;
++pub const MSG_DONTWAIT: ::c_int = 0x1000;
++pub const MSG_EOR: ::c_int = 4;
++pub const MSG_OOB: ::c_int = 8;
+ pub const MSG_PEEK: ::c_int = 0x20;
++pub const MSG_TRUNC: ::c_int = 0x40;
++pub const MSG_WAITALL: ::c_int = 0x80;
++pub const PF_APPLETALK: ::c_int = 7;
++pub const PF_BLUETOOTH: ::c_int = 8;
++pub const PF_DECnet: ::c_int = 9;
+ pub const PF_INET6: ::c_int = 2;
+ pub const PF_INET: ::c_int = 1;
++pub const PF_IPX: ::c_int = 10;
++pub const PF_ISDN: ::c_int = 11;
++pub const PF_PACKET: ::c_int = 13;
++pub const PF_SNA: ::c_int = 12;
+ pub const PF_UNIX: ::c_int = 3;
++pub const PF_UNSPEC: ::c_int = 4;
++pub const SCM_RIGHTS: ::c_int = 1;
++pub const SCM_TIMESTAMP: ::c_int = SO_TIMESTAMP;
+ pub const SHUT_RD: ::c_int = 1;
+ pub const SHUT_RDWR: ::c_int = 2;
+ pub const SHUT_WR: ::c_int = 3;
+ pub const SOCK_DGRAM: ::c_int = 1;
++pub const SOCK_RAW: ::c_int = 2;
++pub const SOCK_RDM: ::c_int = 0x40000;
++pub const SOCK_SEQPACKET: ::c_int = 3;
+ pub const SOCK_STREAM: ::c_int = 4;
+ pub const SOL_SOCKET: ::c_int = 1;
+-
+ pub const SO_ACCEPTCONN: ::c_int = 1;
++pub const SO_ATTACH_FILTER: ::c_int = 19;
+ pub const SO_BROADCAST: ::c_int = 2;
+ pub const SO_DEBUG: ::c_int = 3;
+ pub const SO_DONTROUTE: ::c_int = 4;
+@@ -241,26 +385,61 @@ pub const SO_ERROR: ::c_int = 5;
+ pub const SO_KEEPALIVE: ::c_int = 6;
+ pub const SO_LINGER: ::c_int = 7;
+ pub const SO_OOBINLINE: ::c_int = 8;
++pub const SO_PASSCRED: ::c_int = 20;
++pub const SO_PEERCRED: ::c_int = 18;
+ pub const SO_RCVBUF: ::c_int = 9;
++pub const SO_RCVBUFFORCE: ::c_int = 21;
+ pub const SO_RCVLOWAT: ::c_int = 10;
+ pub const SO_RCVTIMEO: ::c_int = 11;
+ pub const SO_REUSEADDR: ::c_int = 12;
++pub const SO_REUSEPORT: ::c_int = 24;
+ pub const SO_SNDBUF: ::c_int = 13;
++pub const SO_SNDBUFFORCE: ::c_int = 17;
+ pub const SO_SNDLOWAT: ::c_int = 14;
+ pub const SO_SNDTIMEO: ::c_int = 15;
++pub const SO_TIMESTAMP: ::c_int = 25;
+ pub const SO_TYPE: ::c_int = 16;
+-pub const SO_SNDBUFFORCE: ::c_int = 17;
+-pub const SO_PEERCRED: ::c_int = 18;
+-pub const SO_ATTACH_FILTER: ::c_int = 19;
+-pub const SO_PASSCRED: ::c_int = 20;
+-pub const SO_RCVBUFFORCE: ::c_int = 21;
++pub const TCP_KEEPCNT: ::c_int = 6;
++pub const TCP_KEEPIDLE: ::c_int = 4;
++pub const TCP_KEEPINTVL: ::c_int = 5;
+ 
+-pub type sa_family_t = ::c_uint;
++pub type sa_family_t = ::c_int;
+ s! {
+     pub struct sockaddr_storage {
+         pub ss_family: sa_family_t,
+         __padding: [u8; 128 - ::mem::size_of::<sa_family_t>()],
+     }
++    pub struct msghdr {
++        pub msg_name: *mut ::c_void,
++        pub msg_namelen: ::socklen_t,
++        pub msg_iov: *mut ::iovec,
++        pub msg_iovlen: ::c_int,
++        pub msg_control: *mut ::c_void,
++        pub msg_controllen: ::size_t, // nix assumes this is a size_t
++        pub msg_flags: ::c_int,
++    }
++}
++
++f! {
++    pub fn CMSG_FIRSTHDR(_mhdr: *const msghdr) -> *mut cmsghdr {
++        unimplemented!()
++    }
++
++    pub fn CMSG_NXTHDR(_mhdr: *const ::msghdr, _cmsg: *const ::cmsghdr) -> *mut ::cmsghdr {
++        unimplemented!()
++    }
++
++    pub fn CMSG_LEN(_length: ::c_uint) -> ::c_uint {
++        unimplemented!()
++    }
++
++    pub fn CMSG_DATA(_cmsg: *const cmsghdr) -> *mut ::c_uchar {
++        unimplemented!()
++    }
++
++    pub fn CMSG_SPACE(_len: ::c_uint) -> ::c_uint {
++        unimplemented!()
++    }
+ }
+ 
+ // abis/mlibc/errno.h
+@@ -295,6 +474,7 @@ pub const ENOSYS: ::c_int = 1051;
+ pub const ENOTCONN: ::c_int = 1052;
+ pub const ENOTDIR: ::c_int = 1053;
+ pub const ENOTEMPTY: ::c_int = 1054;
++pub const ENOTTY: ::c_int = 1058;
+ pub const EPERM: ::c_int = 1063;
+ pub const EPIPE: ::c_int = 1064;
+ pub const ERANGE: ::c_int = 3;
+@@ -305,25 +485,53 @@ pub const ETIMEDOUT: ::c_int = 1072;
+ pub const ETXTBSY: ::c_int = 1073;
+ pub const EWOULDBLOCK: ::c_int = EAGAIN;
+ pub const EXDEV: ::c_int = 1075;
++pub const EPROTO: ::c_int = 1065;
+ 
+ // options/posix/include/fcntl.h
+ pub const AT_FDCWD: ::c_int = -100;
+ pub const AT_REMOVEDIR: ::c_int = 8;
++pub const AT_SYMLINK_FOLLOW: ::c_int = 2;
++pub const AT_SYMLINK_NOFOLLOW: ::c_int = 4;
++pub const F_DUPFD: ::c_int = 1;
+ pub const F_DUPFD_CLOEXEC: ::c_int = 2;
++pub const F_GETFD: ::c_int = 3;
+ pub const F_GETFL: ::c_int = 5;
++pub const F_GETLK: ::c_int = 7;
++pub const F_SETFD: ::c_int = 4;
+ pub const F_SETFL: ::c_int = 6;
++pub const F_SETLK: ::c_int = 8;
++pub const F_SETLKW: ::c_int = 9;
+ pub const O_ACCMODE: ::c_int = 7;
+ pub const O_APPEND: ::c_int = 8;
++pub const O_ASYNC: ::c_int = 0x40000;
+ pub const O_CLOEXEC: ::c_int = 0x4000;
+ pub const O_CREAT: ::c_int = 0x10;
+ pub const O_DIRECTORY: ::c_int = 0x00020;
+ pub const O_EXCL: ::c_int = 0x40;
++pub const O_NDELAY: ::c_int = 0x400;
++pub const O_NOCTTY: ::c_int = 0x80;
+ pub const O_NOFOLLOW: ::c_int = 0x100;
+ pub const O_NONBLOCK: ::c_int = 0x400;
+ pub const O_RDONLY: ::c_int = 2;
+ pub const O_RDWR: ::c_int = 3;
++pub const O_SYNC: ::c_int = 0x2000;
+ pub const O_TRUNC: ::c_int = 0x200;
+ pub const O_WRONLY: ::c_int = 5;
++s! {
++    pub struct flock {
++        pub l_type: ::c_short,
++        pub l_whence: ::c_short,
++        pub l_start: ::off_t,
++        pub l_len: ::off_t,
++        pub l_pid: ::pid_t,
++    }
++}
++
++// options/posix/include/sys/file.h
++pub const LOCK_EX: ::c_int = 2;
++pub const LOCK_NB: ::c_int = 4;
++pub const LOCK_SH: ::c_int = 1;
++pub const LOCK_UN: ::c_int = 8;
+ 
+ // options/mlibc/seek-whence.h
+ pub const SEEK_CUR: ::c_int = 1;
+@@ -406,19 +614,50 @@ safe_f! {
+ }
+ 
+ // options/linux/include/sys/poll.h
+-// TODO: Port epoll!
+ pub const POLLHUP: ::c_short = 8;
+ pub const POLLIN: ::c_short = 1;
+ pub const POLLNVAL: ::c_short = 0x40;
+ pub const POLLOUT: ::c_short = 2;
+ pub type nfds_t = ::size_t;
+ 
++// options/linux/include/sys/epoll.h
++pub const EPOLLERR: ::c_int = 8;
++pub const EPOLLET: ::c_int = 1 << 31;
++pub const EPOLLHUP : ::c_int = 0x10;
++pub const EPOLLIN: ::c_int = 1;
++pub const EPOLLMSG: ::c_int = 0x400;
++pub const EPOLLONESHOT: ::c_int = 1 << 30;
++pub const EPOLLOUT: ::c_int = 4;
++pub const EPOLLPRI: ::c_int = 2;
++pub const EPOLLRDBAND: ::c_int = 0x80;
++pub const EPOLLRDHUP: ::c_int = 0x2000;
++pub const EPOLLRDNORM: ::c_int = 0x40;
++pub const EPOLLWRBAND: ::c_int = 0x200;
++pub const EPOLLWRNORM: ::c_int = 0x100;
++pub const EPOLLWAKEUP: ::c_int = 1 << 29;
++pub const EPOLL_CLOEXEC: ::c_int = 1;
++pub const EPOLL_CTL_ADD: ::c_int = 1;
++pub const EPOLL_CTL_DEL: ::c_int = 2;
++pub const EPOLL_CTL_MOD: ::c_int = 3;
++
++s! {
++    pub struct epoll_event {
++        pub events: u32,
++        pub u64: u64,
++    }
++}
++
++// options/linux/include/sys/eventfd.h
++pub const EFD_CLOEXEC: ::c_int = O_CLOEXEC;
++pub const EFD_NONBLOCK: ::c_int = O_NONBLOCK;
++
+ // options/glibc/include/sys/ioctl.h
+ pub const FIOCLEX: ::c_ulong = 0x5451;
+ pub const FIONBIO: ::c_ulong = 0x5421;
+ 
+ // options/ansi/include/limits.h
+ pub const PTHREAD_STACK_MIN: ::size_t = 16384;
++pub const PATH_MAX: ::size_t = 4096;
+ 
+ // options/elf/include/link.h
+ pub type Elf64_Half = u16;
+@@ -469,6 +708,27 @@ s! {
+         pub sa_family: sa_family_t,
+         pub sa_data: [::c_char; 14],
+     }
++
++    pub struct cmsghdr {
++        // mio needs this to be a size_t for some reason
++        // pub cmsg_len: ::socklen_t,
++        pub cmsg_len: ::size_t,
++        pub cmsg_level: ::c_int,
++        pub cmsg_type: ::c_int,
++    }
++}
++
++// options/linux-headers/include/linux/if_packet.h
++s! {
++    pub struct sockaddr_ll {
++        pub sll_family: ::c_ushort,
++        pub sll_protocol: ::c_ushort,
++        pub sll_ifindex: ::c_int,
++        pub sll_hatype: ::c_ushort,
++        pub sll_pkttype: ::c_uchar,
++        pub sll_halen: ::c_uchar,
++        pub sll_addr: [::c_uchar; 8]
++    }
+ }
+ 
+ // options/posix/include/bits/posix/pthread_t.h
+@@ -535,6 +795,7 @@ s! {
+ }
+ 
+ // options/ansi/include/locale.h
++pub const LC_CTYPE: ::c_int = 3;
+ s! {
+     pub struct lconv {
+         pub decimal_point: *mut ::c_char,
+@@ -618,10 +879,14 @@ s! {
+ // abis/mlibc/in.h
+ pub const IPV6_ADD_MEMBERSHIP: ::c_int = 1;
+ pub const IPV6_DROP_MEMBERSHIP: ::c_int = 2;
++pub const IPV6_MULTICAST_HOPS: ::c_int = 3;
++pub const IPV6_MULTICAST_IF: ::c_int = 4;
+ pub const IPV6_MULTICAST_LOOP: ::c_int = 5;
++pub const IPV6_UNICAST_HOPS: ::c_int = 6;
+ pub const IPV6_V6ONLY: ::c_int = 7;
+ pub const IP_ADD_MEMBERSHIP: ::c_int = 35;
+ pub const IP_DROP_MEMBERSHIP: ::c_int = 36;
++pub const IP_MULTICAST_IF: ::c_int = 4;
+ pub const IP_MULTICAST_LOOP: ::c_int = 34;
+ pub const IP_MULTICAST_TTL: ::c_int = 33;
+ pub const IP_TTL: ::c_int = 2;
+@@ -637,7 +902,7 @@ s! {
+         pub sin_family: sa_family_t,
+         pub sin_port: in_port_t,
+         pub sin_addr: in_addr,
+-        pub __padding: [u8; 8], // std relies on this being public
++        pub sin_zero: [u8; 8], // std relies on this being public
+     }
+     pub struct sockaddr_in6 {
+         pub sin6_family: sa_family_t,
+@@ -656,6 +921,8 @@ s! {
+ }
+ 
+ extern "C" {
++    pub fn __errno_location() -> *mut ::c_int;
++    pub fn acct(filename: *const ::c_char) -> ::c_int;
+     pub fn bind(socket: ::c_int, address: *const ::sockaddr, address_len: ::socklen_t) -> ::c_int;
+     pub fn clock_gettime(clk_id: clockid_t, tp: *mut ::timespec) -> ::c_int;
+     pub fn clock_settime(clk_id: clockid_t, tp: *const ::timespec) -> ::c_int;
+@@ -670,6 +937,24 @@ extern "C" {
+         data: *mut ::c_void,
+     ) -> ::c_int;
+     pub fn endpwent();
++    pub fn epoll_create(size: ::c_int) -> ::c_int;
++    pub fn epoll_create1(flags: ::c_int) -> ::c_int;
++    pub fn epoll_ctl(epfd: ::c_int, op: ::c_int, fd: ::c_int, event: *mut ::epoll_event) -> ::c_int;
++    pub fn epoll_wait(
++        epfd: ::c_int,
++        events: *mut ::epoll_event,
++        maxevents: ::c_int,
++        timeout: ::c_int,
++    ) -> ::c_int;
++    pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;
++    pub fn forkpty(
++        amaster: *mut ::c_int,
++        name: *mut ::c_char,
++        termp: *mut termios,
++        winp: *mut ::winsize,
++    ) -> ::pid_t;
++    pub fn futimes(file: ::c_int, times: *const ::timeval) -> ::c_int;
++    pub fn futimens(fd: ::c_int, times: *const ::timespec) -> ::c_int;
+     pub fn getpwent() -> *mut passwd;
+     pub fn getgrgid_r(
+         gid: ::gid_t,
+@@ -705,9 +990,21 @@ extern "C" {
+         buflen: ::size_t,
+         result: *mut *mut passwd,
+     ) -> ::c_int;
++    pub fn initgroups(user: *const ::c_char, group: ::gid_t) -> ::c_int;
+     pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
++    pub fn lutimes(file: *const ::c_char, times: *const ::timeval) -> ::c_int;
++    pub fn madvise(addr: *mut ::c_void, len: ::size_t, advice: ::c_int) -> ::c_int;
++    pub fn mkfifoat(dirfd: ::c_int, pathname: *const ::c_char, mode: ::mode_t) -> ::c_int;
+     pub fn mprotect(addr: *mut ::c_void, len: ::size_t, prot: ::c_int) -> ::c_int;
+     pub fn msync(addr: *mut ::c_void, len: ::size_t, flags: ::c_int) -> ::c_int;
++    pub fn openpty(
++        amaster: *mut ::c_int,
++        aslave: *mut ::c_int,
++        name: *mut ::c_char,
++        termp: *const termios,
++        winp: *const ::winsize,
++    ) -> ::c_int;
++    pub fn pipe2(fds: *mut ::c_int, flags: ::c_int) -> ::c_int;
+     pub fn pthread_condattr_setclock(
+         attr: *mut pthread_condattr_t,
+         clock_id: ::clockid_t,
+@@ -729,7 +1026,18 @@ extern "C" {
+         addr: *mut ::sockaddr,
+         addrlen: *mut ::socklen_t,
+     ) -> ::ssize_t;
++    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
++    pub fn sendmsg(fd: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
+     pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
++    pub fn sethostname(name: *const ::c_char, len: ::size_t) -> ::c_int;
+     pub fn setpwent();
++    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
++    pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
++    pub fn utimensat(
++        dirfd: ::c_int,
++        path: *const ::c_char,
++        times: *const ::timespec,
++        flag: ::c_int,
++    ) -> ::c_int;
+     pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
+ }
+-- 
+2.36.1
+

--- a/patches/rust-libloading/0001-managarm-initial-port.patch
+++ b/patches/rust-libloading/0001-managarm-initial-port.patch
@@ -1,0 +1,50 @@
+From fb811324a8c4c979a84dc5c5eb0230ee3876f9dc Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 02:39:12 +0000
+Subject: [PATCH] managarm: initial port
+
+---
+ src/os/unix/consts.rs | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/os/unix/consts.rs b/src/os/unix/consts.rs
+index dbe4df9..04e646c 100644
+--- a/src/os/unix/consts.rs
++++ b/src/os/unix/consts.rs
+@@ -58,7 +58,7 @@ mod posix {
+     use self::cfg_if::cfg_if;
+     use super::c_int;
+     cfg_if! {
+-        if #[cfg(target_os = "haiku")] {
++        if #[cfg(any(target_os = "haiku", target_os = "managarm"))] {
+             pub(super) const RTLD_LAZY: c_int = 0;
+         } else if #[cfg(any(
+             target_os = "linux",
+@@ -90,7 +90,7 @@ mod posix {
+     }
+ 
+     cfg_if! {
+-        if #[cfg(target_os = "haiku")] {
++        if #[cfg(any(target_os = "haiku", target_os = "managarm"))] {
+             pub(super) const RTLD_NOW: c_int = 1;
+         } else if #[cfg(any(
+             target_os = "linux",
+@@ -126,6 +126,7 @@ mod posix {
+     cfg_if! {
+         if #[cfg(any(
+             target_os = "haiku",
++            target_os = "managarm",
+             all(target_os = "android",target_pointer_width = "32"),
+         ))] {
+             pub(super) const RTLD_GLOBAL: c_int = 2;
+@@ -193,6 +194,7 @@ mod posix {
+ 
+             target_os = "fuchsia",
+             target_os = "redox",
++            target_os = "managarm",
+         ))] {
+             pub(super) const RTLD_LOCAL: c_int = 0;
+         } else {
+-- 
+2.35.1
+

--- a/patches/rust-mio-0.6/0001-managarm-initial-port.patch
+++ b/patches/rust-mio-0.6/0001-managarm-initial-port.patch
@@ -1,0 +1,94 @@
+From f8154d014a199093419c2cd5964ebfbaf529faf0 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 12:20:38 +0000
+Subject: [PATCH] managarm: initial port
+
+---
+ src/event_imp.rs      | 10 ++++++----
+ src/sys/unix/mod.rs   |  2 ++
+ src/sys/unix/ready.rs |  7 +++++--
+ 3 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/src/event_imp.rs b/src/event_imp.rs
+index f93e1fd..0109f74 100644
+--- a/src/event_imp.rs
++++ b/src/event_imp.rs
+@@ -512,8 +512,9 @@ impl ops::Sub for PollOpt {
+     }
+ }
+ 
+-#[deprecated(since = "0.6.10", note = "removed")]
+-#[cfg(feature = "with-deprecated")]
++// Hack: causes errors for us since this isn't upstream.
++// #[deprecated(since = "0.6.10", note = "removed")]
++// #[cfg(feature = "with-deprecated")]
+ #[doc(hidden)]
+ impl ops::Not for PollOpt {
+     type Output = PollOpt;
+@@ -999,8 +1000,9 @@ impl<T: Into<Ready>> ops::SubAssign<T> for Ready {
+     }
+ }
+ 
+-#[deprecated(since = "0.6.10", note = "removed")]
+-#[cfg(feature = "with-deprecated")]
++// Hack: causes errors for us since this isn't upstream.
++// #[deprecated(since = "0.6.10", note = "removed")]
++// #[cfg(feature = "with-deprecated")]
+ #[doc(hidden)]
+ impl ops::Not for Ready {
+     type Output = Ready;
+diff --git a/src/sys/unix/mod.rs b/src/sys/unix/mod.rs
+index c5726c0..8c8043c 100644
+--- a/src/sys/unix/mod.rs
++++ b/src/sys/unix/mod.rs
+@@ -6,6 +6,7 @@ pub mod dlsym;
+ #[cfg(any(
+     target_os = "android",
+     target_os = "illumos",
++    target_os = "managarm",
+     target_os = "linux",
+     target_os = "solaris"
+ ))]
+@@ -14,6 +15,7 @@ mod epoll;
+ #[cfg(any(
+     target_os = "android",
+     target_os = "illumos",
++    target_os = "managarm",
+     target_os = "linux",
+     target_os = "solaris"
+ ))]
+diff --git a/src/sys/unix/ready.rs b/src/sys/unix/ready.rs
+index ef90147..ade762f 100644
+--- a/src/sys/unix/ready.rs
++++ b/src/sys/unix/ready.rs
+@@ -276,6 +276,7 @@ impl UnixReady {
+     #[cfg(any(
+         target_os = "android",
+         target_os = "illumos",
++        target_os = "managarm",
+         target_os = "linux",
+         target_os = "solaris"
+     ))]
+@@ -407,6 +408,7 @@ impl UnixReady {
+     #[cfg(any(
+         target_os = "android",
+         target_os = "illumos",
++        target_os = "managarm",
+         target_os = "linux",
+         target_os = "solaris"
+     ))]
+@@ -477,8 +479,9 @@ impl ops::Sub for UnixReady {
+     }
+ }
+ 
+-#[deprecated(since = "0.6.10", note = "removed")]
+-#[cfg(feature = "with-deprecated")]
++// Hack: causes errors for us since this isn't upstream.
++// #[deprecated(since = "0.6.10", note = "removed")]
++// #[cfg(feature = "with-deprecated")]
+ #[doc(hidden)]
+ impl ops::Not for UnixReady {
+     type Output = UnixReady;
+-- 
+2.36.1
+

--- a/patches/rust-mio-0.8/0001-managarm-initial-port.patch
+++ b/patches/rust-mio-0.8/0001-managarm-initial-port.patch
@@ -1,0 +1,73 @@
+From 22b12d99454d0dba66f27e5acfe69bfa4ae7b3fd Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 02:35:35 +0000
+Subject: [PATCH] managarm: initial port
+
+---
+ src/sys/unix/pipe.rs         | 2 ++
+ src/sys/unix/selector/mod.rs | 2 ++
+ src/sys/unix/waker.rs        | 4 ++--
+ 3 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/sys/unix/pipe.rs b/src/sys/unix/pipe.rs
+index b2865cd..a05475a 100644
+--- a/src/sys/unix/pipe.rs
++++ b/src/sys/unix/pipe.rs
+@@ -150,6 +150,7 @@ pub fn new() -> io::Result<(Sender, Receiver)> {
+     #[cfg(any(
+         target_os = "android",
+         target_os = "dragonfly",
++        target_os = "managarm",
+         target_os = "freebsd",
+         target_os = "linux",
+         target_os = "netbsd",
+@@ -189,6 +190,7 @@ pub fn new() -> io::Result<(Sender, Receiver)> {
+         target_os = "dragonfly",
+         target_os = "freebsd",
+         target_os = "linux",
++        target_os = "managarm",
+         target_os = "netbsd",
+         target_os = "openbsd",
+         target_os = "ios",
+diff --git a/src/sys/unix/selector/mod.rs b/src/sys/unix/selector/mod.rs
+index 9ae4c14..45786f1 100644
+--- a/src/sys/unix/selector/mod.rs
++++ b/src/sys/unix/selector/mod.rs
+@@ -3,6 +3,7 @@
+     target_os = "illumos",
+     target_os = "linux",
+     target_os = "redox",
++    target_os = "managarm",
+ ))]
+ mod epoll;
+ 
+@@ -11,6 +12,7 @@ mod epoll;
+     target_os = "illumos",
+     target_os = "linux",
+     target_os = "redox",
++    target_os = "managarm",
+ ))]
+ pub(crate) use self::epoll::{event, Event, Events, Selector};
+ 
+diff --git a/src/sys/unix/waker.rs b/src/sys/unix/waker.rs
+index de88e31..f32664f 100644
+--- a/src/sys/unix/waker.rs
++++ b/src/sys/unix/waker.rs
+@@ -1,4 +1,4 @@
+-#[cfg(any(target_os = "linux", target_os = "android"))]
++#[cfg(any(target_os = "linux", target_os = "android", target_os = "managarm"))]
+ mod eventfd {
+     use crate::sys::Selector;
+     use crate::{Interest, Token};
+@@ -58,7 +58,7 @@ mod eventfd {
+     }
+ }
+ 
+-#[cfg(any(target_os = "linux", target_os = "android"))]
++#[cfg(any(target_os = "linux", target_os = "android", target_os = "managarm"))]
+ pub use self::eventfd::Waker;
+ 
+ #[cfg(any(target_os = "freebsd", target_os = "ios", target_os = "macos"))]
+-- 
+2.36.1
+

--- a/patches/rust-nix/0001-managarm-initial-port.patch
+++ b/patches/rust-nix/0001-managarm-initial-port.patch
@@ -1,0 +1,709 @@
+From eb4103e03b7c5176e75ae95539a30679152bd99a Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 02:42:37 +0000
+Subject: [PATCH] managarm: initial port
+
+---
+ src/errno.rs           | 217 +++++++++++++++++++++++++++++++++++++++++
+ src/lib.rs             |  12 ++-
+ src/sys/mod.rs         |  10 +-
+ src/sys/socket/addr.rs |  16 +--
+ src/sys/socket/mod.rs  |   5 +-
+ src/sys/termios.rs     |  54 +++++++++-
+ src/unistd.rs          |  27 +++++
+ 7 files changed, 327 insertions(+), 14 deletions(-)
+
+diff --git a/src/errno.rs b/src/errno.rs
+index 9c2dfe4..d0b4857 100644
+--- a/src/errno.rs
++++ b/src/errno.rs
+@@ -22,6 +22,7 @@ cfg_if! {
+     } else if #[cfg(any(target_os = "linux",
+                         target_os = "redox",
+                         target_os = "dragonfly",
++                        target_os = "managarm",
+                         target_os = "fuchsia"))] {
+         unsafe fn errno_location() -> *mut c_int {
+             libc::__errno_location()
+@@ -183,6 +184,9 @@ fn last() -> Errno {
+ 
+ fn desc(errno: Errno) -> &'static str {
+     use self::Errno::*;
++    // TODO: This is completely broken on managarm
++    #[allow(unreachable_patterns)]
++    #[allow(unused_variables)]
+     match errno {
+         UnknownErrno    => "Unknown errno",
+         EPERM           => "Operation not permitted",
+@@ -1557,6 +1561,219 @@ mod consts {
+     }
+ }
+ 
++#[cfg(target_os = "managarm")]
++mod consts {
++    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
++    #[repr(i32)]
++    pub enum Errno {
++        UnknownErrno    = 0,
++        E2BIG           = libc::E2BIG,
++        EACCES          = libc::EACCES,
++        EADDRINUSE      = libc::EADDRINUSE,
++        EADDRNOTAVAIL   = libc::EADDRNOTAVAIL,
++        // EAFNOSUPPORT    = libc::EAFNOSUPPORT,
++        EAGAIN          = libc::EAGAIN,
++        // EALREADY        = libc::EALREADY,
++        // EAUTH           = libc::EAUTH,
++        EBADF           = libc::EBADF,
++        // EBADMSG         = libc::EBADMSG,
++        // EBADRPC         = libc::EBADRPC,
++        // EBUSY           = libc::EBUSY,
++        // ECANCELED       = libc::ECANCELED,
++        // ECHILD          = libc::ECHILD,
++        ECONNABORTED    = libc::ECONNABORTED,
++        ECONNREFUSED    = libc::ECONNREFUSED,
++        ECONNRESET      = libc::ECONNRESET,
++        EDEADLK         = libc::EDEADLK,
++        // EDESTADDRREQ    = libc::EDESTADDRREQ,
++        // EDOM            = libc::EDOM,
++        // EDQUOT          = libc::EDQUOT,
++        EEXIST          = libc::EEXIST,
++        // EFAULT          = libc::EFAULT,
++        // EFBIG           = libc::EFBIG,
++        // EFTYPE          = libc::EFTYPE,
++        // EHOSTDOWN       = libc::EHOSTDOWN,
++        // EHOSTUNREACH    = libc::EHOSTUNREACH,
++        // EIDRM           = libc::EIDRM,
++        // EILSEQ          = libc::EILSEQ,
++        EINPROGRESS     = libc::EINPROGRESS,
++        EINTR           = libc::EINTR,
++        EINVAL          = libc::EINVAL,
++        // EIO             = libc::EIO,
++        // EISCONN         = libc::EISCONN,
++        // EISDIR          = libc::EISDIR,
++        // ELOOP           = libc::ELOOP,
++        // EMFILE          = libc::EMFILE,
++        // EMLINK          = libc::EMLINK,
++        // EMSGSIZE        = libc::EMSGSIZE,
++        // EMULTIHOP       = libc::EMULTIHOP,
++        ENAMETOOLONG    = libc::ENAMETOOLONG,
++        // ENEEDAUTH       = libc::ENEEDAUTH,
++        // ENETDOWN        = libc::ENETDOWN,
++        // ENETRESET       = libc::ENETRESET,
++        // ENETUNREACH     = libc::ENETUNREACH,
++        // ENFILE          = libc::ENFILE,
++        // ENOATTR         = libc::ENOATTR,
++        // ENOBUFS         = libc::ENOBUFS,
++        // ENODATA         = libc::ENODATA,
++        // ENODEV          = libc::ENODEV,
++        ENOENT          = libc::ENOENT,
++        // ENOEXEC         = libc::ENOEXEC,
++        // ENOLCK          = libc::ENOLCK,
++        // ENOLINK         = libc::ENOLINK,
++        // ENOMEM          = libc::ENOMEM,
++        // ENOMSG          = libc::ENOMSG,
++        // ENOPROTOOPT     = libc::ENOPROTOOPT,
++        // ENOSPC          = libc::ENOSPC,
++        // ENOSR           = libc::ENOSR,
++        // ENOSTR          = libc::ENOSTR,
++        ENOSYS          = libc::ENOSYS,
++        // ENOTBLK         = libc::ENOTBLK,
++        ENOTCONN        = libc::ENOTCONN,
++        // ENOTDIR         = libc::ENOTDIR,
++        // ENOTEMPTY       = libc::ENOTEMPTY,
++        // ENOTSOCK        = libc::ENOTSOCK,
++        // ENOTSUP         = libc::ENOTSUP,
++        ENOTTY          = libc::ENOTTY,
++        // ENXIO           = libc::ENXIO,
++        // EOPNOTSUPP      = libc::EOPNOTSUPP,
++        // EOVERFLOW       = libc::EOVERFLOW,
++        EPERM           = libc::EPERM,
++        // EPFNOSUPPORT    = libc::EPFNOSUPPORT,
++        EPIPE           = libc::EPIPE,
++        // EPROCLIM        = libc::EPROCLIM,
++        // EPROCUNAVAIL    = libc::EPROCUNAVAIL,
++        // EPROGMISMATCH   = libc::EPROGMISMATCH,
++        // EPROGUNAVAIL    = libc::EPROGUNAVAIL,
++        EPROTO          = libc::EPROTO,
++        // EPROTONOSUPPORT = libc::EPROTONOSUPPORT,
++        // EPROTOTYPE      = libc::EPROTOTYPE,
++        ERANGE          = libc::ERANGE,
++        // EREMOTE         = libc::EREMOTE,
++        // EROFS           = libc::EROFS,
++        // ERPCMISMATCH    = libc::ERPCMISMATCH,
++        // ESHUTDOWN       = libc::ESHUTDOWN,
++        // ESOCKTNOSUPPORT = libc::ESOCKTNOSUPPORT,
++        // ESPIPE          = libc::ESPIPE,
++        // ESRCH           = libc::ESRCH,
++        // ESTALE          = libc::ESTALE,
++        // ETIME           = libc::ETIME,
++        ETIMEDOUT       = libc::ETIMEDOUT,
++        // ETOOMANYREFS    = libc::ETOOMANYREFS,
++        // ETXTBSY         = libc::ETXTBSY,
++        // EUSERS          = libc::EUSERS,
++        // EXDEV           = libc::EXDEV,
++    }
++
++    // pub const ELAST: Errno       = Errno::ENOTSUP;
++    pub const EWOULDBLOCK: Errno = Errno::EAGAIN;
++
++    // pub const EL2NSYNC: Errno = Errno::UnknownErrno;
++
++    pub fn from_i32(e: i32) -> Errno {
++        use self::Errno::*;
++
++        match e {
++            // libc::E2BIG => E2BIG,
++            libc::EACCES => EACCES,
++            libc::EADDRINUSE => EADDRINUSE,
++            libc::EADDRNOTAVAIL => EADDRNOTAVAIL,
++            // libc::EAFNOSUPPORT => EAFNOSUPPORT,
++            libc::EAGAIN => EAGAIN,
++            // libc::EALREADY => EALREADY,
++            // libc::EAUTH => EAUTH,
++            libc::EBADF => EBADF,
++            // libc::EBADMSG => EBADMSG,
++            // libc::EBADRPC => EBADRPC,
++            // libc::EBUSY => EBUSY,
++            // libc::ECANCELED => ECANCELED,
++            // libc::ECHILD => ECHILD,
++            libc::ECONNABORTED => ECONNABORTED,
++            libc::ECONNREFUSED => ECONNREFUSED,
++            libc::ECONNRESET => ECONNRESET,
++            libc::EDEADLK => EDEADLK,
++            // libc::EDESTADDRREQ => EDESTADDRREQ,
++            // libc::EDOM => EDOM,
++            // libc::EDQUOT => EDQUOT,
++            libc::EEXIST => EEXIST,
++            // libc::EFAULT => EFAULT,
++            // libc::EFBIG => EFBIG,
++            // libc::EFTYPE => EFTYPE,
++            // libc::EHOSTDOWN => EHOSTDOWN,
++            // libc::EHOSTUNREACH => EHOSTUNREACH,
++            // libc::EIDRM => EIDRM,
++            // libc::EILSEQ => EILSEQ,
++            libc::EINPROGRESS => EINPROGRESS,
++            libc::EINTR => EINTR,
++            libc::EINVAL => EINVAL,
++            // libc::EIO => EIO,
++            // libc::EISCONN => EISCONN,
++            // libc::EISDIR => EISDIR,
++            // libc::ELOOP => ELOOP,
++            // libc::EMFILE => EMFILE,
++            // libc::EMLINK => EMLINK,
++            // libc::EMSGSIZE => EMSGSIZE,
++            // libc::EMULTIHOP => EMULTIHOP,
++            libc::ENAMETOOLONG => ENAMETOOLONG,
++            // libc::ENEEDAUTH => ENEEDAUTH,
++            // libc::ENETDOWN => ENETDOWN,
++            // libc::ENETRESET => ENETRESET,
++            // libc::ENETUNREACH => ENETUNREACH,
++            // libc::ENFILE => ENFILE,
++            // libc::ENOATTR => ENOATTR,
++            // libc::ENOBUFS => ENOBUFS,
++            // libc::ENODATA => ENODATA,
++            // libc::ENODEV => ENODEV,
++            libc::ENOENT => ENOENT,
++            // libc::ENOEXEC => ENOEXEC,
++            // libc::ENOLCK => ENOLCK,
++            // libc::ENOLINK => ENOLINK,
++            // libc::ENOMEM => ENOMEM,
++            // libc::ENOMSG => ENOMSG,
++            // libc::ENOPROTOOPT => ENOPROTOOPT,
++            // libc::ENOSPC => ENOSPC,
++            // libc::ENOSR => ENOSR,
++            // libc::ENOSTR => ENOSTR,
++            libc::ENOSYS => ENOSYS,
++            // libc::ENOTBLK => ENOTBLK,
++            libc::ENOTCONN => ENOTCONN,
++            // libc::ENOTDIR => ENOTDIR,
++            // libc::ENOTEMPTY => ENOTEMPTY,
++            // libc::ENOTSOCK => ENOTSOCK,
++            // libc::ENOTSUP => ENOTSUP,
++            // libc::ENOTTY => ENOTTY,
++            // libc::ENXIO => ENXIO,
++            // libc::EOPNOTSUPP => EOPNOTSUPP,
++            // libc::EOVERFLOW => EOVERFLOW,
++            libc::EPERM => EPERM,
++            // libc::EPFNOSUPPORT => EPFNOSUPPORT,
++            libc::EPIPE => EPIPE,
++            // libc::EPROCLIM => EPROCLIM,
++            // libc::EPROCUNAVAIL => EPROCUNAVAIL,
++            // libc::EPROGMISMATCH => EPROGMISMATCH,
++            // libc::EPROGUNAVAIL => EPROGUNAVAIL,
++            // libc::EPROTO => EPROTO,
++            // libc::EPROTONOSUPPORT => EPROTONOSUPPORT,
++            // libc::EPROTOTYPE => EPROTOTYPE,
++            libc::ERANGE => ERANGE,
++            // libc::EREMOTE => EREMOTE,
++            // libc::EROFS => EROFS,
++            // libc::ERPCMISMATCH => ERPCMISMATCH,
++            // libc::ESHUTDOWN => ESHUTDOWN,
++            // libc::ESOCKTNOSUPPORT => ESOCKTNOSUPPORT,
++            // libc::ESPIPE => ESPIPE,
++            // libc::ESRCH => ESRCH,
++            // libc::ESTALE => ESTALE,
++            // libc::ETIME => ETIME,
++            libc::ETIMEDOUT => ETIMEDOUT,
++            // libc::ETOOMANYREFS => ETOOMANYREFS,
++            // libc::ETXTBSY => ETXTBSY,
++            // libc::EUSERS => EUSERS,
++            // libc::EXDEV => EXDEV,
++             _   => UnknownErrno,
++         }
++     }
++}
+ 
+ #[cfg(target_os = "dragonfly")]
+ mod consts {
+diff --git a/src/lib.rs b/src/lib.rs
+index 3b534a5..fa8ee19 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -5,12 +5,13 @@
+ #![crate_name = "nix"]
+ #![cfg(unix)]
+ #![allow(non_camel_case_types)]
++#![allow(non_snake_case)]
+ // latest bitflags triggers a rustc bug with cross-crate macro expansions causing dead_code
+ // warnings even though the macro expands into something with allow(dead_code)
+ #![allow(dead_code)]
+ #![cfg_attr(test, deny(warnings))]
+ #![recursion_limit = "500"]
+-#![deny(unused)]
++// #![deny(unused)]
+ #![deny(unstable_features)]
+ #![deny(missing_copy_implementations)]
+ #![deny(missing_debug_implementations)]
+@@ -22,11 +23,13 @@ pub use libc;
+ #[macro_use] mod macros;
+ 
+ // Public crates
+-#[cfg(not(target_os = "redox"))]
++#[cfg(not(any(target_os = "redox", target_os = "managarm")))]
+ pub mod dir;
++#[cfg(not(target_os = "managarm"))]
+ pub mod env;
+ pub mod errno;
+ #[deny(missing_docs)]
++#[cfg(not(target_os = "managarm"))]
+ pub mod features;
+ pub mod fcntl;
+ #[deny(missing_docs)]
+@@ -54,15 +57,18 @@ pub mod mount;
+           target_os = "netbsd"))]
+ pub mod mqueue;
+ #[deny(missing_docs)]
+-#[cfg(not(target_os = "redox"))]
++#[cfg(not(any(target_os = "redox", target_os = "managarm")))]
+ pub mod net;
+ #[deny(missing_docs)]
++#[cfg(not(target_os = "managarm"))]
+ pub mod poll;
+ #[deny(missing_docs)]
+ #[cfg(not(any(target_os = "redox", target_os = "fuchsia")))]
+ pub mod pty;
++#[cfg(not(target_os = "managarm"))]
+ pub mod sched;
+ pub mod sys;
++#[cfg(not(target_os = "managarm"))]
+ pub mod time;
+ // This can be implemented for other platforms as soon as libc
+ // provides bindings for them.
+diff --git a/src/sys/mod.rs b/src/sys/mod.rs
+index 43877a1..42491b9 100644
+--- a/src/sys/mod.rs
++++ b/src/sys/mod.rs
+@@ -6,7 +6,7 @@
+           target_os = "netbsd"))]
+ pub mod aio;
+ 
+-#[cfg(any(target_os = "android", target_os = "linux"))]
++#[cfg(any(target_os = "android", target_os = "linux", target_os = "managarm"))]
+ pub mod epoll;
+ 
+ #[cfg(any(target_os = "dragonfly",
+@@ -42,6 +42,7 @@ pub mod mman;
+ #[cfg(target_os = "linux")]
+ pub mod personality;
+ 
++#[cfg(not(target_os = "managarm"))]
+ pub mod pthread;
+ 
+ #[cfg(any(target_os = "android",
+@@ -59,7 +60,8 @@ pub mod quota;
+ #[cfg(any(target_os = "linux"))]
+ pub mod reboot;
+ 
+-#[cfg(not(target_os = "redox"))]
++// #[cfg(not(target_os = "redox"))]
++#[cfg(not(any(target_os = "redox", target_os = "managarm")))]
+ pub mod select;
+ 
+ #[cfg(any(target_os = "android",
+@@ -69,6 +71,7 @@ pub mod select;
+           target_os = "macos"))]
+ pub mod sendfile;
+ 
++#[cfg(not(target_os = "managarm"))]
+ pub mod signal;
+ 
+ #[cfg(any(target_os = "android", target_os = "linux"))]
+@@ -89,6 +92,7 @@ pub mod stat;
+ ))]
+ pub mod statfs;
+ 
++#[cfg(not(target_os = "managarm"))]
+ pub mod statvfs;
+ 
+ #[cfg(any(target_os = "android", target_os = "linux"))]
+@@ -100,8 +104,10 @@ pub mod time;
+ 
+ pub mod uio;
+ 
++#[cfg(not(target_os = "managarm"))]
+ pub mod utsname;
+ 
++#[cfg(not(target_os = "managarm"))]
+ pub mod wait;
+ 
+ #[cfg(any(target_os = "android", target_os = "linux"))]
+diff --git a/src/sys/socket/addr.rs b/src/sys/socket/addr.rs
+index d486056..70944bd 100644
+--- a/src/sys/socket/addr.rs
++++ b/src/sys/socket/addr.rs
+@@ -17,6 +17,7 @@ use std::os::unix::io::RawFd;
+ use crate::sys::socket::addr::sys_control::SysControlAddr;
+ #[cfg(any(target_os = "android",
+           target_os = "dragonfly",
++          target_os = "managarm",
+           target_os = "freebsd",
+           target_os = "ios",
+           target_os = "linux",
+@@ -46,6 +47,7 @@ pub enum AddressFamily {
+     /// Low level packet interface (see [`packet(7)`](https://man7.org/linux/man-pages/man7/packet.7.html))
+     #[cfg(any(target_os = "android",
+               target_os = "linux",
++              target_os = "managarm",
+               target_os = "illumos",
+               target_os = "fuchsia",
+               target_os = "solaris"))]
+@@ -245,7 +247,7 @@ impl AddressFamily {
+             libc::AF_NETLINK => Some(AddressFamily::Netlink),
+             #[cfg(any(target_os = "macos", target_os = "macos"))]
+             libc::AF_SYSTEM => Some(AddressFamily::System),
+-            #[cfg(any(target_os = "android", target_os = "linux"))]
++            #[cfg(any(target_os = "android", target_os = "linux", target_os = "managarm"))]
+             libc::AF_PACKET => Some(AddressFamily::Packet),
+             #[cfg(any(target_os = "dragonfly",
+                       target_os = "freebsd",
+@@ -653,6 +655,7 @@ pub enum SockAddr {
+     /// Datalink address (MAC)
+     #[cfg(any(target_os = "android",
+               target_os = "dragonfly",
++              target_os = "managarm",
+               target_os = "freebsd",
+               target_os = "ios",
+               target_os = "linux",
+@@ -705,7 +708,7 @@ impl SockAddr {
+             SockAddr::Alg(..) => AddressFamily::Alg,
+             #[cfg(any(target_os = "ios", target_os = "macos"))]
+             SockAddr::SysControl(..) => AddressFamily::System,
+-            #[cfg(any(target_os = "android", target_os = "linux"))]
++            #[cfg(any(target_os = "android", target_os = "linux", target_os = "managarm"))]
+             SockAddr::Link(..) => AddressFamily::Packet,
+             #[cfg(any(target_os = "dragonfly",
+                       target_os = "freebsd",
+@@ -738,7 +741,7 @@ impl SockAddr {
+         if addr.is_null() {
+             None
+         } else {
+-            match AddressFamily::from_i32(i32::from((*addr).sa_family)) {
++            match AddressFamily::from_i32((*addr).sa_family as i32) {
+                 Some(AddressFamily::Unix) => None,
+                 Some(AddressFamily::Inet) => Some(SockAddr::Inet(
+                     InetAddr::V4(*(addr as *const libc::sockaddr_in)))),
+@@ -750,7 +753,7 @@ impl SockAddr {
+                 #[cfg(any(target_os = "ios", target_os = "macos"))]
+                 Some(AddressFamily::System) => Some(SockAddr::SysControl(
+                     SysControlAddr(*(addr as *const libc::sockaddr_ctl)))),
+-                #[cfg(any(target_os = "android", target_os = "linux"))]
++                #[cfg(any(target_os = "android", target_os = "linux", target_os = "managarm"))]
+                 Some(AddressFamily::Packet) => Some(SockAddr::Link(
+                     LinkAddr(*(addr as *const libc::sockaddr_ll)))),
+                 #[cfg(any(target_os = "dragonfly",
+@@ -833,7 +836,7 @@ impl SockAddr {
+                 mem::size_of_val(sa) as libc::socklen_t
+ 
+             ),
+-            #[cfg(any(target_os = "android", target_os = "linux"))]
++            #[cfg(any(target_os = "android", target_os = "linux", target_os = "managarm"))]
+             SockAddr::Link(LinkAddr(ref addr)) => (
+                 // This cast is always allowed in C
+                 unsafe {
+@@ -879,6 +882,7 @@ impl fmt::Display for SockAddr {
+             #[cfg(any(target_os = "ios", target_os = "macos"))]
+             SockAddr::SysControl(ref sc) => sc.fmt(f),
+             #[cfg(any(target_os = "android",
++                      target_os = "managarm",
+                       target_os = "dragonfly",
+                       target_os = "freebsd",
+                       target_os = "ios",
+@@ -1064,7 +1068,7 @@ pub mod sys_control {
+ }
+ 
+ 
+-#[cfg(any(target_os = "android", target_os = "linux", target_os = "fuchsia"))]
++#[cfg(any(target_os = "android", target_os = "linux", target_os = "managarm", target_os = "fuchsia"))]
+ mod datalink {
+     use super::{fmt, AddressFamily};
+ 
+diff --git a/src/sys/socket/mod.rs b/src/sys/socket/mod.rs
+index da5573c..e116186 100644
+--- a/src/sys/socket/mod.rs
++++ b/src/sys/socket/mod.rs
+@@ -251,6 +251,7 @@ libc_bitflags!{
+         ///
+         /// Only used in [`recvmsg`](fn.recvmsg.html) function.
+         #[cfg(any(target_os = "android",
++                  target_os = "managarm",
+                   target_os = "dragonfly",
+                   target_os = "freebsd",
+                   target_os = "linux",
+@@ -866,13 +867,13 @@ impl<'a> ControlMessage<'a> {
+ 
+     /// The value of CMSG_LEN on this message.
+     /// Safe because CMSG_LEN is always safe
+-    #[cfg(any(target_os = "android",
++    #[cfg(any(target_os = "android", target_os = "managarm",
+               all(target_os = "linux", not(target_env = "musl"))))]
+     fn cmsg_len(&self) -> usize {
+         unsafe{CMSG_LEN(self.len() as libc::c_uint) as usize}
+     }
+ 
+-    #[cfg(not(any(target_os = "android",
++    #[cfg(not(any(target_os = "android", target_os = "managarm",
+                   all(target_os = "linux", not(target_env = "musl")))))]
+     fn cmsg_len(&self) -> libc::c_uint {
+         unsafe{CMSG_LEN(self.len() as libc::c_uint)}
+diff --git a/src/sys/termios.rs b/src/sys/termios.rs
+index 36a3601..c57bd1b 100644
+--- a/src/sys/termios.rs
++++ b/src/sys/termios.rs
+@@ -467,10 +467,19 @@ impl From<BaudRate> for u32 {
+ }
+ 
+ // TODO: Add TCSASOFT, which will require treating this as a bitfield.
++#[cfg(target_os = "managarm")]
+ libc_enum! {
+     /// Specify when a port configuration change should occur.
+     ///
+     /// Used as an argument to `tcsetattr()`
++    #[repr(i32)]
++    pub enum SetArg {
++        TCSANOW,
++    }
++}
++
++#[cfg(not(target_os = "managarm"))]
++libc_enum! {
+     #[repr(i32)]
+     pub enum SetArg {
+         /// The change will occur immediately
+@@ -482,10 +491,19 @@ libc_enum! {
+     }
+ }
+ 
++#[cfg(target_os = "managarm")]
+ libc_enum! {
+     /// Specify a combination of the input and output buffers to flush
+     ///
+     /// Used as an argument to `tcflush()`.
++    #[repr(i32)]
++    pub enum FlushArg {
++        TCIFLUSH,
++    }
++}
++
++#[cfg(not(target_os = "managarm"))]
++libc_enum! {
+     #[repr(i32)]
+     pub enum FlushArg {
+         /// Flush data that was received but not read
+@@ -515,8 +533,17 @@ libc_enum! {
+ }
+ 
+ // TODO: Make this usable directly as a slice index.
++#[cfg(target_os = "managarm")]
+ libc_enum! {
+     /// Indices into the `termios.c_cc` array for special characters.
++    #[repr(usize)]
++    pub enum SpecialCharacterIndices {
++        VEOF,
++    }
++}
++
++#[cfg(not(target_os = "managarm"))]
++libc_enum! {
+     #[repr(usize)]
+     pub enum SpecialCharacterIndices {
+         VDISCARD,
+@@ -601,13 +628,22 @@ libc_bitflags! {
+         IXOFF;
+         #[cfg(not(target_os = "redox"))]
+         IXANY;
+-        #[cfg(not(target_os = "redox"))]
++        #[cfg(not(any(target_os = "redox", target_os = "managarm")))]
+         IMAXBEL;
+         #[cfg(any(target_os = "android", target_os = "linux", target_os = "macos"))]
+         IUTF8;
+     }
+ }
+ 
++#[cfg(target_os = "managarm")]
++libc_bitflags! {
++    /// Flags for configuring the output mode of a terminal
++    pub struct OutputFlags: tcflag_t {
++        OPOST;
++    }
++}
++
++#[cfg(not(target_os = "managarm"))]
+ libc_bitflags! {
+     /// Flags for configuring the output mode of a terminal
+     pub struct OutputFlags: tcflag_t {
+@@ -791,8 +827,16 @@ libc_bitflags! {
+     }
+ }
+ 
++#[cfg(target_os = "managarm")]
+ libc_bitflags! {
+     /// Flags for setting the control mode of a terminal
++    pub struct ControlFlags: tcflag_t {
++        CS5;
++    }
++}
++
++#[cfg(not(target_os = "managarm"))]
++lib_bitflags! {
+     pub struct ControlFlags: tcflag_t {
+         #[cfg(any(target_os = "dragonfly",
+                   target_os = "freebsd",
+@@ -859,8 +903,16 @@ libc_bitflags! {
+     }
+ }
+ 
++#[cfg(target_os = "managarm")]
+ libc_bitflags! {
+     /// Flags for setting any local modes
++    pub struct LocalFlags: tcflag_t {
++        ECHO;
++    }
++}
++
++#[cfg(not(target_os = "managarm"))]
++libc_bitflags! {
+     pub struct LocalFlags: tcflag_t {
+         #[cfg(not(target_os = "redox"))]
+         ECHOKE;
+diff --git a/src/unistd.rs b/src/unistd.rs
+index d94cb99..3ba8588 100644
+--- a/src/unistd.rs
++++ b/src/unistd.rs
+@@ -1081,6 +1081,7 @@ pub fn pipe() -> std::result::Result<(RawFd, RawFd), Error> {
+ /// See also [pipe(2)](https://man7.org/linux/man-pages/man2/pipe.2.html)
+ #[cfg(any(target_os = "android",
+           target_os = "dragonfly",
++          target_os = "managarm",
+           target_os = "emscripten",
+           target_os = "freebsd",
+           target_os = "illumos",
+@@ -1478,6 +1479,7 @@ pub fn getgroups() -> Result<Vec<Gid>> {
+ pub fn setgroups(groups: &[Gid]) -> Result<()> {
+     cfg_if! {
+         if #[cfg(any(target_os = "dragonfly",
++                     target_os = "managarm",
+                      target_os = "freebsd",
+                      target_os = "illumos",
+                      target_os = "ios",
+@@ -1799,6 +1801,14 @@ pub fn mkstemp<P: ?Sized + NixPath>(template: &P) -> Result<(RawFd, PathBuf)> {
+ /// - [pathconf(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pathconf.html)
+ /// - [limits.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)
+ /// - [unistd.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html)
++#[cfg(target_os = "managarm")]
++#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
++#[repr(i32)]
++pub enum PathconfVar {
++    NAME_MAX = libc::_PC_NAME_MAX,
++}
++
++#[cfg(not(target_os = "managarm"))]
+ #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+ #[repr(i32)]
+ pub enum PathconfVar {
+@@ -1978,6 +1988,17 @@ pub fn pathconf<P: ?Sized + NixPath>(path: &P, var: PathconfVar) -> Result<Optio
+ /// - [sysconf(3)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sysconf.html)
+ /// - [unistd.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/unistd.h.html)
+ /// - [limits.h](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html)
++#[cfg(target_os = "managarm")]
++#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
++#[repr(i32)]
++pub enum SysconfVar {
++    PAGE_SIZE = libc::_SC_PAGESIZE,
++    GETGR_R_SIZE_MAX = libc::_SC_GETGR_R_SIZE_MAX,
++    GETPW_R_SIZE_MAX = libc::_SC_GETPW_R_SIZE_MAX,
++    NGROUPS_MAX = libc::_SC_NGROUPS_MAX,
++}
++
++#[cfg(not(target_os = "managarm"))]
+ #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+ #[repr(i32)]
+ pub enum SysconfVar {
+@@ -2633,6 +2654,7 @@ pub struct User {
+     /// Login class
+     #[cfg(not(any(target_os = "android",
+                   target_os = "fuchsia",
++                  target_os = "managarm",
+                   target_os = "illumos",
+                   target_os = "linux",
+                   target_os = "solaris")))]
+@@ -2640,6 +2662,7 @@ pub struct User {
+     /// Last password change
+     #[cfg(not(any(target_os = "android",
+                   target_os = "fuchsia",
++                  target_os = "managarm",
+                   target_os = "illumos",
+                   target_os = "linux",
+                   target_os = "solaris")))]
+@@ -2647,6 +2670,7 @@ pub struct User {
+     /// Expiration time of account
+     #[cfg(not(any(target_os = "android",
+                   target_os = "fuchsia",
++                  target_os = "managarm",
+                   target_os = "illumos",
+                   target_os = "linux",
+                   target_os = "solaris")))]
+@@ -2668,18 +2692,21 @@ impl From<&libc::passwd> for User {
+                 gid: Gid::from_raw((*pw).pw_gid),
+                 #[cfg(not(any(target_os = "android",
+                               target_os = "fuchsia",
++                              target_os = "managarm",
+                               target_os = "illumos",
+                               target_os = "linux",
+                               target_os = "solaris")))]
+                 class: CString::new(CStr::from_ptr((*pw).pw_class).to_bytes()).unwrap(),
+                 #[cfg(not(any(target_os = "android",
+                               target_os = "fuchsia",
++                              target_os = "managarm",
+                               target_os = "illumos",
+                               target_os = "linux",
+                               target_os = "solaris")))]
+                 change: (*pw).pw_change,
+                 #[cfg(not(any(target_os = "android",
+                               target_os = "fuchsia",
++                              target_os = "managarm",
+                               target_os = "illumos",
+                               target_os = "linux",
+                               target_os = "solaris")))]
+-- 
+2.36.1
+

--- a/patches/rust-shared-library/0001-managarm-initial-port.patch
+++ b/patches/rust-shared-library/0001-managarm-initial-port.patch
@@ -1,0 +1,32 @@
+From 17a7e87fd250f1e4e80120a9e5d572155570400e Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 12:21:48 +0000
+Subject: [PATCH] managarm: initial port
+
+---
+ src/dynamic_library.rs | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/dynamic_library.rs b/src/dynamic_library.rs
+index 753b632..82fc668 100644
+--- a/src/dynamic_library.rs
++++ b/src/dynamic_library.rs
+@@ -192,6 +192,7 @@ mod test {
+     #[test]
+     #[cfg(any(target_os = "linux",
+               target_os = "macos",
++              target_os = "managarm",
+               target_os = "freebsd",
+               target_os = "fuchsia",
+               target_os = "netbsd",
+@@ -213,6 +214,7 @@ mod test {
+ //TODO: use `unix` shortcut?
+ #[cfg(any(target_os = "linux",
+           target_os = "android",
++          target_os = "managarm",
+           target_os = "macos",
+           target_os = "ios",
+           target_os = "fuchsia",
+-- 
+2.35.1
+

--- a/patches/rust-winit/0001-managarm-initial-port.patch
+++ b/patches/rust-winit/0001-managarm-initial-port.patch
@@ -1,0 +1,122 @@
+From 5b931ef20fbedcb1d36464cea9ce9193da05ec04 Mon Sep 17 00:00:00 2001
+From: Matt Taylor <mstaveleytaylor@gmail.com>
+Date: Mon, 21 Feb 2022 02:42:46 +0000
+Subject: [PATCH] managarm: initial port
+
+---
+ Cargo.toml                             | 2 +-
+ src/platform/run_return.rs             | 1 +
+ src/platform/unix.rs                   | 1 +
+ src/platform_impl/linux/mod.rs         | 8 ++++++++
+ src/platform_impl/linux/wayland/mod.rs | 1 +
+ src/platform_impl/linux/x11/mod.rs     | 1 +
+ src/platform_impl/mod.rs               | 2 ++
+ 7 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index b1e4159..8d1ad95 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -84,7 +84,7 @@ features = [
+     "timeapi"
+ ]
+ 
+-[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
++[target.'cfg(any(target_os = "linux", target_os = "managarm", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
+ wayland-client = { version = "0.29", default_features = false,  features = ["use_system_lib"], optional = true }
+ wayland-protocols = { version = "0.29", features = [ "staging_protocols"], optional = true }
+ sctk = { package = "smithay-client-toolkit", version = "0.15.1", default_features = false, features = ["calloop"],  optional = true }
+diff --git a/src/platform/run_return.rs b/src/platform/run_return.rs
+index 932d9e3..eb116e9 100644
+--- a/src/platform/run_return.rs
++++ b/src/platform/run_return.rs
+@@ -1,5 +1,6 @@
+ #![cfg(any(
+     target_os = "windows",
++    target_os = "managarm",
+     target_os = "macos",
+     target_os = "android",
+     target_os = "linux",
+diff --git a/src/platform/unix.rs b/src/platform/unix.rs
+index ba600b1..87026f1 100644
+--- a/src/platform/unix.rs
++++ b/src/platform/unix.rs
+@@ -1,5 +1,6 @@
+ #![cfg(any(
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+diff --git a/src/platform_impl/linux/mod.rs b/src/platform_impl/linux/mod.rs
+index 953fca1..0c04d73 100644
+--- a/src/platform_impl/linux/mod.rs
++++ b/src/platform_impl/linux/mod.rs
+@@ -1,6 +1,7 @@
+ #![cfg(any(
+     target_os = "linux",
+     target_os = "dragonfly",
++    target_os = "managarm",
+     target_os = "freebsd",
+     target_os = "netbsd",
+     target_os = "openbsd"
+@@ -771,6 +772,13 @@ fn is_main_thread() -> bool {
+     unsafe { syscall(SYS_gettid) == getpid() as c_long }
+ }
+ 
++#[cfg(any(target_os = "managarm"))]
++fn is_main_thread() -> bool {
++    // This function is only used for assertions (to make sure that library consumers don't do
++    // anything wrong), but we don't currently implement gettid yet so just return true for now.
++    true
++}
++
+ #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]
+ fn is_main_thread() -> bool {
+     use libc::pthread_main_np;
+diff --git a/src/platform_impl/linux/wayland/mod.rs b/src/platform_impl/linux/wayland/mod.rs
+index 4ed564a..bdffc47 100644
+--- a/src/platform_impl/linux/wayland/mod.rs
++++ b/src/platform_impl/linux/wayland/mod.rs
+@@ -1,6 +1,7 @@
+ #![cfg(any(
+     target_os = "linux",
+     target_os = "dragonfly",
++    target_os = "managarm",
+     target_os = "freebsd",
+     target_os = "netbsd",
+     target_os = "openbsd"
+diff --git a/src/platform_impl/linux/x11/mod.rs b/src/platform_impl/linux/x11/mod.rs
+index 27c92c4..e890d8c 100644
+--- a/src/platform_impl/linux/x11/mod.rs
++++ b/src/platform_impl/linux/x11/mod.rs
+@@ -1,5 +1,6 @@
+ #![cfg(any(
+     target_os = "linux",
++    target_os = "managarm",
+     target_os = "dragonfly",
+     target_os = "freebsd",
+     target_os = "netbsd",
+diff --git a/src/platform_impl/mod.rs b/src/platform_impl/mod.rs
+index 152065d..d4a5318 100644
+--- a/src/platform_impl/mod.rs
++++ b/src/platform_impl/mod.rs
+@@ -6,6 +6,7 @@ mod platform;
+ #[cfg(any(
+     target_os = "linux",
+     target_os = "dragonfly",
++    target_os = "managarm",
+     target_os = "freebsd",
+     target_os = "netbsd",
+     target_os = "openbsd"
+@@ -32,6 +33,7 @@ mod platform;
+     not(target_os = "macos"),
+     not(target_os = "android"),
+     not(target_os = "dragonfly"),
++    not(target_os = "managarm"),
+     not(target_os = "freebsd"),
+     not(target_os = "netbsd"),
+     not(target_os = "openbsd"),
+-- 
+2.36.1
+

--- a/scripts/cargo-inject-patches.py
+++ b/scripts/cargo-inject-patches.py
@@ -3,10 +3,19 @@
 import argparse, os, subprocess, pathlib
 
 patched_libs = {
-	'libc': '0.2.117',
+	'backtrace': '0.3.64',
+	'calloop': 'calloop',
+	'libc': '0.2.125',
+	'libloading': '0.7.3',
+	'mio': ['0.6.23', '0.8.3'],
+	'nix': '0.22.3',
 	'num_cpus': '1.13.0',
 	'users': '0.11.0',
-	'backtrace': '0.3.64',
+	'winit': '0.26.1',
+	'glutin': '0.28.0',
+	'glutin_glx_sys': '0.1.7',
+	'glutin_egl_sys': '0.1.5',
+	'shared_library': '0.1.9',
 }
 
 parser = argparse.ArgumentParser(description='Inject patched Rust libraries into Cargo lockfiles')
@@ -16,20 +25,24 @@ manifest = parser.parse_args().manifest
 # First, delete the existing lockfile to work around https://github.com/rust-lang/cargo/issues/9470
 lockfile = os.path.join(os.path.dirname(manifest), 'Cargo.lock')
 if os.path.exists(lockfile):
-    print('cargo-inject-patches: workaround cargo bug by removing existing lockfile...')
-    os.remove(lockfile)
+	print('cargo-inject-patches: workaround cargo bug by removing existing lockfile...')
+	os.remove(lockfile)
 
-for lib, version in patched_libs.items():
-	cmd = [
-		'cargo',
-		'update',
-		'--manifest-path', manifest,
-		'--package', lib,
-		'--precise', version
-	]
+for lib, versions in patched_libs.items():
+	if not isinstance(versions, list):
+		versions = [versions]
 
-	output = subprocess.run(cmd, capture_output=True)
-	if 'did not match any packages' in str(output.stderr):
-		print(f'cargo-inject-patches: Injecting {lib} v{version} failed, patch not used')
-	else:
-		print(f'cargo-inject-patches: Injected {lib} v{version}')
+	for version in versions:
+		cmd = [
+			'cargo',
+			'update',
+			'--manifest-path', manifest,
+			'--package', lib,
+			'--precise', version
+		]
+
+		output = subprocess.run(cmd, capture_output=True)
+		if 'did not match any packages' in str(output.stderr):
+			print(f'cargo-inject-patches: Injecting {lib} v{version} failed, patch not used')
+		else:
+			print(f'cargo-inject-patches: Injected {lib} v{version}')


### PR DESCRIPTION
Ports the required libraries for alacritty, including some bits of nix and mio.

Blocked on a number of PRs (but ready to go once they're merged):
- [x] https://github.com/managarm/managarm/pull/447
- [x] https://github.com/managarm/managarm/pull/448
- [x] https://github.com/managarm/mlibc/pull/429
- [x] https://github.com/managarm/libasync/pull/15
