### PR TITLE
scripts: Style managarm as Managarm

### DIFF
--- a/scripts/meson-aarch64-managarm.cross-file
+++ b/scripts/meson-aarch64-managarm.cross-file
@@ -8,7 +8,7 @@ pkgconfig = 'aarch64-managarm-pkg-config'
 # sed adds binaries here.
 
 [host_machine]
-system = 'managarm'
+system = 'Managarm'
 cpu_family = 'aarch64'
 cpu = 'cortex-a72'
 endian = 'little'

--- a/scripts/meson-clang-aarch64-managarm.cross-file
+++ b/scripts/meson-clang-aarch64-managarm.cross-file
@@ -11,7 +11,7 @@ cpp_args = ['-DLIBASYNC_FORCE_USE_EXPERIMENTAL', '-fsized-deallocation', '-fdebu
 cpp_link_args = [ '-fsized-deallocation', '-fdebug-default-version=4', '-target', 'aarch64-managarm', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']
 
 [host_machine]
-system = 'managarm'
+system = 'Managarm'
 cpu_family = 'aarch64'
 cpu = 'cortex-a72'
 endian = 'little'

--- a/scripts/meson-clang-x86_64-managarm.cross-file
+++ b/scripts/meson-clang-x86_64-managarm.cross-file
@@ -11,7 +11,7 @@ cpp_args = ['-DLIBASYNC_FORCE_USE_EXPERIMENTAL', '-fsized-deallocation', '-fdebu
 cpp_link_args = ['-fsized-deallocation', '-fdebug-default-version=4', '-target', 'x86_64-managarm', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']
 
 [host_machine]
-system = 'managarm'
+system = 'Managarm'
 cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'

--- a/scripts/meson-kernel-aarch64-managarm.cross-file
+++ b/scripts/meson-kernel-aarch64-managarm.cross-file
@@ -20,7 +20,7 @@ cpp_link_args = args
 needs_exe_wrapper = true
 
 [host_machine]
-system = 'managarm'
+system = 'Managarm'
 cpu_family = 'aarch64'
 cpu = 'cortex-a72'
 endian = 'little'

--- a/scripts/meson-kernel-riscv64-managarm.cross-file
+++ b/scripts/meson-kernel-riscv64-managarm.cross-file
@@ -20,7 +20,7 @@ cpp_link_args = args
 needs_exe_wrapper = true
 
 [host_machine]
-system = 'managarm'
+system = 'Managarm'
 cpu_family = 'riscv64'
 cpu = 'riscv64'
 endian = 'little'

--- a/scripts/meson-kernel-x86_64-managarm.cross-file
+++ b/scripts/meson-kernel-x86_64-managarm.cross-file
@@ -18,7 +18,7 @@ cpp_args = cxx
 cpp_link_args = cxx
 
 [host_machine]
-system = 'managarm'
+system = 'Managarm'
 cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'

--- a/scripts/meson-riscv64-managarm.cross-file
+++ b/scripts/meson-riscv64-managarm.cross-file
@@ -7,6 +7,6 @@ pkgconfig = 'riscv64-managarm-pkg-config'
 # sed adds binaries here.
 
 [host_machine]
-system = 'managarm'
+system = 'Managarm'
 cpu_family = 'riscv64'
 endian = 'little'

--- a/scripts/meson-x86_64-managarm.cross-file
+++ b/scripts/meson-x86_64-managarm.cross-file
@@ -8,7 +8,7 @@ pkgconfig = 'x86_64-managarm-pkg-config'
 # sed adds binaries here.
 
 [host_machine]
-system = 'managarm'
+system = 'Managarm'
 cpu_family = 'x86_64'
 cpu = 'x86_64'
 endian = 'little'


### PR DESCRIPTION
As discussed on Discord, this change is to make `uname -s` print `Managarm` instead of `managarm`.

Blocked on managarm/mlibc#678, need to be merged together to avoid build failures.