### PR TITLE
nyancat: Add missing metadata and build on AArch64

### DIFF
--- a/bootstrap.d/games-misc.yml
+++ b/bootstrap.d/games-misc.yml
@@ -64,7 +64,15 @@ packages:
         quiet: true
 
   - name: nyancat
+    labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: The famous nyancat
+      description: This package provides Nyancat in your terminal, rendered through ANSI escape sequences.
+      spdx: 'no-spdx: UoI-NCSA'
+      website: 'https://github.com/klange/nyancat'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['games-misc']
     source:
       subdir: 'ports'
       git: 'https://github.com/klange/nyancat.git'


### PR DESCRIPTION
Can't leave AArch64 without nyancat can we? Untested but I see no issues with this build.