### PR TITLE
Another batch of updates

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -1076,8 +1076,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://git.lysator.liu.se/nettle/nettle.git'
-      tag: 'nettle_3.7.3_release_20210606'
-      version: '3.7.3'
+      tag: 'nettle_3.8.1_release_20220727'
+      version: '3.8.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -1094,7 +1094,6 @@ packages:
     pkgs_required:
       - mlibc
       - gmp
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -888,11 +888,11 @@ packages:
       categories: ['dev-libs']
     source:
       subdir: 'ports'
-      url: 'https://ftp.gnu.org/gnu/libunistring/libunistring-0.9.10.tar.xz'
+      url: 'https://ftp.gnu.org/gnu/libunistring/libunistring-1.0.tar.xz'
       format: 'tar.xz'
-      checksum: blake2b:25d162d9d510cc35ad4209acceb9b06bcc0553b8ce56e94f8df12c4df64d91abfc4a9e15b50b5c8d5b9672939305a394a7e83f1892258defb7ae5ac2ccf79dfb
-      extract_path: 'libunistring-0.9.10'
-      version: '0.9.10'
+      checksum: blake2b:8208fe33d4ac2f015b0efb56b0c7dd87afc4bb1c6ca4eb3ded86d7e2101d7b7f68bfd8991af4b6dd408282ec73f134ee0b884e761ff6d52e8a1e398326aec420
+      extract_path: 'libunistring-1.0'
+      version: '1.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -904,7 +904,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -912,7 +911,7 @@ packages:
         - '--prefix=/usr'
         - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
         - '--disable-static'
-        - '--docdir=/usr/share/doc/libunistring-0.9.10'
+        - '--docdir=/usr/share/doc/libunistring-1.0'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -848,8 +848,8 @@ packages:
     source:
       subdir: ports
       git: 'https://gitlab.com/gnutls/libtasn1.git'
-      tag: 'v4.17.0'
-      version: '4.17.0'
+      tag: 'v4.18.0'
+      version: '4.18.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -864,7 +864,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -815,8 +815,8 @@ packages:
     source:
       subdir: ports
       git: 'https://gitlab.com/cjwatson/libpipeline.git'
-      tag: '1.5.4'
-      version: '1.5.4'
+      tag: '1.5.6'
+      version: '1.5.6'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -831,7 +831,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -955,11 +955,11 @@ packages:
     source:
       subdir: ports
       git: 'https://gitlab.gnome.org/GNOME/libxml2.git'
-      tag: 'v2.9.12'
-      version: '2.9.12'
+      tag: 'v2.10.0'
+      version: '2.10.0'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
       regenerate:
@@ -968,19 +968,16 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
-      - host-python
     pkgs_required:
       - mlibc
       - zlib
-      - python
       - libiconv
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=@OPTION:arch-triple@'
         - '--prefix=/usr'
-        - '--with-python=@SYSROOT_DIR@/usr/bin/python3.8'
+        - '--without-python'
         - '--disable-static'
         - '--with-threads'
         - '--disable-ipv6'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -614,10 +614,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/libiconv.git'
-      # Last release tag is broken for us, use current master (07-12-2020)
-      branch: 'master'
-      commit: '0eb1068ceb77ba383c3ce2fc391ab40ef686c491'
-      version: '1.16'
+      tag: 'v1.17'
+      version: '1.17'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -627,8 +625,9 @@ packages:
         - host-gettext
       regenerate:
         - args: ['./gitsub.sh', 'pull']
-        # Gnulib broke on commit e3174b6d1fdbe6ea2297bf8c8333f65f9d9d9588, so check out the one before that.
-        - args: ['git', 'checkout', '766ec17a90f67e8cda78394e58a7fffb00f5a4b7']
+        # Checkout current gnulib master, 044bf893acee0a55b22b4be0ede0e3ce010c480a, 29-08-2022.
+        # This avoids random breakage in the future
+        - args: ['git', 'checkout', '044bf893acee0a55b22b4be0ede0e3ce010c480a']
           workdir: '@THIS_SOURCE_DIR@/gnulib'
         - args: ['./autogen.sh']
           environ:
@@ -663,7 +662,6 @@ packages:
       - host-libtool
     pkgs_required:
       - mlibc
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -584,8 +584,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://gitlab.com/libtiff/libtiff.git'
-      tag: 'v4.3.0'
-      version: '4.3.0'
+      tag: 'v4.4.0'
+      version: '4.4.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -603,7 +603,6 @@ packages:
       - zlib
       - zstd
       - xz-utils
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -611,7 +610,7 @@ packages:
         - '--prefix=/usr'
         - '--disable-static'
         - '--enable-shared'
-        - '--with-docdir=/usr/share/doc/libtiff-4.3.0'
+        - '--with-docdir=/usr/share/doc/libtiff-4.4.0'
         - '--without-x'
         - '--enable-zlib'
         - '--enable-zstd'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -709,8 +709,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/webmproject/libwebp.git'
-      tag: 'v1.2.2'
-      version: '1.2.2'
+      tag: 'v1.2.4'
+      version: '1.2.4'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -727,7 +727,6 @@ packages:
       - freeglut
       - sdl2
       - libtiff
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -446,8 +446,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/libjpeg-turbo/libjpeg-turbo.git'
-      tag: '2.1.2'
-      version: '2.1.2'
+      tag: '2.1.4'
+      version: '2.1.4'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -456,7 +456,6 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - 'cmake'
@@ -464,7 +463,7 @@ packages:
         - '-DCMAKE_INSTALL_PREFIX=/usr'
         - '-DCMAKE_BUILD_TYPE=RELEASE'
         - '-DENABLE_STATIC=FALSE'
-        - '-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/libjpeg-turbo-2.1.2'
+        - '-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/libjpeg-turbo-2.1.4'
         - '-DCMAKE_INSTALL_DEFAULT_LIBDIR=lib'
         - '-DWITH_JPEG8=ON'
         - '-DCMAKE_SYSTEM_PROCESSOR=@OPTION:arch@'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -850,7 +850,7 @@ packages:
       - libarchive
       - openssl
       - zlib
-    revision: 7
+    revision: 8
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -142,8 +142,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/besser82/libxcrypt.git'
-      tag: 'v4.4.26'
-      version: '4.4.26'
+      tag: 'v4.4.28'
+      version: '4.4.28'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -157,7 +157,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/www-client.yml
+++ b/bootstrap.d/www-client.yml
@@ -2,11 +2,11 @@ packages:
   - name: links
     source:
       subdir: 'ports'
-      url: 'http://links.twibright.com/download/links-2.25.tar.gz'
+      url: 'http://links.twibright.com/download/links-2.27.tar.gz'
       format: 'tar.gz'
-      checksum: blake2b:2e52c5c00e5e32c927324b2c16e65794492f854e105674d6b1a3607e73ea487ce0fedd8d17dd067f86547ba94ec01ebd2324e7122e1ac0e72bba5e30aa8b8ef1
-      extract_path: 'links-2.25'
-      version: '2.25'
+      checksum: blake2b:e10be3c8dd07ef2fd87afc5dd438c58857350533edfa154e8cf663e8868b5f1fe8a4f7e5c67e2aab3f0c09ab17638fc31e986f5f975af6a79ee2a4c254c1039b
+      extract_path: 'links-2.27'
+      version: '2.27'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -24,7 +24,6 @@ packages:
       - fontconfig
       - libjpeg-turbo
       - xz-utils
-    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -433,8 +433,8 @@ packages:
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libx11.git'
-      tag: 'libX11-1.7.2'
-      version: '1.7.2'
+      tag: 'libX11-1.8.1'
+      version: '1.8.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -457,7 +457,6 @@ packages:
       - xorg-proto
       - libxcb
       - libxtrans
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -569,8 +569,8 @@ packages:
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxcb.git'
-      tag: 'libxcb-1.14'
-      version: '1.14'
+      tag: 'libxcb-1.15'
+      version: '1.15'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -583,7 +583,6 @@ packages:
             'NOCONFIGURE': 'yes'
     tools_required:
       - system-gcc
-      - host-python
       - host-autoconf-v2.69
       - host-automake-v1.15
       - host-pkg-config
@@ -594,7 +593,6 @@ packages:
       - libxau
       - libxdmcp
       - xcb-proto
-    revision: 5
     configure:
       - args: ['sed', '-i', "s/pthread-stubs//", '@THIS_SOURCE_DIR@/configure']
       - args:
@@ -607,7 +605,7 @@ packages:
         - '--without-doxygen'
         - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
         environ:
-          PYTHON: '@BUILD_ROOT@/tools/host-python/bin/python3.8'
+          PYTHON: 'python3'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1093,8 +1093,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/xkbcommon/libxkbcommon.git'
-      tag: 'xkbcommon-1.3.1'
-      version: '1.3.1'
+      tag: 'xkbcommon-1.4.1'
+      version: '1.4.1'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -1110,7 +1110,6 @@ packages:
       - libxcb
       - libxml
       - xkeyboard-config
-    revision: 3
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -666,8 +666,8 @@ packages:
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/xorg/lib/libxcursor.git'
-      tag: 'libXcursor-1.2.0'
-      version: '1.2.0'
+      tag: 'libXcursor-1.2.1'
+      version: '1.2.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -690,7 +690,6 @@ packages:
       - libx11
       - libxfixes
       - libxrender
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -83,6 +83,8 @@ RUN apt-get update \
 		python3-wheel \
 		# Used by managarm
 		python3-protobuf \
+		# Used by libxcb
+		python3-xcbgen \
 		# Several programs use rsync
 		rsync \
 		# makeinfo is used in gnu build systems

--- a/patches/fontconfig/0001-Add-Managarm-support.patch
+++ b/patches/fontconfig/0001-Add-Managarm-support.patch
@@ -1,0 +1,26 @@
+From 817dc2102610dd853a718e14eee63373ab31c8eb Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 29 Aug 2022 01:04:27 +0200
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ src/fcstat.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/fcstat.c b/src/fcstat.c
+index 4f69eae..d0a0664 100644
+--- a/src/fcstat.c
++++ b/src/fcstat.c
+@@ -386,7 +386,7 @@ FcFStatFs (int fd, FcStatFS *statb)
+ #  endif
+ #  if defined(HAVE_STRUCT_STATFS_F_FSTYPENAME)
+ 	p = buf.f_fstypename;
+-#  elif defined(__linux__) || defined (__EMSCRIPTEN__)
++#  elif defined(__linux__) || defined (__EMSCRIPTEN__) || defined(__managarm__)
+ 	switch (buf.f_type)
+ 	{
+ 	case 0x6969: /* nfs */
+-- 
+2.37.2
+

--- a/patches/libiconv/0001-Remove-calls-to-versioned-binaries.patch
+++ b/patches/libiconv/0001-Remove-calls-to-versioned-binaries.patch
@@ -1,50 +1,42 @@
-From 1e0451005e0f150330390f5440ac52790c1cd502 Mon Sep 17 00:00:00 2001
-From: Dennisbonke <admin@dennisbonke.com>
-Date: Mon, 7 Dec 2020 16:32:04 +0100
+From 858ee78090f83b5323e8665ed12316fe0f04f546 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 29 Aug 2022 00:54:41 +0200
 Subject: [PATCH] Remove calls to versioned binaries
 
-Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- Makefile.devel            | 8 ++++----
- libcharset/Makefile.devel | 6 +++---
- 2 files changed, 7 insertions(+), 7 deletions(-)
+ Makefile.devel            | 4 ++--
+ libcharset/Makefile.devel | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/Makefile.devel b/Makefile.devel
-index 2a5e101..a179aaf 100644
+index 3102ad2..d49e74a 100644
 --- a/Makefile.devel
 +++ b/Makefile.devel
-@@ -4,10 +4,10 @@
- 
- SHELL = /bin/sh
+@@ -6,8 +6,8 @@ SHELL = /bin/sh
  MAKE = make
--AUTOCONF = autoconf-2.69
--AUTOHEADER = autoheader-2.69
+ AUTOCONF = autoconf
+ AUTOHEADER = autoheader
 -AUTOMAKE = automake-1.16
 -ACLOCAL = aclocal-1.16
-+AUTOCONF = autoconf
-+AUTOHEADER = autoheader
 +AUTOMAKE = automake
 +ACLOCAL = aclocal
  GPERF = gperf
  CC = gcc -Wall
  CFLAGS = -O
 diff --git a/libcharset/Makefile.devel b/libcharset/Makefile.devel
-index 04f4c7a..3e0e2ca 100644
+index 7a991cd..3e0e2ca 100644
 --- a/libcharset/Makefile.devel
 +++ b/libcharset/Makefile.devel
-@@ -3,9 +3,9 @@
- 
- SHELL = /bin/sh
+@@ -5,7 +5,7 @@ SHELL = /bin/sh
  MAKE = make
--AUTOCONF = autoconf-2.69
--AUTOHEADER = autoheader-2.69
+ AUTOCONF = autoconf
+ AUTOHEADER = autoheader
 -ACLOCAL = aclocal-1.16
-+AUTOCONF = autoconf
-+AUTOHEADER = autoheader
 +ACLOCAL = aclocal
  CP = cp
  RM = rm -f
  
 -- 
-2.29.2
+2.37.2
 

--- a/patches/libtiff/0001-Don-t-fetch-new-versions-of-config.guess-and-config..patch
+++ b/patches/libtiff/0001-Don-t-fetch-new-versions-of-config.guess-and-config..patch
@@ -1,19 +1,19 @@
-From b5f632aa5df4e20361367fb3df6d768ca34a539e Mon Sep 17 00:00:00 2001
+From 457a6790efcc1387f4482ebd2cfa511ccfc9e8a0 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
-Date: Tue, 19 Apr 2022 20:57:12 +0200
+Date: Mon, 29 Aug 2022 02:27:51 +0200
 Subject: [PATCH] Don't fetch new versions of config.guess and config.sub by
  default
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- autogen.sh | 14 +-------------
- 1 file changed, 1 insertion(+), 13 deletions(-)
+ autogen.sh | 13 -------------
+ 1 file changed, 13 deletions(-)
 
 diff --git a/autogen.sh b/autogen.sh
-index 9ef71b5..5633885 100755
+index 2882bfc..db8c38e 100755
 --- a/autogen.sh
 +++ b/autogen.sh
-@@ -5,16 +5,4 @@ aclocal -I ./m4
+@@ -5,16 +5,3 @@ aclocal -I ./m4
  autoheader
  automake --foreign --add-missing --copy
  autoconf
@@ -24,13 +24,12 @@ index 9ef71b5..5633885 100755
 -    echo "$0: getting $file..."
 -    wget -q --timeout=5 -O config/$file.tmp \
 -      "https://git.savannah.gnu.org/cgit/config.git/plain/${file}" \
--      && mv config/$file.tmp config/$file \
+-      && mv -f config/$file.tmp config/$file \
 -      && chmod a+x config/$file
 -    retval=$?
 -    rm -f config/$file.tmp
 -    test $retval -eq 0 || exit $retval
 -done
-+
 -- 
-2.35.2
+2.37.2
 


### PR DESCRIPTION
The following ports received updates:

- `libiconv`, from version 1.16 to 1.17;
- `libjpeg-turbo`, from version 2.1.2 to 2.1.4;
- `libpipeline`, from version 1.5.4 to 1.5.6;
- `libtasn`, from version 4.17.0 to 4.18.0;
- `libtiff`, from version 4.3.0 to 4.4.0;
- `libunistring`, from version 0.9.10 to 1.0;
- `libwebp`, from version 1.2.2 to 1.2.4;
- `libX11`, from version 1.7.3 to 1.8.1;
- `libxcb`, from version 1.14 to 1.15;
- `libxcrypt`, from version 4.4.26 to 4.4.28;
- `libXcursor`, from version 1.2.0 to 1.2.1;
- `libxkbcommon`, from version 1.3.1 to 1.4.1;
- `libxml`, from version 2.9.12 to 2.10.0;
- `links`, from version 2.25 to 2.27;
- `nettle`, from version 3.7.3 to 3.8.1.

The dockerfile got updated to install `python3-xcbgen` which is needed for `libxcb` to generate some files during compile time.
`fontconfig` got a missing patch fixed and added, this should unbreak ci.
Lastly, `xbps` got a revbump because the recent libarchive update seems to have bumped sonames.

This is not everything but I'm breaking it up into smaller parts due to vacation.