### PR TITLE
Qt stack updates

### DIFF
--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -395,3 +395,41 @@ packages:
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: qtwayland6
+    architecture: '@OPTION:arch@'
+    metadata:
+      spdx: 'GPL-2.0-only GPL-3.0-only LGPL-3.0-only GFDL-1.3-only'
+      website: 'https://code.qt.io/cgit/qt/qtwayland.git/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-qt']
+    source:
+      subdir: 'ports'
+      git: 'http://code.qt.io/qt/qtwayland.git'
+      tag: 'v6.4.0'
+      version: '6.4.0'
+    tools_required:
+      - system-gcc
+      - host-cmake
+      - host-qt6
+    pkgs_required:
+      - mlibc
+      - qtbase6
+      - qtdeclarative6
+      - mesa
+      - wayland
+      - libxkbcommon
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_BUILD_TYPE=Debug'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -253,8 +253,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://code.qt.io/qt/qtlanguageserver.git'
-      tag: 'v6.3.0'
-      version: '6.3.0'
+      tag: 'v6.4.0'
+      version: '6.4.0'
     tools_required:
       - system-gcc
       - host-cmake
@@ -262,7 +262,6 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -167,8 +167,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://code.qt.io/qt/qtdeclarative.git'
-      tag: 'v6.3.0'
-      version: '6.3.0'
+      tag: 'v6.4.0'
+      version: '6.4.0'
     tools_required:
       - system-gcc
       - host-cmake
@@ -182,7 +182,6 @@ packages:
       - qtsvg6
       - libxkbcommon
       - mesa
-    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -373,8 +373,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://code.qt.io/qt/qtsvg.git'
-      tag: 'v6.3.0'
-      version: '6.3.0'
+      tag: 'v6.4.0'
+      version: '6.4.0'
     tools_required:
       - system-gcc
       - host-cmake
@@ -383,7 +383,6 @@ packages:
       - mlibc
       - qtbase6
       - zlib
-    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -42,8 +42,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://code.qt.io/qt/qtbase.git'
-      tag: 'v6.3.0'
-      version: '6.3.0'
+      tag: 'v6.4.0'
+      version: '6.4.0'
     tools_required:
       - system-gcc
       - host-cmake
@@ -88,7 +88,6 @@ packages:
       - libxi
       - sqlite
       - brotli
-    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -3,8 +3,8 @@ sources:
     subdir: 'ports'
     # This may seem strange, but is actually correct
     git: 'https://code.qt.io/qt/qt5.git'
-    tag: 'v6.3.0'
-    version: '6.3.0'
+    tag: 'v6.4.0'
+    version: '6.4.0'
     regenerate:
       # Get the submodules that we'll need as a host tool
       - args: ['./init-repository', '-f', '--module-subset', 'qtbase,qtsvg,qtimageformats,qtshadertools,qtlanguageserver,qtdeclarative,qtwayland,qtmultimedia']
@@ -15,7 +15,6 @@ tools:
     from_source: qt6
     tools_required:
       - host-cmake
-    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -288,8 +288,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://code.qt.io/qt/qtmultimedia.git'
-      tag: 'v6.3.0'
-      version: '6.3.0'
+      tag: 'v6.4.0'
+      version: '6.4.0'
     tools_required:
       - system-gcc
       - host-cmake
@@ -302,7 +302,6 @@ packages:
       - libglvnd
       - gstreamer
       - gst-plugins-base
-    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -334,8 +334,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://code.qt.io/qt/qtshadertools.git'
-      tag: 'v6.3.0'
-      version: '6.3.0'
+      tag: 'v6.4.0'
+      version: '6.4.0'
     tools_required:
       - system-gcc
       - host-cmake
@@ -345,13 +345,12 @@ packages:
       - qtbase6
       - mesa
       - libxkbcommon
-    revision: 3
     configure:
       - args:
         - 'cmake'
         - '-GNinja'
         - '-DQT_HOST_PATH=@BUILD_ROOT@/tools/host-qt6'
-        - '-DQT_BUILD_TOOLS_WHEN_CROSSCOMPILING=ON'
+        - '-DQT_FORCE_BUILD_TOOLS=ON'
         - '-DCMAKE_INSTALL_PREFIX=/usr'
         - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
         - '-DCMAKE_BUILD_TYPE=Debug'

--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -210,8 +210,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://code.qt.io/qt/qtimageformats.git'
-      tag: 'v6.3.0'
-      version: '6.3.0'
+      tag: 'v6.4.0'
+      version: '6.4.0'
     tools_required:
       - system-gcc
       - host-cmake
@@ -224,7 +224,6 @@ packages:
       - libwebp
       - libtiff
       - zlib
-    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/games-board.yml
+++ b/bootstrap.d/games-board.yml
@@ -63,7 +63,7 @@ packages:
       - qtbase6
       - qtsvg6
       - qtmultimedia6
-    revision: 3
+    revision: 4
     configure:
       - args:
         - 'cmake'

--- a/patches/libremines/0001-Disable-sound-as-we-don-t-support-sound.patch
+++ b/patches/libremines/0001-Disable-sound-as-we-don-t-support-sound.patch
@@ -1,0 +1,131 @@
+From 1b6d09e9c8ac5387b49bcd0ddeaa33a8ad4e7452 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 9 Oct 2022 21:03:22 +0200
+Subject: [PATCH] Disable sound as we don't support sound
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ src/libreminesgui.cpp | 26 +++++++++++++-------------
+ src/libreminesgui.h   |  2 +-
+ 2 files changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/src/libreminesgui.cpp b/src/libreminesgui.cpp
+index cdcd6cf..67a7679 100644
+--- a/src/libreminesgui.cpp
++++ b/src/libreminesgui.cpp
+@@ -59,8 +59,8 @@ LibreMinesGui::LibreMinesGui(QWidget *parent, const int thatWidth, const int tha
+     cellLength( 0 ),
+     difficult( NONE ),
+     preferences( new LibreMinesPreferencesDialog(this) ),
+-    dirAppData( QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) ),
+-    sound( new SoundEffects() )
++    dirAppData( QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) )/*,*/
++    // sound( new SoundEffects() )
+ {
+     this->resize(800, 600);
+ 
+@@ -1188,7 +1188,7 @@ void LibreMinesGui::SLOT_showCell(const uchar _X, const uchar _Y)
+     }
+ 
+ 
+-    Q_EMIT(sound->SIGNAL_releaseCell());
++    // Q_EMIT(sound->SIGNAL_releaseCell());
+ }
+ 
+ void LibreMinesGui::SLOT_endGameScore(LibreMinesScore score,
+@@ -1357,7 +1357,7 @@ void LibreMinesGui::SLOT_flagCell(const uchar _X, const uchar _Y)
+         vKeyboardControllerSetCurrentCell(controller.currentX, controller.currentY);
+     }
+ 
+-    Q_EMIT(sound->SIGNAL_flagCell());
++    // Q_EMIT(sound->SIGNAL_flagCell());
+ }
+ 
+ void LibreMinesGui::SLOT_unflagCell(const uchar _X, const uchar _Y)
+@@ -1375,7 +1375,7 @@ void LibreMinesGui::SLOT_unflagCell(const uchar _X, const uchar _Y)
+         vKeyboardControllerSetCurrentCell(controller.currentX, controller.currentY);
+     }
+ 
+-    Q_EMIT(sound->SIGNAL_flagCell());
++    // Q_EMIT(sound->SIGNAL_flagCell());
+ }
+ 
+ void LibreMinesGui::SLOT_remakeGame()
+@@ -1422,7 +1422,7 @@ void LibreMinesGui::SLOT_gameWon()
+ 
+     labelFaceReactionInGame->setPixmap(*pmGrinningFace);
+ 
+-    Q_EMIT(sound->SIGNAL_gameWon());
++    // Q_EMIT(sound->SIGNAL_gameWon());
+ }
+ 
+ void LibreMinesGui::SLOT_gameLost(const uchar _X, const uchar _Y)
+@@ -1487,7 +1487,7 @@ void LibreMinesGui::SLOT_gameLost(const uchar _X, const uchar _Y)
+     }
+ 
+     labelFaceReactionInGame->setPixmap(*pmDizzyFace);
+-    Q_EMIT(sound->SIGNAL_gameLost());
++    // Q_EMIT(sound->SIGNAL_gameLost());
+ }
+ 
+ void LibreMinesGui::SLOT_optionChanged(const QString &name, const QString &value)
+@@ -1738,7 +1738,7 @@ void LibreMinesGui::vKeyboardControllerMoveLeft()
+ 
+     vKeyboardControllerSetCurrentCell(destX, controller.currentY);
+ 
+-    Q_EMIT(sound->SIGNAL_keyboardControllerMove());
++    // Q_EMIT(sound->SIGNAL_keyboardControllerMove());
+ }
+ 
+ void LibreMinesGui::vKeyboardControllerMoveRight()
+@@ -1772,7 +1772,7 @@ void LibreMinesGui::vKeyboardControllerMoveRight()
+ 
+     vKeyboardControllerSetCurrentCell(destX, controller.currentY);
+ 
+-    Q_EMIT(sound->SIGNAL_keyboardControllerMove());
++    // Q_EMIT(sound->SIGNAL_keyboardControllerMove());
+ }
+ 
+ void LibreMinesGui::vKeyboardControllerMoveDown()
+@@ -1806,7 +1806,7 @@ void LibreMinesGui::vKeyboardControllerMoveDown()
+ 
+     vKeyboardControllerSetCurrentCell(controller.currentX, destY);
+ 
+-    Q_EMIT(sound->SIGNAL_keyboardControllerMove());
++    // Q_EMIT(sound->SIGNAL_keyboardControllerMove());
+ }
+ 
+ void LibreMinesGui::vKeyboardControllerMoveUp()
+@@ -1840,7 +1840,7 @@ void LibreMinesGui::vKeyboardControllerMoveUp()
+ 
+     vKeyboardControllerSetCurrentCell(controller.currentX, destY);
+ 
+-    Q_EMIT(sound->SIGNAL_keyboardControllerMove());
++    // Q_EMIT(sound->SIGNAL_keyboardControllerMove());
+ }
+ 
+ void LibreMinesGui::vKeyboardControllerCenterCurrentCell()
+@@ -1883,6 +1883,6 @@ void LibreMinesGui::vUpdatePreferences()
+ #endif
+     }
+ 
+-    sound->setVolume(preferences->optionSoundVolume());
+-    sound->setMuted(preferences->optionSoundVolume() == 0);
++    // sound->setVolume(preferences->optionSoundVolume());
++    // sound->setMuted(preferences->optionSoundVolume() == 0);
+ }
+diff --git a/src/libreminesgui.h b/src/libreminesgui.h
+index 8f97244..82cc6a2 100644
+--- a/src/libreminesgui.h
++++ b/src/libreminesgui.h
+@@ -287,6 +287,6 @@ private:
+ 
+     QDir dirAppData;
+ 
+-    QScopedPointer<SoundEffects> sound;
++    // QScopedPointer<SoundEffects> sound;
+ };
+ #endif // LIBREMINESGUI_H
+-- 
+2.37.2
+

--- a/patches/qtbase6/0001-Add-Managarm-support.patch
+++ b/patches/qtbase6/0001-Add-Managarm-support.patch
@@ -1,4 +1,4 @@
-From ff8971212ec4b8c820b08fa69b5fe123b34dec29 Mon Sep 17 00:00:00 2001
+From e8912eccb24096955c0e77656c51d6fb90298b53 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Tue, 12 Apr 2022 15:50:25 +0200
 Subject: [PATCH] Add Managarm support
@@ -12,21 +12,23 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  mkspecs/managarm-g++/qmake.conf               | 12 +++
  mkspecs/managarm-g++/qplatformdefs.h          | 88 +++++++++++++++++++
  src/corelib/global/qsystemdetection.h         |  2 +
+ src/corelib/io/qstandardpaths_unix.cpp        |  4 +-
  src/corelib/io/qstorageinfo_unix.cpp          |  3 +
+ src/corelib/thread/qthread_unix.cpp           |  2 +-
  src/gui/configure.cmake                       |  4 +-
  src/network/kernel/qdnslookup_unix.cpp        |  2 +-
  src/network/kernel/qnetworkinterface_unix.cpp |  4 +
  .../kmsconvenience/qkmsdevice.cpp             |  1 +
- 12 files changed, 174 insertions(+), 5 deletions(-)
+ 14 files changed, 177 insertions(+), 8 deletions(-)
  create mode 100644 mkspecs/common/managarm.conf
  create mode 100644 mkspecs/managarm-g++/qmake.conf
  create mode 100644 mkspecs/managarm-g++/qplatformdefs.h
 
 diff --git a/cmake/QtBuild.cmake b/cmake/QtBuild.cmake
-index 3d10fc38..d78d0e01 100644
+index bb7049e7..ee547b21 100644
 --- a/cmake/QtBuild.cmake
 +++ b/cmake/QtBuild.cmake
-@@ -316,6 +316,12 @@ elseif(LINUX)
+@@ -314,6 +314,12 @@ elseif(LINUX)
      elseif(CLANG)
          set(QT_DEFAULT_MKSPEC linux-clang)
      endif()
@@ -40,7 +42,7 @@ index 3d10fc38..d78d0e01 100644
      if(GCC)
          set(QT_DEFAULT_MKSPEC android-g++)
 diff --git a/cmake/QtPlatformSupport.cmake b/cmake/QtPlatformSupport.cmake
-index 11b31641..b54352b9 100644
+index 22c6b9e0..4b61a10e 100644
 --- a/cmake/QtPlatformSupport.cmake
 +++ b/cmake/QtPlatformSupport.cmake
 @@ -7,6 +7,7 @@ function(qt_set01 result)
@@ -110,10 +112,10 @@ index 00000000..e7ea7d13
 +QMAKE_STRIP             = strip
 +QMAKE_STRIPFLAGS_LIB   += --strip-unneeded
 diff --git a/mkspecs/common/posix/qplatformdefs.h b/mkspecs/common/posix/qplatformdefs.h
-index 3ebc5233..8a8cff25 100644
+index ffae2ac3..3196f1b1 100644
 --- a/mkspecs/common/posix/qplatformdefs.h
 +++ b/mkspecs/common/posix/qplatformdefs.h
-@@ -48,7 +48,7 @@
+@@ -12,7 +12,7 @@
  #endif
  #include <sys/stat.h>
  
@@ -122,7 +124,7 @@ index 3ebc5233..8a8cff25 100644
  
  #define QT_STATBUF              struct stat64
  #define QT_FPOS_T               fpos64_t
-@@ -141,7 +141,7 @@
+@@ -105,7 +105,7 @@
  
  #if defined(QT_LARGEFILE_SUPPORT) \
          && defined(QT_USE_XOPEN_LFS_EXTENSIONS) \
@@ -244,10 +246,10 @@ index 00000000..91654548
 +
 +#endif // QPLATFORMDEFS_H
 diff --git a/src/corelib/global/qsystemdetection.h b/src/corelib/global/qsystemdetection.h
-index c8f98042..550d819b 100644
+index cbbe613e..072c219b 100644
 --- a/src/corelib/global/qsystemdetection.h
 +++ b/src/corelib/global/qsystemdetection.h
-@@ -165,6 +165,8 @@
+@@ -129,6 +129,8 @@
  #  define Q_OS_VXWORKS
  #elif defined(__HAIKU__)
  #  define Q_OS_HAIKU
@@ -256,11 +258,29 @@ index c8f98042..550d819b 100644
  #elif defined(__MAKEDEPEND__)
  #else
  #  error "Qt has not been ported to this OS - see http://www.qt-project.org/"
+diff --git a/src/corelib/io/qstandardpaths_unix.cpp b/src/corelib/io/qstandardpaths_unix.cpp
+index e5122ff3..9b60f6b2 100644
+--- a/src/corelib/io/qstandardpaths_unix.cpp
++++ b/src/corelib/io/qstandardpaths_unix.cpp
+@@ -160,11 +160,11 @@ static bool checkXdgRuntimeDir(const QString &xdgRuntimeDir)
+ 
+     // "and he MUST be the only one having read and write access to it. Its Unix access mode MUST be 0700."
+     if (metaData.permissions() != wantedPerms) {
+-        qWarning("QStandardPaths: wrong permissions on runtime directory %ls, %s instead of %s",
++        qWarning("QStandardPaths: wrong permissions on runtime directory %ls, %s instead of %s (Managarm ignores it!)",
+                  qUtf16Printable(xdgRuntimeDir),
+                  unixPermissionsText(metaData.permissions()).constData(),
+                  unixPermissionsText(wantedPerms).constData());
+-        return false;
++        // return false;
+     }
+ 
+     return true;
 diff --git a/src/corelib/io/qstorageinfo_unix.cpp b/src/corelib/io/qstorageinfo_unix.cpp
-index 2b635f63..ef151f7b 100644
+index 89b6dfea..34188433 100644
 --- a/src/corelib/io/qstorageinfo_unix.cpp
 +++ b/src/corelib/io/qstorageinfo_unix.cpp
-@@ -100,6 +100,9 @@
+@@ -64,6 +64,9 @@
  #elif defined(Q_OS_HAIKU)
  #  define QT_STATFSBUF struct statvfs
  #  define QT_STATFS    ::statvfs
@@ -270,20 +290,33 @@ index 2b635f63..ef151f7b 100644
  #else
  #  if defined(QT_LARGEFILE_SUPPORT)
  #    define QT_STATFSBUF struct statvfs64
+diff --git a/src/corelib/thread/qthread_unix.cpp b/src/corelib/thread/qthread_unix.cpp
+index 777aa362..8671eb19 100644
+--- a/src/corelib/thread/qthread_unix.cpp
++++ b/src/corelib/thread/qthread_unix.cpp
+@@ -675,7 +675,7 @@ void QThread::start(Priority priority)
+ 
+ 
+     if (d->stackSize > 0) {
+-#if defined(_POSIX_THREAD_ATTR_STACKSIZE) && (_POSIX_THREAD_ATTR_STACKSIZE-0 > 0)
++#if (defined(_POSIX_THREAD_ATTR_STACKSIZE) && (_POSIX_THREAD_ATTR_STACKSIZE-0 > 0)) || defined(__managarm__)
+         int code = pthread_attr_setstacksize(&attr, d->stackSize);
+ #else
+         int code = ENOSYS; // stack size not supported, automatically fail
 diff --git a/src/gui/configure.cmake b/src/gui/configure.cmake
-index f59f0ab2..5af332df 100644
+index 6b05d4cc..55f877a3 100644
 --- a/src/gui/configure.cmake
 +++ b/src/gui/configure.cmake
 @@ -25,7 +25,7 @@ set_property(CACHE INPUT_libpng PROPERTY STRINGS undefined no qt system)
  
  
  #### Libraries
--qt_set01(X11_SUPPORTED LINUX OR HPUX OR FREEBSD OR NETBSD OR OPENBSD OR SOLARIS) # special case
-+qt_set01(X11_SUPPORTED LINUX OR HPUX OR FREEBSD OR NETBSD OR OPENBSD OR SOLARIS OR MANAGARM) # special case
+-qt_set01(X11_SUPPORTED LINUX OR HPUX OR FREEBSD OR NETBSD OR OPENBSD OR SOLARIS OR HURD) # special case
++qt_set01(X11_SUPPORTED LINUX OR HPUX OR FREEBSD OR NETBSD OR OPENBSD OR SOLARIS OR HURD OR MANAGARM) # special case
  qt_find_package(ATSPI2 PROVIDED_TARGETS PkgConfig::ATSPI2 MODULE_NAME gui QMAKE_LIB atspi)
  qt_find_package(DirectFB PROVIDED_TARGETS PkgConfig::DirectFB MODULE_NAME gui QMAKE_LIB directfb)
  qt_find_package(Libdrm PROVIDED_TARGETS Libdrm::Libdrm MODULE_NAME gui QMAKE_LIB drm)
-@@ -51,7 +51,7 @@ qt_find_package(WrapOpenGL PROVIDED_TARGETS WrapOpenGL::WrapOpenGL MODULE_NAME g
+@@ -55,7 +55,7 @@ qt_find_package(WrapOpenGL PROVIDED_TARGETS WrapOpenGL::WrapOpenGL MODULE_NAME g
  qt_find_package(GLESv2 PROVIDED_TARGETS GLESv2::GLESv2 MODULE_NAME gui QMAKE_LIB opengl_es2)
  qt_find_package(Tslib PROVIDED_TARGETS PkgConfig::Tslib MODULE_NAME gui QMAKE_LIB tslib)
  qt_find_package(WrapVulkanHeaders PROVIDED_TARGETS WrapVulkanHeaders::WrapVulkanHeaders MODULE_NAME gui QMAKE_LIB vulkan MARK_OPTIONAL) # special case
@@ -293,10 +326,10 @@ index f59f0ab2..5af332df 100644
  endif()
  if((X11_SUPPORTED) OR QT_FIND_ALL_PACKAGES_ALWAYS)
 diff --git a/src/network/kernel/qdnslookup_unix.cpp b/src/network/kernel/qdnslookup_unix.cpp
-index 1449c329..88fcd997 100644
+index 75f7c6c4..5597bb85 100644
 --- a/src/network/kernel/qdnslookup_unix.cpp
 +++ b/src/network/kernel/qdnslookup_unix.cpp
-@@ -50,7 +50,7 @@
+@@ -14,7 +14,7 @@
  #include <sys/types.h>
  #include <netinet/in.h>
  #include <arpa/nameser.h>
@@ -306,10 +339,10 @@ index 1449c329..88fcd997 100644
  #endif
  #include <resolv.h>
 diff --git a/src/network/kernel/qnetworkinterface_unix.cpp b/src/network/kernel/qnetworkinterface_unix.cpp
-index 94f3a53c..40943178 100644
+index 51a266b2..08bb7125 100644
 --- a/src/network/kernel/qnetworkinterface_unix.cpp
 +++ b/src/network/kernel/qnetworkinterface_unix.cpp
-@@ -61,6 +61,10 @@
+@@ -25,6 +25,10 @@
  # include <ifaddrs.h>
  #endif
  
@@ -321,10 +354,10 @@ index 94f3a53c..40943178 100644
  #  include <arpa/inet.h>
  #  ifndef SIOCGIFBRDADDR
 diff --git a/src/platformsupport/kmsconvenience/qkmsdevice.cpp b/src/platformsupport/kmsconvenience/qkmsdevice.cpp
-index 4206b20a..71127dd8 100644
+index c7a1624e..df2ba09f 100644
 --- a/src/platformsupport/kmsconvenience/qkmsdevice.cpp
 +++ b/src/platformsupport/kmsconvenience/qkmsdevice.cpp
-@@ -48,6 +48,7 @@
+@@ -12,6 +12,7 @@
  #include <QtCore/QLoggingCategory>
  
  #include <errno.h>
@@ -333,5 +366,5 @@ index 4206b20a..71127dd8 100644
  #define ARRAY_LENGTH(a) (sizeof (a) / sizeof (a)[0])
  
 -- 
-2.35.2
+2.37.2
 


### PR DESCRIPTION
This PR updates the following packages:

- `host-qt6`, from version 6.3.0 to version 6.4.0;
- `qtbase6`, from version 6.3.0 to version 6.4.0;
- `qtimageformats6`, from version 6.3.0 to version 6.4.0;
- `qtlanguageserver6`, from version 6.3.0 to version 6.4.0;
- `qtshadertools6`, from version 6.3.0 to version 6.4.0;
- `qtsvg6`, from version 6.3.0 to version 6.4.0;
- `qtdeclarative6`, from version 6.3.0 to version 6.4.0;
- `qtmultimedia6`, from version 6.3.0 to version 6.4.0;
- `libremines` got a patch to disable sound.

Furthermore, `qtwayland6` got added as a port, allowing us to run Qt6 based GUI applications without X11/XWayland running.