### PR TITLE
everywhere: Revision bump the entire world for mlibc 3.0

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -18,6 +18,7 @@ packages:
       - host-cmake
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -53,6 +54,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       # Remove the test directory from the Makefile, as it tries to run (and fail on) the tests
@@ -96,6 +98,7 @@ packages:
       - mlibc
       - libiconv
       - libintl
+    revision: 2
     configure:
       # Fix a build issue when building with gcc 10 and higher
       - args: ['sed', '-i', '/The name/,+2 d', '@THIS_SOURCE_DIR@/src/global.c']
@@ -139,6 +142,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -178,6 +182,7 @@ packages:
       - libexpat
       - libxml
       - zstd
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -210,7 +215,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'
@@ -251,6 +256,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -288,6 +294,7 @@ packages:
       - mlibc
       - bzip2
       - libiconv
+    revision: 2
     configure:
       # Fixup their makefile, thanks gentoo!
       - args: |
@@ -340,6 +347,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -373,6 +381,7 @@ packages:
     pkgs_required:
       - mlibc
       - bzip2
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -409,6 +418,7 @@ packages:
       - mlibc
       - zlib
       - xz-utils
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/app-crypt.yml
+++ b/bootstrap.d/app-crypt.yml
@@ -22,6 +22,7 @@ packages:
       - mlibc
       - libffi
       - libtasn
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -32,6 +32,7 @@ packages:
       - ncurses
       - libintl
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -73,6 +74,7 @@ packages:
       - mlibc
       - ncurses
       - libiconv
+    revision: 2
     configure:
       # vim does not seem to support out-of-tree builds, so we just copy
       # the source tree into the build directory instead

--- a/bootstrap.d/app-emulation.yml
+++ b/bootstrap.d/app-emulation.yml
@@ -30,7 +30,7 @@ packages:
       - pixman
       - ncurses
       - nettle
-    revision: 4
+    revision: 5
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -56,7 +56,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 2
+    revision: 3
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/app-shells.yml
+++ b/bootstrap.d/app-shells.yml
@@ -26,6 +26,7 @@ packages:
       - ncurses
       - readline
       - libiconv
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-db.yml
+++ b/bootstrap.d/dev-db.yml
@@ -20,6 +20,7 @@ packages:
       - mlibc
       - readline
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -128,6 +128,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -155,7 +156,7 @@ packages:
       - bzip2
       - libxcrypt
       - zlib
-    revision: 2
+    revision: 3
     configure:
       - args: ['cp', '-rf', '@THIS_SOURCE_DIR@/../perl-cross/.', '@THIS_SOURCE_DIR@/']
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
@@ -209,7 +210,7 @@ packages:
       - util-linux-libs
       - xz-utils
       - zlib
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -254,6 +255,7 @@ packages:
     pkgs_required:
       - sqlite
       - zlib
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -311,6 +313,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -108,6 +108,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -148,6 +149,7 @@ packages:
     pkgs_required:
       - mlibc
       - gmp
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -183,6 +185,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -230,6 +233,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -258,7 +262,7 @@ packages:
       - zlib
       - libiconv
       - libintl
-    revision: 3
+    revision: 4
     configure:
       - args:
         - 'meson'
@@ -304,6 +308,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -328,6 +333,7 @@ packages:
       - host-icu
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['cp',
           '@THIS_SOURCE_DIR@/icu4c/source/config/mh-linux',
@@ -355,6 +361,7 @@ packages:
       - host-cmake
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -389,6 +396,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -431,6 +439,7 @@ packages:
       - mlibc
       - openssl
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -465,6 +474,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/expat/configure'
@@ -501,6 +511,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -540,6 +551,7 @@ packages:
     pkgs_required:
       - mlibc
       - libgpg-error
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -586,6 +598,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       # libgpg-error does not know about managarm, teach it
       - args: ['cp', '-v', '@THIS_SOURCE_DIR@/src/syscfg/lock-obj-pub.x86_64-unknown-linux-gnu.h',
@@ -658,7 +671,7 @@ packages:
       - host-libtool
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -693,6 +706,7 @@ packages:
       - eudev
       - libevdev
       - mtdev
+    revision: 2
     configure:
       - args:
           - 'meson'
@@ -734,6 +748,7 @@ packages:
     pkgs_required:
       - mlibc
       - libiconv
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -826,6 +841,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -859,6 +875,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -899,7 +916,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -933,7 +950,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -970,6 +987,7 @@ packages:
       - zlib
       - python
       - libiconv
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1005,6 +1023,7 @@ packages:
       - mlibc
       - gmp
       - mpfr
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1046,6 +1065,7 @@ packages:
     pkgs_required:
       - mlibc
       - gmp
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1090,6 +1110,7 @@ packages:
     pkgs_required:
       - mlibc
       - gmp
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1117,6 +1138,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/Configure'
@@ -1167,7 +1189,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1215,6 +1237,7 @@ packages:
       - ncurses
       - readline
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1253,6 +1276,7 @@ packages:
     pkgs_required:
       - mlibc
       - libiconv
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1326,6 +1350,7 @@ packages:
       - pango
       - glib
       - libjpeg-turbo
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -1369,6 +1394,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -88,6 +88,7 @@ packages:
       - libxi
       - sqlite
       - brotli
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -182,6 +183,7 @@ packages:
       - qtsvg6
       - libxkbcommon
       - mesa
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -223,6 +225,7 @@ packages:
       - libwebp
       - libtiff
       - zlib
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -261,6 +264,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -302,6 +306,7 @@ packages:
       - libglvnd
       - gstreamer
       - gst-plugins-base
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -343,6 +348,7 @@ packages:
       - qtbase6
       - mesa
       - libxkbcommon
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -381,6 +387,7 @@ packages:
       - mlibc
       - qtbase6
       - zlib
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-util.yml
+++ b/bootstrap.d/dev-util.yml
@@ -68,6 +68,7 @@ packages:
       - xz-utils
       - zlib
       - zstd
+    revision: 2
     configure:
       - args: ['sed', '-i', '/"lib64"/s/64//', '@THIS_SOURCE_DIR@/Modules/GNUInstallDirs.cmake']
       - args: ['cp', '-f', '@SOURCE_ROOT@/scripts/managarm.cmake', '@THIS_SOURCE_DIR@/Modules/Platform/']
@@ -113,6 +114,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -154,6 +156,7 @@ packages:
       - mlibc
       - libxml
       - python
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -186,6 +189,7 @@ packages:
       - host-cmake
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -205,6 +209,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/games-board.yml
+++ b/bootstrap.d/games-board.yml
@@ -27,7 +27,7 @@ packages:
       - libx11
       - libxpm
       - zlib
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -63,6 +63,7 @@ packages:
       - qtbase6
       - qtsvg6
       - qtmultimedia6
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/games-fps.yml
+++ b/bootstrap.d/games-fps.yml
@@ -54,6 +54,7 @@ packages:
       - pcre
       - sdl2
       - glu
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -95,6 +96,7 @@ packages:
     pkgs_required:
       - mlibc
       - sdl2
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/games-misc.yml
+++ b/bootstrap.d/games-misc.yml
@@ -22,6 +22,7 @@ packages:
       - cairo
       - libx11
       - glib
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -70,6 +71,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/gnome-base.yml
+++ b/bootstrap.d/gnome-base.yml
@@ -23,7 +23,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
-    revision: 2
+    revision: 3
     configure:
       - args: |
               sed -i -r 's:"(/system):"/org/gnome\1:g' @THIS_SOURCE_DIR@/schemas/*.in

--- a/bootstrap.d/media-fonts.yml
+++ b/bootstrap.d/media-fonts.yml
@@ -78,6 +78,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/media-gfx.yml
+++ b/bootstrap.d/media-gfx.yml
@@ -14,6 +14,7 @@ packages:
     pkgs_required:
       - mlibc
       - gcc # Actually requires libstdc++.so in the system root, otherwise it links against the host libstdc++.so.6
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -31,7 +31,7 @@ packages:
       - host-pkg-config
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -62,7 +62,7 @@ packages:
       - libxi
       - mesa
       - glu
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'
@@ -106,6 +106,7 @@ packages:
       - bzip2
       - libpng
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -137,6 +138,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -161,6 +163,7 @@ packages:
       - mlibc
       - glu
       - mesa
+    revision: 2
     configure:
       # These two seds lets the build system respect the GCC variable
       - args: ['sed', '-i', 's/CC = cc/CC = $(GCC)/g', '@THIS_SOURCE_DIR@/config/Makefile.linux']
@@ -199,6 +202,7 @@ packages:
       - mlibc
       - gcc # Actually requires libstdc++.so in the system root, otherwise it links against the host libstdc++.so.6
       - mesa
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -248,6 +252,7 @@ packages:
       - wayland
       - pango
       - libxext
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -291,6 +296,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -337,6 +343,7 @@ packages:
       - freetype
       - cairo
       - icu
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -381,6 +388,7 @@ packages:
       - mesa
       - xorg-proto
       - libx11
+    revision: 2
     configure:
       - args:
           - 'meson'
@@ -412,6 +420,7 @@ packages:
       - mlibc
       - libx11
       - libxext
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -450,6 +459,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -488,6 +498,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -518,6 +529,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -550,6 +562,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -594,6 +607,7 @@ packages:
       - zlib
       - zstd
       - xz-utils
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -634,6 +648,7 @@ packages:
       - mlibc
       - libogg
       - libvorbis
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -674,6 +689,7 @@ packages:
     pkgs_required:
       - mlibc
       - libogg
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -716,6 +732,7 @@ packages:
       - freeglut
       - sdl2
       - libtiff
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -768,6 +785,7 @@ packages:
       - libxext
       - libxcb
       - libglvnd
+    revision: 2
     configure:
       - args: ['cp', '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file', 'meson.cross-file']
       - args:
@@ -839,7 +857,7 @@ packages:
       - libxrandr
       - libxrender
       - libxxf86vm
-    revision: 4
+    revision: 5
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/net-dns.yml
+++ b/bootstrap.d/net-dns.yml
@@ -31,6 +31,7 @@ packages:
       - mlibc
       - libunistring
       - libiconv
+    revision: 2
     configure:
       # Remove some files from the source directory if they exist.
       - args: |

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -23,7 +23,7 @@ packages:
       - glib
       - gnutls
       - gsettings-desktop-schemas
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'
@@ -83,6 +83,7 @@ packages:
       - libiconv
       - libintl
       - openssl
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -134,6 +135,7 @@ packages:
       - libidn2
       - libunistring
       - libiconv
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -180,6 +182,7 @@ packages:
       - libxml
       - sqlite
       - libpsl
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -24,6 +24,7 @@ packages:
       - openssl
       - zlib
       - zstd
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -82,7 +83,6 @@ packages:
       - system-gcc
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
-    revision: 2
     pkgs_required:
       - mlibc
       - lz4
@@ -92,6 +92,7 @@ packages:
       - xxhash
       - zstd
       - popt
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -142,7 +143,7 @@ packages:
       - ncurses
       - readline
       - openssl
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -188,6 +189,7 @@ packages:
       - mlibc
       - pcre
       - openssl
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/net-print.yml
+++ b/bootstrap.d/net-print.yml
@@ -28,6 +28,7 @@ packages:
       - gnutls
       - libiconv
       - zlib
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -63,6 +63,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       # Huge hack: coreutils does not compile the build-machine binary make-prime-list
       # using the build-machine compiler. Hence, build and invoke the binary manually here.
@@ -108,6 +109,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -145,7 +147,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
@@ -175,6 +177,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -211,6 +214,7 @@ packages:
       - host-python
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -249,6 +253,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -283,6 +288,7 @@ packages:
     pkgs_required:
       - mlibc
       - pcre
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -318,7 +324,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -357,7 +363,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -395,7 +401,7 @@ packages:
       - groff
       - less
       - libiconv
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -454,6 +460,7 @@ packages:
     pkgs_required:
       - mlibc
       - pciids
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -503,6 +510,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -535,7 +543,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
     build:
@@ -569,7 +577,7 @@ packages:
       - libiconv
       - file
       - libxcrypt
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -718,7 +726,7 @@ packages:
       - libiconv
       - file
       - libxcrypt
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -814,6 +822,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -842,7 +851,7 @@ packages:
       - libarchive
       - openssl
       - zlib
-    revision: 5
+    revision: 6
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:

--- a/bootstrap.d/sys-devel.yml
+++ b/bootstrap.d/sys-devel.yml
@@ -82,6 +82,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args: ['./configure.sh', '-G', '-O3']
@@ -205,6 +206,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -242,6 +244,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -280,7 +283,7 @@ packages:
     pkgs_required:
       - mlibc
       - diffutils
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -100,7 +100,6 @@ sources:
       - name: rust-shared-library
         recursive: true
 
-
 packages:
   - name: gdbm
     labels: [aarch64]
@@ -122,6 +121,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -158,6 +158,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -195,6 +196,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -220,7 +222,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -265,6 +267,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/www-client.yml
+++ b/bootstrap.d/www-client.yml
@@ -24,6 +24,7 @@ packages:
       - fontconfig
       - libjpeg-turbo
       - xz-utils
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-apps.yml
+++ b/bootstrap.d/x11-apps.yml
@@ -27,6 +27,7 @@ packages:
       - libxext
       - mesa
       - wayland
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -77,7 +78,7 @@ packages:
       - libxt
       - libxkbfile
       - libiconv
-    revision: 4
+    revision: 5
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -124,6 +125,7 @@ packages:
       - libxi
       - libxrender
       - libxtst
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -162,6 +164,7 @@ packages:
       - mesa
       - xorg-util-macros
       - libx11
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -200,6 +203,7 @@ packages:
       - xorg-util-macros
       - libx11
       - libxkbfile
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -238,6 +242,7 @@ packages:
       - xorg-util-macros
       - libx11
       - libxmu
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -276,6 +281,7 @@ packages:
       - mlibc
       - xorg-util-macros
       - libxcb
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -311,6 +317,7 @@ packages:
       - mlibc
       - xorg-util-macros
       - libx11
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -348,6 +355,7 @@ packages:
       - libxmu
       - libx11
       - libxext
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -388,6 +396,7 @@ packages:
       - xorg-util-macros
       - libx11
       - xcb-util
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-base.yml
+++ b/bootstrap.d/x11-base.yml
@@ -25,6 +25,7 @@ packages:
       - xorg-proto
       - libxau
       - libxdmcp
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -64,7 +65,7 @@ packages:
     pkgs_required:
       - mlibc
       - xorg-util-macros
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -117,6 +118,7 @@ packages:
       - nettle
       - xkbcomp
       - pixman
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -65,7 +65,7 @@ packages:
       - libxext
       - mesa
       - libxrender
-    revision: 2
+    revision: 3
     configure:
       - args:
         # For now, we build without glesv2 backend as Weston prefers the image backend.
@@ -108,7 +108,7 @@ packages:
       - libpng
       - shared-mime-info
       - libx11
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'
@@ -160,7 +160,7 @@ packages:
       - libxcb
       - pango
       - hicolor-icon-theme
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -222,6 +222,7 @@ packages:
       - xorg-proto
       - libx11
       - libxext
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -257,6 +258,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -318,7 +320,7 @@ packages:
       - libxtrans
       - xorg-font-util
       - zlib
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -364,7 +366,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -411,7 +413,7 @@ packages:
       - libx11
       - libxtrans
       - libice
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -456,7 +458,7 @@ packages:
       - xorg-proto
       - libxcb
       - libxtrans
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -501,7 +503,7 @@ packages:
       - mlibc
       - xorg-util-macros
       - xorg-proto
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -548,7 +550,7 @@ packages:
       - libxt
       - libxmu
       - libxpm
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -594,7 +596,7 @@ packages:
       - libxau
       - libxdmcp
       - xcb-proto
-    revision: 3
+    revision: 4
     configure:
       - args: ['sed', '-i', "s/pthread-stubs//", '@THIS_SOURCE_DIR@/configure']
       - args:
@@ -647,6 +649,7 @@ packages:
       - xorg-proto
       - libx11
       - libxfixes
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -691,7 +694,7 @@ packages:
       - libx11
       - libxfixes
       - libxrender
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -737,7 +740,7 @@ packages:
       - libx11
       - libxtrans
       - libxfixes
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -780,7 +783,7 @@ packages:
       - xorg-util-macros
       - xorg-proto
       - libxau
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -825,7 +828,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -871,7 +874,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -925,7 +928,7 @@ packages:
       - bzip2
       - libfontenc
       - zlib
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -975,7 +978,7 @@ packages:
       - libxrender
       - freetype
       - fontconfig
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1023,7 +1026,7 @@ packages:
       - libxtrans
       - libxext
       - libxfixes
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1073,6 +1076,7 @@ packages:
       - xorg-proto
       - libx11
       - libxext
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1111,6 +1115,7 @@ packages:
       - libxcb
       - libxml
       - xkeyboard-config
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -1159,7 +1164,7 @@ packages:
       - xorg-util-macros
       - xorg-proto
       - libx11
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1207,7 +1212,7 @@ packages:
       - libxext
       - libxtrans
       - libxt
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1252,7 +1257,7 @@ packages:
       - libx11
       - libxext
       - libxt
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1299,7 +1304,7 @@ packages:
       - libxtrans
       - libxrender
       - libxext
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1345,7 +1350,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1395,6 +1400,7 @@ packages:
       - xorg-proto
       - libx11
       - libxext
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1444,6 +1450,7 @@ packages:
       - xorg-proto
       - libx11
       - libxext
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1489,7 +1496,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1536,7 +1543,7 @@ packages:
       - libxtrans
       - libsm
       - libice
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1566,7 +1573,7 @@ packages:
       - xorg-util-macros
       - xorg-proto
       - libxcb
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1613,7 +1620,7 @@ packages:
       - libxtrans
       - libxext
       - libxi
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1659,7 +1666,7 @@ packages:
       - libx11
       - libxtrans
       - libxext
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1706,7 +1713,7 @@ packages:
       - libx11
       - libxtrans
       - libxext
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1749,6 +1756,7 @@ packages:
       - libxext
       - harfbuzz
       - libxft
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -1791,6 +1799,7 @@ packages:
     pkgs_required:
       - mlibc
       - libpng
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1836,7 +1845,7 @@ packages:
       - libx11
       - libxtrans
       - libxcb
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1880,6 +1889,7 @@ packages:
       - xorg-util-macros
       - xorg-proto
       - xcb-util
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1922,6 +1932,7 @@ packages:
       - libxcb
       - xorg-util-macros
       - xorg-proto
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1964,6 +1975,7 @@ packages:
       - libxcb
       - xorg-util-macros
       - xorg-proto
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2006,6 +2018,7 @@ packages:
       - libxcb
       - xorg-util-macros
       - xorg-proto
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-misc.yml
+++ b/bootstrap.d/x11-misc.yml
@@ -53,7 +53,7 @@ packages:
       - glib
       - libxml
       - itstool
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -93,6 +93,7 @@ packages:
     pkgs_required:
       - mlibc
       - xorg-util-macros
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -135,6 +136,7 @@ packages:
       - mlibc
       - libx11
       - xorg-proto
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -157,6 +159,7 @@ packages:
     tools_required:
       - system-gcc
       - host-xorg-macros
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-terms.yml
+++ b/bootstrap.d/x11-terms.yml
@@ -23,7 +23,7 @@ packages:
       - fontconfig
       - freetype
       - wayland
-    revision: 2
+    revision: 3
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
       - args: ['cargo', 'update', '-p', 'smithay-clipboard', '--precise', '0.6.5', '--manifest-path', '@THIS_SOURCE_DIR@/Cargo.toml']

--- a/bootstrap.d/x11-themes.yml
+++ b/bootstrap.d/x11-themes.yml
@@ -20,6 +20,7 @@ packages:
         - args: ['./autogen.sh', '--no-configure']
     tools_required:
       - system-gcc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -61,6 +62,7 @@ packages:
       - mlibc
       - xorg-util-macros
       - libxcursor
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -629,7 +629,7 @@ packages:
       - tool: system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -747,6 +747,7 @@ packages:
       branch: 'master'
     tools_required:
       - system-gcc
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -810,6 +811,7 @@ packages:
       - mpfr
       - mpc
       - zlib
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -854,7 +856,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -888,6 +890,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -917,6 +920,7 @@ packages:
       - system-gcc
     pkgs_required:
       - boost
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -948,6 +952,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -975,6 +980,7 @@ packages:
       branch: 'master'
     tools_required:
       - system-gcc
+    revision: 2
     configure: []
     build:
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/include']
@@ -1000,6 +1006,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1050,6 +1057,7 @@ packages:
     pkgs_required:
       - mlibc
       - mesa
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1089,7 +1097,7 @@ packages:
     pkgs_required:
       - frigg
       - cxxshim
-    revision: 2
+    revision: 3
     configure:
       - args: |
           sed -e 's|_BUILD_ROOT_|@BUILD_ROOT@|' @SOURCE_ROOT@/scripts/meson-kernel-@OPTION:arch-triple@.cross-file \
@@ -1142,7 +1150,7 @@ packages:
       - libdrm
       - libsmarter
       - protobuf
-    revision: 2
+    revision: 3
     configure:
       - args: |
           sed -e 's|_BUILD_ROOT_|@BUILD_ROOT@|' -e 's|_SYSROOT_DIR_|@SYSROOT_DIR@|' @SOURCE_ROOT@/scripts/meson-clang-@OPTION:arch-triple@.cross-file \
@@ -1280,7 +1288,7 @@ packages:
       - host-protoc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1312,6 +1320,7 @@ packages:
       - mlibc
       - libexpat
       - libffi
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -1352,6 +1361,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1398,6 +1408,7 @@ packages:
     pkgs_required:
       - mlibc
       - libxkbcommon
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1447,6 +1458,7 @@ packages:
       - libdrm
       - libtsm
       - eudev
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1479,6 +1491,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -1523,7 +1536,7 @@ packages:
       - libintl
       - libiconv
       - zlib
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'


### PR DESCRIPTION
With the merging of abi-break into master, we should bump all packages to catch breakages and ensure everything keeps building and running smoothly. In the future, I'd like to only do this for packages where it is needed, but managarm/xbbs#7 seems to be needed for that.