### PR TITLE
Revert "xclock: add missing dependency on util-linux-libs"

### DIFF
--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -77,7 +77,7 @@ packages:
       - libxt
       - libxkbfile
       - libiconv
-    revision: 2
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -77,8 +77,7 @@ packages:
       - libxt
       - libxkbfile
       - libiconv
-      - util-linux-libs
-    revision: 3
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'


### PR DESCRIPTION
Reverts managarm/bootstrap-managarm#183 since xbbs was already able to build the package correctly and `util-linux-libs` already shows up as a dependency.