### PR TITLE
mlibc: switch to using external linux kernel headers

### DIFF
--- a/bootstrap.d/sys-kernel.yml
+++ b/bootstrap.d/sys-kernel.yml
@@ -1,0 +1,37 @@
+packages:
+  - name: linux-headers
+    labels: [aarch64, riscv64]
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Linux kernel headers
+      description: This package provides the Linux headers installed into /usr/include
+      spdx: 'GPL-2.0-only'
+      website: 'https://kernel.org'
+      maintainer: "no92 <no92.mail@gmail.com>"
+      categories: ['sys-kernel']
+    source:
+      subdir: 'ports'
+      url: 'https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.1.8.tar.xz'
+      checksum: 'blake2b:1eeab95bf09757131031ebeaa3fb66f01626ecfe3b72d0044176613d027ac6643c688a0bb8f4493ae6faa3d3bf0c89fcdff3c28d7b8375e59ed6e8bd6d856e44'
+      extract_path: 'linux-6.1.8'
+      format: 'tar.xz'
+      version: '6.1.8'
+    configure:
+      - args: ['cp', '-Tr', '@THIS_SOURCE_DIR@', '.']
+    build:
+      - args: |
+          LINUX_ARCH="@OPTION:arch@"
+          case "$LINUX_ARCH" in
+            "aarch64")
+              LINUX_ARCH="arm64"
+              ;;
+            "riscv64")
+              LINUX_ARCH="riscv"
+              ;;
+          esac
+          make ARCH="$LINUX_ARCH" headers_install
+      - args: ['find', 'usr/include', '-type', 'f', '!', '-name', '*.h', '-delete']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr']
+      # remove this file, as mlibc will override this file with one suited to mlibc
+      - args: ['rm', 'usr/include/linux/libc-compat.h']
+      - args: ['cp', '-r', 'usr/include', '@THIS_COLLECT_DIR@/usr']

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -28,6 +28,7 @@ imports:
   - file: bootstrap.d/sys-auth.yml
   - file: bootstrap.d/sys-boot.yml
   - file: bootstrap.d/sys-devel.yml
+  - file: bootstrap.d/sys-kernel.yml
   - file: bootstrap.d/sys-libs.yml
   - file: bootstrap.d/sys-process.yml
   - file: bootstrap.d/www-client.yml
@@ -1236,10 +1237,12 @@ packages:
       # These are not strictly necessary.
       - host-managarm-tools
       - host-protoc
-    revision: 2
+    pkgs_required:
+      - linux-headers
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -1249,6 +1252,7 @@ packages:
         - '-Ddisable_crypt_option=true'
         - '-Ddisable_iconv_option=true'
         - '-Ddisable_intl_option=true'
+        - '-Dlinux_kernel_headers=@BUILD_ROOT@/packages/linux-headers/usr/include'
     build:
       - args: ['ninja']
       - args: ['ninja', 'install']
@@ -1275,13 +1279,14 @@ packages:
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
     pkgs_required:
+      - linux-headers
       - mlibc-headers
       - frigg
       - cxxshim
-    revision: 2
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -1292,6 +1297,7 @@ packages:
         - '-Ddisable_crypt_option=true'
         - '-Ddisable_iconv_option=true'
         - '-Ddisable_intl_option=true'
+        - '-Dlinux_kernel_headers=@BUILD_ROOT@/packages/linux-headers/usr/include'
         - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']


### PR DESCRIPTION
Hard blocked on managarm/mlibc#784.