### PR TITLE
ci: Fix the system-toolchain job after the kernel headers

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,6 +4,7 @@ jobs:
       - bootstrap-system-gcc
       - system-gcc
     packages:
+      - linux-headers
       - mlibc
       - mlibc-headers
 


### PR DESCRIPTION
Fixes broken xbbs after #221, or so we hope.