### PR TITLE
zsh: add port

### DIFF
--- a/bootstrap.d/app-shells.yml
+++ b/bootstrap.d/app-shells.yml
@@ -49,3 +49,51 @@ packages:
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/profile', '@THIS_COLLECT_DIR@/etc']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/bash.bashrc', '@THIS_COLLECT_DIR@/etc']
       - args: ['ln', '-sf', 'bash', '@THIS_COLLECT_DIR@/usr/bin/sh']
+
+  - name: zsh
+    metadata:
+      summary: 'UNIX Shell similar to the Korn shell'
+      description: 'Zsh is a shell designed for interactive use, although it is also a powerful scripting language. Many of the useful features of bash, ksh, and tcsh were incorporated into zsh; many original features were added.'
+      spdx: 'MIT'
+      website: 'https://zsh.sourceforge.io/'
+      maintainer: "no92 <no92.mail@gmail.com>"
+      categories: ['app-shells']
+    labels: [aarch64]
+    architecture: '@OPTION:arch@'
+    source:
+      subdir: 'ports'
+      git: 'https://git.code.sf.net/p/zsh/code'
+      branch: 'master'
+      tag: 'zsh-5.9'
+      version: '5.9'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.11
+      regenerate:
+        - args: ['./Util/preconfig']
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.11/share/automake-1.11/config.sub',
+            '@THIS_SOURCE_DIR@/']
+    tools_required:
+      - host-yodl
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - gdbm
+      - pcre
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--quiet'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc/zsh'
+        - '--enable-etcdir=/etc/zsh'
+        - '--enable-gdbm'
+        - '--enable-pcre'
+    build:
+      - args: ['make', 'prep']
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
+        quiet: true
+

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -865,6 +865,23 @@ tools:
     install:
       - args: ['ninja', 'install']
 
+  - name: host-icmake
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.com/fbb-git/icmake'
+      tag: '9.03.01'
+      regenerate:
+        - args: ['sed', '-i', 's#"usr/bin"#"bin"#', '@THIS_SOURCE_DIR@/icmake/INSTALL.im']
+    configure:
+      - args: ['@THIS_SOURCE_DIR@/icmake/icm_prepare', '@PREFIX@/']
+        workdir: '@THIS_SOURCE_DIR@/icmake'
+    compile:
+      - args: ['@THIS_SOURCE_DIR@/icmake/icm_bootstrap', 'x']
+        workdir: '@THIS_SOURCE_DIR@/icmake'
+    install:
+      - args: ['@THIS_SOURCE_DIR@/icmake/icm_install', 'strip', 'all', '/']
+        workdir: '@THIS_SOURCE_DIR@/icmake'
+
 packages:
   - name: binutils
     architecture: '@OPTION:arch@'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -882,6 +882,27 @@ tools:
       - args: ['@THIS_SOURCE_DIR@/icmake/icm_install', 'strip', 'all', '/']
         workdir: '@THIS_SOURCE_DIR@/icmake'
 
+  - name: host-yodl
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.com/fbb-git/yodl'
+      tag: '4.03.03'
+      regenerate:
+        - args: ['sed', '-i', 's#"/usr"#"/"#', '@THIS_SOURCE_DIR@/yodl/INSTALL.im']
+        - args: ['sed', '-i', 's#/usr/bin/icmake#@BUILD_ROOT@/tools/host-icmake/bin/icmake#', '@THIS_SOURCE_DIR@/yodl/build']
+    tools_required:
+      - host-icmake
+    compile:
+      - args: ['./build', 'programs']
+        workdir: '@THIS_SOURCE_DIR@/yodl'
+      - args: ['./build', 'macros']
+        workdir: '@THIS_SOURCE_DIR@/yodl'
+    install:
+      - args: ['./build', 'install', 'programs', '@PREFIX@']
+        workdir: '@THIS_SOURCE_DIR@/yodl'
+      - args: ['./build', 'install', 'macros', '@PREFIX@']
+        workdir: '@THIS_SOURCE_DIR@/yodl'
+
 packages:
   - name: binutils
     architecture: '@OPTION:arch@'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -127,8 +127,6 @@ RUN apt-get update \
 		x11-apps \
 		# Used by eudev
 		xsltproc \
-		# Used for building zsh documentation
-		yodl \
 		# Used by various programs, for example, it is used by file
 		zlib1g-dev \
 		# Used by the developers


### PR DESCRIPTION
This adds a zsh port that seems to work for simple command-line use. Building this requires `yodl` being installed in the rootfs, i.e. chroot into the rootfs and run `apt install yodl`. Including this as a host-tool would introduce 2 host-tools with ridiculous build systems.