### PR TITLE
Drop stivale2 boot protocol in favour of multiboot2

### DIFF
--- a/scripts/limine.cfg
+++ b/scripts/limine.cfg
@@ -2,8 +2,8 @@ TIMEOUT=3
 
 :managarm (Weston, e9 output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-stivale
-PROTOCOL=stivale2
+KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=weston plainfb.force=1
 
 MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
@@ -11,8 +11,8 @@ MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
 
 :managarm (kmscon, e9 output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-stivale
-PROTOCOL=stivale2
+KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=kmscon plainfb.force=1
 
 MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
@@ -20,8 +20,8 @@ MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
 
 :managarm (Weston, e9 output)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-stivale
-PROTOCOL=stivale2
+KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=weston
 
 MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
@@ -29,8 +29,8 @@ MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
 
 :managarm (kmscon, e9 output)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-stivale
-PROTOCOL=stivale2
+KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=kmscon
 
 MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
@@ -40,8 +40,8 @@ MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
 
 ::managarm (Weston, serial output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-stivale
-PROTOCOL=stivale2
+KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+PROTOCOL=multiboot2
 CMDLINE=serial init.launch=weston plainfb.force=1
 
 MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
@@ -49,8 +49,8 @@ MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
 
 ::managarm (kmscon, serial output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-stivale
-PROTOCOL=stivale2
+KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+PROTOCOL=multiboot2
 CMDLINE=serial init.launch=kmscon plainfb.force=1
 
 MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
@@ -60,8 +60,8 @@ MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
 
 ::managarm (profiling, Weston, e9 output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-stivale
-PROTOCOL=stivale2
+KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+PROTOCOL=multiboot2
 CMDLINE=kernel-profile bochs init.launch=weston plainfb.force=1
 
 MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor

--- a/scripts/update-image.py
+++ b/scripts/update-image.py
@@ -365,8 +365,8 @@ def generate_plan(arch, root_uuid, scriptdir):
     yield FsAction.INSTALL, "initrd.cpio", "boot/managarm", dict(ignore_sysroot=True)
 
     if arch == "x86_64-managarm":
-        yield FsAction.INSTALL, "usr/managarm/bin/eir-stivale", "boot/managarm"
         yield FsAction.INSTALL, "usr/managarm/bin/eir-mb1", "boot/managarm", dict(strip=True)
+        yield FsAction.INSTALL, "usr/managarm/bin/eir-mb2", "boot/managarm", dict(strip=True)
         yield FsAction.INSTALL, "usr/managarm/bin/thor", "boot/managarm", dict(strip=True)
         yield FsAction.CP, os.path.join(scriptdir, "grub.cfg"), "boot/grub"
 


### PR DESCRIPTION
The stivale boot protocols are deprecated and due to be removed in Limine 4.0.

We could move to the Limine boot protocol but I don't think there is a need to do so due to eir already supporting multiboot2 just fine (which is not deprecated).