### PR TITLE
bootstrap.yml: install cxxshim and frigg headers to /usr/share

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1047,6 +1047,9 @@ packages:
       - host-managarm-tools
       - host-protoc
       - kernel-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
     pkgs_required:
       - frigg
     revision: 2
@@ -1089,6 +1092,8 @@ packages:
       - host-pkg-config
       - host-protoc
       - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
       - eudev
@@ -1197,6 +1202,8 @@ packages:
       - bootstrap-system-gcc
       - host-protoc
       - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc-headers
       - frigg

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -143,8 +143,6 @@ sources:
     version: '0.0pl@ROLLING_ID@'
     sources_required:
       - cralgo
-      - cxxshim
-      - frigg
       - lai
       - libarch
       - libasync
@@ -153,7 +151,6 @@ sources:
     regenerate:
       - args: ['mkdir', '-p', '@THIS_SOURCE_DIR@/subprojects']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/cralgo', '@THIS_SOURCE_DIR@/subprojects/']
-      - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/cxxshim', '@THIS_SOURCE_DIR@/subprojects/']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/lai', '@THIS_SOURCE_DIR@/subprojects/']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/libarch', '@THIS_SOURCE_DIR@/subprojects/']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/libasync', '@THIS_SOURCE_DIR@/subprojects/']
@@ -168,8 +165,6 @@ sources:
     rolling_version: true
     version: '0.0pl@ROLLING_ID@'
     sources_required:
-      - cxxshim
-      - frigg
       - libdrm
       - managarm
       - bragi
@@ -296,8 +291,6 @@ tools:
     labels: [aarch64, riscv64]
     architecture: noarch
     from_source: managarm
-    sources_required:
-      - frigg
     tools_required:
       - tool: host-protoc
         recursive: true
@@ -1049,8 +1042,6 @@ packages:
     architecture: '@OPTION:arch@'
     default: true
     from_source: managarm
-    sources_required:
-      - frigg
     tools_required:
       - host-llvm-toolchain
       - host-managarm-tools

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1070,6 +1070,7 @@ packages:
         - '--prefix=/usr/managarm'
         - '--libdir=lib'
         - '--buildtype=debugoptimized'
+        - '--wrap-mode=nofallback'
         - '-Dbuild_kernel=true'
         - '@THIS_SOURCE_DIR@'
     build:
@@ -1175,6 +1176,7 @@ packages:
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
         - '@THIS_SOURCE_DIR@'
+        - '--wrap-mode=nofallback'
         - '-Dheaders_only=true'
         - '-Ddisable_crypt_option=true'
         - '-Ddisable_iconv_option=true'
@@ -1214,6 +1216,7 @@ packages:
         - '--prefix=/usr'
         - '--libdir=lib'
         - '--buildtype=debugoptimized'
+        - '--wrap-mode=nofallback'
         - '-Dmlibc_no_headers=true'
         - '-Ddisable_crypt_option=true'
         - '-Ddisable_iconv_option=true'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1205,6 +1205,8 @@ packages:
       - host-pkg-config
     pkgs_required:
       - mlibc-headers
+      - frigg
+      - cxxshim
     configure:
       - args:
         - 'meson'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -737,6 +737,12 @@ packages:
         quiet: true
 
   - name: frigg
+    metadata:
+      summary: Lightweight C++ utilities and algorithms for system programming
+      description: This package provides utility header files for freestanding C++ applications.
+      spdx: 'MIT'
+      maintainer: "Alexander van der Grinten <avdgrinten@managarm.org>"
+      categories: ['sys-libs']
     labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
     source:
@@ -1132,8 +1138,14 @@ packages:
         quiet: true
 
   - name: cxxshim
-    labels: [aarch64]
-    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Shim for freestanding C++
+      description: This package provides headers to use in freestanding C++ build environments.
+      spdx: 'MIT'
+      maintainer: "Alexander van der Grinten <avdgrinten@managarm.org>"
+      categories: ['sys-libs']
+    labels: [aarch64, riscv]
+    architecture: noarch
     from_source: cxxshim
     tools_required:
       - host-managarm-tools

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1058,6 +1058,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - frigg
+      - cxxshim
     revision: 2
     configure:
       - args: |
@@ -1104,9 +1105,8 @@ packages:
       - mlibc
       - eudev
       - fafnir
-      # This should not be necessary (due to the source dep),
-      # but libarch and managarm-system do not correctly declare all deps in their meson.build.
       - frigg
+      - cxxshim
       - lewis
       - libasync
       - libdrm
@@ -1147,8 +1147,6 @@ packages:
     labels: [aarch64, riscv]
     architecture: noarch
     from_source: cxxshim
-    tools_required:
-      - host-managarm-tools
     configure:
       - args:
         - 'meson'
@@ -1177,6 +1175,7 @@ packages:
     architecture: '@OPTION:arch@'
     from_source: mlibc
     tools_required:
+      # These are not strictly necessary.
       - host-managarm-tools
       - host-protoc
     configure:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1121,6 +1121,8 @@ packages:
         - '--prefix=/usr'
         - '--libdir=lib'
         - '--buildtype=debugoptimized'
+        - '--wrap-mode=nofallback'
+        - '--force-fallback-for=cli11'
         - '-Dbuild_drivers=true'
         - '@THIS_SOURCE_DIR@'
         environ:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -176,8 +176,6 @@ sources:
       - bragi
     regenerate:
       - args: ['ln', '-sf', '@SOURCE_ROOT@/managarm', '@THIS_SOURCE_DIR@/subprojects/']
-      - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/cxxshim', '@THIS_SOURCE_DIR@/subprojects/']
-      - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/frigg', '@THIS_SOURCE_DIR@/subprojects/']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/bragi', '@THIS_SOURCE_DIR@/subprojects/']
 
   - name: wayland
@@ -760,6 +758,8 @@ packages:
         - 'meson'
         - '--prefix=/usr'
         - '--libdir=lib'
+        # Install to /usr/share to avoid conflicts with standard C++ headers.
+        - '--includedir=share/frigg/include'
         - '--buildtype=debugoptimized'
         - '@THIS_SOURCE_DIR@'
     build:
@@ -1133,6 +1133,28 @@ packages:
           'DESTDIR': '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: cxxshim
+    labels: [aarch64]
+    architecture: '@OPTION:arch@'
+    from_source: cxxshim
+    tools_required:
+      - host-managarm-tools
+    configure:
+      - args:
+        - 'meson'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        # Install to /usr/share to avoid conflicts with standard C++ headers.
+        - '--includedir=share/cxxshim/include'
+        - '@THIS_SOURCE_DIR@'
+        - '-Dinstall_headers=true'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: mlibc-headers
     metadata:
       summary: Managarm libc headers
@@ -1180,6 +1202,7 @@ packages:
       - host-managarm-tools
       - bootstrap-system-gcc
       - host-protoc
+      - host-pkg-config
     pkgs_required:
       - mlibc-headers
     configure:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -154,7 +154,6 @@ sources:
       - args: ['mkdir', '-p', '@THIS_SOURCE_DIR@/subprojects']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/cralgo', '@THIS_SOURCE_DIR@/subprojects/']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/cxxshim', '@THIS_SOURCE_DIR@/subprojects/']
-      - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/frigg', '@THIS_SOURCE_DIR@/subprojects/']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/lai', '@THIS_SOURCE_DIR@/subprojects/']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/libarch', '@THIS_SOURCE_DIR@/subprojects/']
       - args: ['ln', '-sf', '@SOURCE_ROOT@/ports/libasync', '@THIS_SOURCE_DIR@/subprojects/']

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -292,6 +292,7 @@ tools:
     architecture: noarch
     from_source: managarm
     tools_required:
+      - host-frigg
       - tool: host-protoc
         recursive: true
       - virtual: pkgconfig-for-host
@@ -582,6 +583,26 @@ tools:
         - '-Ddocumentation=false'
         - '-Dscanner=true'
         - '-Dlibraries=false'
+        - '@THIS_SOURCE_DIR@'
+    compile:
+      - args: ['ninja']
+    install:
+      - args: ['ninja', 'install']
+
+  - name: host-frigg
+    labels: [aarch64, riscv]
+    architecture: noarch
+    from_source: frigg
+    tools_required:
+      - virtual: pkgconfig-for-host
+        program_name: host-pkg-config
+    configure:
+      - args:
+        - 'meson'
+        - '--native-file'
+        - '@SOURCE_ROOT@/scripts/meson.native-file'
+        - '--prefix=@PREFIX@'
+        - '-Dfrigg_no_install=false'
         - '@THIS_SOURCE_DIR@'
     compile:
       - args: ['ninja']

--- a/scripts/meson-clang-aarch64-managarm.cross-file
+++ b/scripts/meson-clang-aarch64-managarm.cross-file
@@ -3,7 +3,7 @@ c = 'clang'
 cpp = 'clang++'
 ar = 'aarch64-managarm-ar'
 strip = 'aarch64-managarm-strip'
-pkgconfig = 'aarch64-pkg-config'
+pkgconfig = 'aarch64-managarm-pkg-config'
 
 [built-in options]
 c_args = ['-target', 'aarch64-managarm', '-fdebug-default-version=4', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']

--- a/scripts/meson-clang-aarch64-managarm.cross-file
+++ b/scripts/meson-clang-aarch64-managarm.cross-file
@@ -3,7 +3,7 @@ c = 'clang'
 cpp = 'clang++'
 ar = 'aarch64-managarm-ar'
 strip = 'aarch64-managarm-strip'
-pkgconfig = 'pkg-config'
+pkgconfig = 'aarch64-pkg-config'
 
 [built-in options]
 c_args = ['-target', 'aarch64-managarm', '-fdebug-default-version=4', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']

--- a/scripts/meson-clang-x86_64-managarm.cross-file
+++ b/scripts/meson-clang-x86_64-managarm.cross-file
@@ -4,7 +4,7 @@ c = 'clang'
 cpp = 'clang++'
 ar = 'x86_64-managarm-ar'
 strip = 'x86_64-managarm-strip'
-pkgconfig = 'pkg-config'
+pkgconfig = 'x86_64-managarm-pkg-config'
 
 [built-in options]
 cpp_args = ['-DLIBASYNC_FORCE_USE_EXPERIMENTAL', '-fsized-deallocation', '-fdebug-default-version=4', '-target', 'x86_64-managarm', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']

--- a/scripts/meson-kernel-x86_64-managarm.cross-file
+++ b/scripts/meson-kernel-x86_64-managarm.cross-file
@@ -3,7 +3,7 @@ c = 'clang'
 cpp = 'clang++'
 ar = 'x86_64-managarm-ar'
 strip = 'x86_64-managarm-strip'
-pkgconfig = 'pkg-config'
+pkgconfig = 'x86_64-managarm-pkg-config'
 
 [constants]
 # common args that c and cxx need

--- a/scripts/meson-x86_64-managarm.cross-file
+++ b/scripts/meson-x86_64-managarm.cross-file
@@ -4,7 +4,7 @@ c = 'x86_64-managarm-gcc'
 cpp = 'x86_64-managarm-g++'
 ar = 'x86_64-managarm-ar'
 strip = 'x86_64-managarm-strip'
-pkgconfig = 'pkg-config'
+pkgconfig = 'x86_64-pkg-config'
 # sed adds binaries here.
 
 [host_machine]

--- a/scripts/meson-x86_64-managarm.cross-file
+++ b/scripts/meson-x86_64-managarm.cross-file
@@ -4,7 +4,7 @@ c = 'x86_64-managarm-gcc'
 cpp = 'x86_64-managarm-g++'
 ar = 'x86_64-managarm-ar'
 strip = 'x86_64-managarm-strip'
-pkgconfig = 'x86_64-managarm-pkg-config'
+pkgconfig = 'pkg-config'
 # sed adds binaries here.
 
 [host_machine]

--- a/scripts/meson-x86_64-managarm.cross-file
+++ b/scripts/meson-x86_64-managarm.cross-file
@@ -4,7 +4,7 @@ c = 'x86_64-managarm-gcc'
 cpp = 'x86_64-managarm-g++'
 ar = 'x86_64-managarm-ar'
 strip = 'x86_64-managarm-strip'
-pkgconfig = 'x86_64-pkg-config'
+pkgconfig = 'x86_64-managarm-pkg-config'
 # sed adds binaries here.
 
 [host_machine]


### PR DESCRIPTION
As discussed on Discord. This allows cxxshim and frigg to be found via `pkg-config` rather than needing to do `ln` hacks.

Some things may break if they incorrectly use frigg without declaring it as a dependency, see e.g https://github.com/managarm/managarm/pull/453.
