### PR TITLE
Some small updates

### DIFF
--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -126,8 +126,8 @@ packages:
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gzip.git'
-      tag: 'v1.11'
-      version: '1.11'
+      tag: 'v1.12'
+      version: '1.12'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -142,7 +142,6 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -412,15 +412,14 @@ packages:
     source:
       subdir: ports
       git: 'https://github.com/facebook/zstd.git'
-      tag: 'v1.5.0'
-      version: '1.5.0'
+      tag: 'v1.5.2'
+      version: '1.5.2'
     tools_required:
       - system-gcc
     pkgs_required:
       - mlibc
       - zlib
       - xz-utils
-    revision: 3
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -247,17 +247,17 @@ packages:
       categories: ['dev-lang']
     source:
       subdir: ports
-      url: 'https://downloads.sourceforge.net/tcl/tcl8.6.11-src.tar.gz'
+      url: 'https://downloads.sourceforge.net/tcl/tcl8.6.12-src.tar.gz'
       format: 'tar.gz'
-      checksum: blake2b:9c6fee5ab54af610518a214822d58caa0e0dcf79b8c9735e3d3e280e4339c8484afb2599f12d71da4a6e6b37639fa1da2b62c13d30579231ca01e00dbf8d1d21
-      extract_path: 'tcl8.6.11'
-      version: '8.6.11'
+      checksum: blake2b:21367f4ee5903fac68177b6cc61517237e1b9347a18f213cb02ebd7cde21af9d5590d7270bc5ba8c03f3595dea1f2eaf065165b1cc0b0bc34e5329cd197b8159
+      extract_path: 'tcl8.6.12'
+      version: '8.6.12'
     tools_required:
       - system-gcc
     pkgs_required:
+      - mlibc
       - sqlite
       - zlib
-    revision: 3
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -275,10 +275,10 @@ packages:
       # The Tcl package expects that its source tree is preserved so that packages depending on it for their compilation can utilize it.
       # These sed's remove the references to the build directory and replace them with saner system-wide locations.
       - args: ['sed', '-e', "s#@THIS_SOURCE_DIR@/unix#/usr/lib#", '-e', "s#@THIS_SOURCE_DIR@#/usr/include#", '-i', 'tclConfig.sh']
-      - args: ['sed', '-e', "s#$@THIS_SOURCE_DIR@/unix/pkgs/tdbc1.1.2#/usr/lib/tdbc1.1.2#", '-e', "s#@THIS_SOURCE_DIR@/pkgs/tdbc1.1.2/generic#/usr/include#",
-          '-e', "s#@THIS_SOURCE_DIR@/pkgs/tdbc1.1.2/library#/usr/lib/tcl8.6#", '-e', "s#@THIS_SOURCE_DIR@/pkgs/tdbc1.1.2#/usr/include#", '-i', 'pkgs/tdbc1.1.2/tdbcConfig.sh']
-      - args: ['sed', '-e', "s#@THIS_SOURCE_DIR@/unix/pkgs/itcl4.2.0#/usr/lib/itcl4.2.1#", '-e', "s#@THIS_SOURCE_DIR@/pkgs/itcl4.2.1/generic#/usr/include#",
-          '-e', "s#@THIS_SOURCE_DIR@/pkgs/itcl4.2.1#/usr/include#", '-i', 'pkgs/itcl4.2.1/itclConfig.sh']
+      - args: ['sed', '-e', "s#$@THIS_SOURCE_DIR@/unix/pkgs/tdbc1.1.3#/usr/lib/tdbc1.1.3#", '-e', "s#@THIS_SOURCE_DIR@/pkgs/tdbc1.1.3/generic#/usr/include#",
+          '-e', "s#@THIS_SOURCE_DIR@/pkgs/tdbc1.1.3/library#/usr/lib/tcl8.6#", '-e', "s#@THIS_SOURCE_DIR@/pkgs/tdbc1.1.3#/usr/include#", '-i', 'pkgs/tdbc1.1.3/tdbcConfig.sh']
+      - args: ['sed', '-e', "s#@THIS_SOURCE_DIR@/unix/pkgs/itcl4.2.2#/usr/lib/itcl4.2.2#", '-e', "s#@THIS_SOURCE_DIR@/pkgs/itcl4.2.2/generic#/usr/include#",
+          '-e', "s#@THIS_SOURCE_DIR@/pkgs/itcl4.2.2#/usr/include#", '-i', 'pkgs/itcl4.2.2/itclConfig.sh']
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -295,7 +295,7 @@ packages:
       subdir: 'ports'
       hg: 'https://gmplib.org/repo/gmp-6.2/'
       tag: 'tip'
-      version: '6.2'
+      version: '6.2.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -310,7 +310,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -318,7 +317,7 @@ packages:
         - '--prefix=/usr'
         - '--enable-cxx'
         - '--disable-static'
-        - '--docdir=/usr/share/doc/gmp-6.2.0'
+        - '--docdir=/usr/share/doc/gmp-6.2.1'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -459,8 +459,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/libexpat/libexpat.git'
-      tag: 'R_2_4_1'
-      version: '2.4.1'
+      tag: 'R_2_4_8'
+      version: '2.4.8'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -475,7 +475,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/expat/configure'

--- a/bootstrap.d/net-misc.yml
+++ b/bootstrap.d/net-misc.yml
@@ -46,14 +46,13 @@ packages:
     default: true
     source:
       subdir: ports
-      url: 'https://github.com/Mic92/iana-etc/releases/download/20211124/iana-etc-20211124.tar.gz'
+      url: 'https://github.com/Mic92/iana-etc/releases/download/20220610/iana-etc-20220610.tar.gz'
       format: 'tar.gz'
-      checksum: blake2b:25483518b0b72e71fcb5a9eb8871a031b3bcc138046c0dc97245ed54eaaf6a882b30099d0b4ce0b35801ad5db254cedd5acdd2d3d0ebeb23ba77387908494a90
-      extract_path: 'iana-etc-20211124'
-      version: '20211124'
+      checksum: blake2b:1112c3621466fcd0e8692a652d846ebff0f2f55fd3542297d585c020e866bfecacf352b75f276a44cc40e2d2296c371b74c60d26202044aeb252c9a09580c321
+      extract_path: 'iana-etc-20220610'
+      version: '20220610'
     tools_required:
       - system-gcc
-    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -50,11 +50,11 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/coreutils.git'
-      tag: 'v9.0'
-      version: '9.0'
+      tag: 'v9.1'
+      version: '9.1'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
       regenerate:
         - args: ['./bootstrap']
         - args: ['cp',
@@ -64,7 +64,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       # Huge hack: coreutils does not compile the build-machine binary make-prime-list
       # using the build-machine compiler. Hence, build and invoke the binary manually here.

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -2,8 +2,8 @@ sources:
   - name: file
     subdir: ports
     git: 'https://github.com/file/file.git'
-    tag: 'FILE5_41'
-    version: '5.41'
+    tag: 'FILE5_42'
+    version: '5.42'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -178,7 +178,6 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -196,8 +196,8 @@ packages:
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/findutils.git'
-      tag: 'v4.8.0'
-      version: '4.8.0'
+      tag: 'v4.9.0'
+      version: '4.9.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -213,7 +213,6 @@ packages:
       - host-python
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -350,11 +350,11 @@ packages:
     architecture: '@OPTION:arch@'
     source:
       subdir: ports
-      url: 'https://www.greenwoodsoftware.com/less/less-563.tar.gz'
+      url: 'https://www.greenwoodsoftware.com/less/less-590.tar.gz'
       format: 'tar.gz'
-      checksum: blake2b:813e54b9a115600e4f20009ccad3708efc64ab4ee940aa3624e968045557bbfef6ace49b791f4b9efff86bf43df9fe2a04a160e76718396e0dae17f0bdaa62fb
-      extract_path: 'less-563'
-      version: '563'
+      checksum: blake2b:0f640f1b6b4d4925c4904ee77460e8becd2dae168fe5c1483bf6a9cfabe9eb0abdc4d4811507ba88a2b4cff6c238158bd8b4463b63d3d7863b44ce8538d32adb
+      extract_path: 'less-590'
+      version: '590'
     tools_required:
       - system-gcc
       - host-autoconf-v2.69
@@ -363,7 +363,6 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -287,13 +287,12 @@ packages:
     default: true
     source:
       subdir: 'ports'
-      url: 'https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz'
+      url: 'https://data.iana.org/time-zones/releases/tzdata2022b.tar.gz'
       format: 'tar.gz'
-      checksum: blake2b:e0e1189a1bbfb2ee641b9c4c8d00775372638d46d7aea72ff0c4bcb02b38a65eedaf89e6b272e054245c940369a50c2573e6fc720414e4ab3d45adeda8ed9c75
-      version: '2021e'
+      checksum: blake2b:23732f1c753efeca97bb9d6ed8d487a56c735943cb1062a77a1a76faf0109f86238ef9b0ec9ec92b8bdf1da10435f2c39e1465a7fefe74eab8de730214920249
+      version: '2022b'
     tools_required:
       - system-gcc
-    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -107,8 +107,8 @@ packages:
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gdbm.git'
-      tag: 'v1.22'
-      version: '1.22'
+      tag: 'v1.23'
+      version: '1.23'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -121,7 +121,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1372,20 +1372,40 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/madler/zlib.git'
-      tag: 'v1.2.11'
-      version: '1.2.11'
+      tag: 'v1.2.12'
+      version: '1.2.12'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+          workdir: '@THIS_SOURCE_DIR@/contrib/minizip'
     tools_required:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
+        - '--prefix=/usr'
+        environ:
+          CHOST: '@OPTION:arch-triple@'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+      - args:
+        - '@THIS_SOURCE_DIR@/contrib/minizip/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
         environ:
           CHOST: '@OPTION:arch-triple@'
           prefix: '/usr'
-    build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']
         environ:


### PR DESCRIPTION
The following ports received updates:

- `zlib`, from version 1.2.11 to 1.2.12;
- `zstd`, from version 1.5.0 to 1.5.2;
- `file`, from version 5.41 to 5.42;
- `tcl`, from version 8.6.11 to 8.6.12;
- `iana-etc`, from version 20211124 to 20220610;
- `tzdata`, from version 2021e to 2022b;
- `gmp`, from version 6.2.0 to 6.2.1;
- `gdbm`, from version 1.22 to 1.23;
- `libexpat`, from version 2.4.1 to 2.4.8;
- `less`, from version 563 to 590;
- `coreutils`, from version 9.0 to 9.1;
- `findutils`, from version 4.8.0 to 4.9.0;
- `gzip`, from version 1.11 to 1.12.

This is not everything but I'm breaking it up into smaller parts due to vacation.