### PR TITLE
Add a cmatrix port

### DIFF
--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -37,6 +37,43 @@ packages:
       # Fix a small permission issue during installation
       - args: ['chmod', '0755', '@THIS_COLLECT_DIR@/etc/ssl/certs/.']
 
+  - name: cmatrix
+    labels: [aarch64]
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: An ncurses based app to show a scrolling screen from the Matrix
+      description: This package provides a classic Matrix screen
+      spdx: 'GPL-2.0-only'
+      website: 'https://github.com/abishekvashok/cmatrix'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-misc']
+    source:
+      subdir: ports
+      git: 'https://github.com/abishekvashok/cmatrix.git'
+      tag: 'v2.0'
+      version: '2.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - ncurses
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--without-fonts'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: sl
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -1,5 +1,7 @@
 packages:
   - name: ca-certificates
+    labels: [aarch64]
+    architecture: noarch
     metadata:
       summary: Common CA certificates PEM files
       description: This package provides the standard set of Certificate Authorities as chosen by Mozilla in their NSS project  It also includes a script to (re)generate the certificate files.
@@ -7,8 +9,6 @@ packages:
       website: 'https://packages.debian.org/sid/ca-certificates'
       maintainer: "Dennis Bonke <dennis@managarm.org>"
       categories: ['app-misc']
-    labels: [aarch64]
-    architecture: noarch
     source:
       subdir: ports
       git: 'https://github.com/djlucas/make-ca.git'

--- a/bootstrap.d/app-misc.yml
+++ b/bootstrap.d/app-misc.yml
@@ -75,6 +75,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: sl
+    labels: [aarch64]
     architecture: '@OPTION:arch@'
     metadata:
       summary: Never type 'ls' wrong again!
@@ -94,7 +95,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 4
+    revision: 5
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:


### PR DESCRIPTION
This PR adds a `cmatrix` port, enables `sl` for AArch64 and fixes some metadata ordering.