### PR TITLE
xclock: add missing dependency on util-linux-libs

### DIFF
--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -77,7 +77,8 @@ packages:
       - libxt
       - libxkbfile
       - libiconv
-    revision: 2
+      - util-linux-libs
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'


### PR DESCRIPTION
Running `xclock -help` without `util-linux-libs` installed complains about missing `libuuid.so.1`, which is solved this way.