### PR TITLE
llvm: Update from version 14.0.5 to 16.0.6

### DIFF
--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -763,8 +763,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/mesa/mesa.git'
-      tag: 'mesa-21.3.5'
-      version: '21.3.5'
+      tag: 'mesa-23.0.2'
+      version: '23.0.2'
       tools_required:
         - host-pkg-config
     tools_required:
@@ -791,7 +791,8 @@ packages:
       - libxext
       - libxcb
       - libglvnd
-    revision: 9
+      - libexpat
+      - zstd
     configure:
       - args: ['cp', '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file', 'meson.cross-file']
       - args:
@@ -819,6 +820,17 @@ packages:
         - '-Dglvnd=true'
         # Force Mesa to build with LLVM.
         - '-Dllvm=enabled'
+        - '-Dgallium-nine=false'
+        - '-Dgallium-va=disabled'
+        - '-Dgallium-vdpau=disabled'
+        - '-Dgallium-xa=disabled'
+        - '-Dshared-glapi=enabled'
+        - '-Ddri3=enabled'
+        - '-Degl=enabled'
+        - '-Dgbm=enabled'
+        - '-Dgles1=enabled'
+        - '-Dgles2=enabled'
+        - '-Dzstd=enabled'
         - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -116,8 +116,8 @@ sources:
   - name: llvm
     subdir: 'ports'
     git: 'https://github.com/llvm/llvm-project'
-    tag: 'llvmorg-14.0.5'
-    version: '14.0.5'
+    tag: 'llvmorg-16.0.6'
+    version: '16.0.6'
 
   - name: gcc
     subdir: 'ports'
@@ -1027,7 +1027,6 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/patches/llvm/0001-Managarm-specific-changes.patch
+++ b/patches/llvm/0001-Managarm-specific-changes.patch
@@ -1,4 +1,4 @@
-From d30c07fc77aa02e4b2442a60f87ab8fe671c134c Mon Sep 17 00:00:00 2001
+From 7cda368ea2c9cba8cb1f45cf8bf07c37d9ce2fb0 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Mon, 14 Feb 2022 08:28:17 +0100
 Subject: [PATCH 1/2] Managarm-specific changes
@@ -13,12 +13,12 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  5 files changed, 8 insertions(+), 6 deletions(-)
 
 diff --git a/llvm/cmake/modules/CrossCompile.cmake b/llvm/cmake/modules/CrossCompile.cmake
-index 2a39b6a40..ceceb2aab 100644
+index a46a0fd63..1f0f07fe5 100644
 --- a/llvm/cmake/modules/CrossCompile.cmake
 +++ b/llvm/cmake/modules/CrossCompile.cmake
 @@ -17,8 +17,8 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
        -DCMAKE_TOOLCHAIN_FILE=\"${LLVM_MAIN_SRC_DIR}/cmake/platforms/${toolchain}.cmake\")
-   else()
+   elseif (NOT CMAKE_CROSSCOMPILING)
      set(CROSS_TOOLCHAIN_FLAGS_INIT
 -      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
 -      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
@@ -28,11 +28,11 @@ index 2a39b6a40..ceceb2aab 100644
    endif()
    set(CROSS_TOOLCHAIN_FLAGS_${target_name} ${CROSS_TOOLCHAIN_FLAGS_INIT}
 diff --git a/llvm/include/llvm/Support/SwapByteOrder.h b/llvm/include/llvm/Support/SwapByteOrder.h
-index e8612ba66..56d3dd721 100644
+index 9dd08665b..1ef9b5586 100644
 --- a/llvm/include/llvm/Support/SwapByteOrder.h
 +++ b/llvm/include/llvm/Support/SwapByteOrder.h
-@@ -22,7 +22,7 @@
- #endif
+@@ -20,7 +20,7 @@
+ #include <type_traits>
  
  #if defined(__linux__) || defined(__GNU__) || defined(__HAIKU__) ||            \
 -    defined(__Fuchsia__) || defined(__EMSCRIPTEN__)
@@ -41,7 +41,7 @@ index e8612ba66..56d3dd721 100644
  #elif defined(_AIX)
  #include <sys/machine.h>
 diff --git a/llvm/lib/Support/Unix/Path.inc b/llvm/lib/Support/Unix/Path.inc
-index 788460d65..02728957f 100644
+index 3efcad4f2..6e68fb905 100644
 --- a/llvm/lib/Support/Unix/Path.inc
 +++ b/llvm/lib/Support/Unix/Path.inc
 @@ -74,7 +74,7 @@ extern char **environ;
@@ -62,7 +62,7 @@ index 788460d65..02728957f 100644
  #if defined(HAVE_LINUX_MAGIC_H)
  #include <linux/magic.h>
  #else
-@@ -478,7 +478,7 @@ std::error_code remove(const Twine &path, bool IgnoreNonExisting) {
+@@ -472,7 +472,7 @@ std::error_code remove(const Twine &path, bool IgnoreNonExisting) {
  }
  
  static bool is_local_impl(struct STATVFS &Vfs) {
@@ -72,7 +72,7 @@ index 788460d65..02728957f 100644
  #define NFS_SUPER_MAGIC 0x6969
  #endif
 diff --git a/llvm/tools/llvm-dwarfdump/Statistics.cpp b/llvm/tools/llvm-dwarfdump/Statistics.cpp
-index 5c08e43b4..516d22d45 100644
+index a967abffc..654403791 100644
 --- a/llvm/tools/llvm-dwarfdump/Statistics.cpp
 +++ b/llvm/tools/llvm-dwarfdump/Statistics.cpp
 @@ -6,6 +6,7 @@
@@ -84,7 +84,7 @@ index 5c08e43b4..516d22d45 100644
  #include "llvm/ADT/DenseMap.h"
  #include "llvm/ADT/StringSet.h"
 diff --git a/llvm/tools/llvm-shlib/CMakeLists.txt b/llvm/tools/llvm-shlib/CMakeLists.txt
-index 8e2b78f1b..4c6763391 100644
+index 90e290435..617bcb524 100644
 --- a/llvm/tools/llvm-shlib/CMakeLists.txt
 +++ b/llvm/tools/llvm-shlib/CMakeLists.txt
 @@ -36,6 +36,7 @@ if(LLVM_BUILD_LLVM_DYLIB)
@@ -96,5 +96,5 @@ index 8e2b78f1b..4c6763391 100644
       OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "Fuchsia")
       OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "DragonFly")
 -- 
-2.35.1
+2.40.0
 

--- a/patches/llvm/0002-Add-Managarm-target.patch
+++ b/patches/llvm/0002-Add-Managarm-target.patch
@@ -1,4 +1,4 @@
-From c367e444fe659d83c6ee5620d367ab16ae095470 Mon Sep 17 00:00:00 2001
+From a789a978ca1913ac1571330b4e00015e2859bf4b Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Sat, 2 Apr 2022 19:44:10 +0200
 Subject: [PATCH 2/2] Add Managarm target
@@ -12,17 +12,17 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  clang/lib/Driver/ToolChains/Gnu.cpp      |  13 +-
  clang/lib/Driver/ToolChains/Managarm.cpp | 432 +++++++++++++++++++++++
  clang/lib/Driver/ToolChains/Managarm.h   |  49 +++
- llvm/include/llvm/ADT/Triple.h           |   5 +-
- llvm/lib/Support/Triple.cpp              |   6 +
+ llvm/include/llvm/TargetParser/Triple.h  |   5 +-
+ llvm/lib/TargetParser/Triple.cpp         |   6 +
  9 files changed, 542 insertions(+), 4 deletions(-)
  create mode 100644 clang/lib/Driver/ToolChains/Managarm.cpp
  create mode 100644 clang/lib/Driver/ToolChains/Managarm.h
 
 diff --git a/clang/lib/Basic/Targets.cpp b/clang/lib/Basic/Targets.cpp
-index 994a491cd..e3df5bfa4 100644
+index 8400774db..b5688e6aa 100644
 --- a/clang/lib/Basic/Targets.cpp
 +++ b/clang/lib/Basic/Targets.cpp
-@@ -149,6 +149,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
+@@ -153,6 +153,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
        return new NetBSDTargetInfo<AArch64leTargetInfo>(Triple, Opts);
      case llvm::Triple::OpenBSD:
        return new OpenBSDTargetInfo<AArch64leTargetInfo>(Triple, Opts);
@@ -31,7 +31,7 @@ index 994a491cd..e3df5bfa4 100644
      case llvm::Triple::Win32:
        switch (Triple.getEnvironment()) {
        case llvm::Triple::GNU:
-@@ -420,6 +422,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
+@@ -424,6 +426,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
        return new FuchsiaTargetInfo<RISCV64TargetInfo>(Triple, Opts);
      case llvm::Triple::Linux:
        return new LinuxTargetInfo<RISCV64TargetInfo>(Triple, Opts);
@@ -40,7 +40,7 @@ index 994a491cd..e3df5bfa4 100644
      default:
        return new RISCV64TargetInfo(Triple, Opts);
      }
-@@ -586,6 +590,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
+@@ -590,6 +594,8 @@ TargetInfo *AllocateTarget(const llvm::Triple &Triple,
      }
      case llvm::Triple::Haiku:
        return new HaikuTargetInfo<X86_64TargetInfo>(Triple, Opts);
@@ -50,11 +50,11 @@ index 994a491cd..e3df5bfa4 100644
        return new NaClTargetInfo<X86_64TargetInfo>(Triple, Opts);
      case llvm::Triple::PS4:
 diff --git a/clang/lib/Basic/Targets/OSTargets.h b/clang/lib/Basic/Targets/OSTargets.h
-index 3c1830d5f..4e80429aa 100644
+index fd372cb12..b45c7a4da 100644
 --- a/clang/lib/Basic/Targets/OSTargets.h
 +++ b/clang/lib/Basic/Targets/OSTargets.h
-@@ -338,6 +338,36 @@ public:
-       : OSTargetInfo<Target>(Triple, Opts) {}
+@@ -340,6 +340,36 @@ public:
+   using OSTargetInfo<Target>::OSTargetInfo;
  };
  
 +// Managarm Target
@@ -91,11 +91,11 @@ index 3c1830d5f..4e80429aa 100644
  template <typename Target>
  class LLVM_LIBRARY_VISIBILITY MinixTargetInfo : public OSTargetInfo<Target> {
 diff --git a/clang/lib/Driver/CMakeLists.txt b/clang/lib/Driver/CMakeLists.txt
-index 78e8fd185..a3fbd19bd 100644
+index ba56a9323..309463336 100644
 --- a/clang/lib/Driver/CMakeLists.txt
 +++ b/clang/lib/Driver/CMakeLists.txt
-@@ -59,6 +59,7 @@ add_clang_library(clangDriver
-   ToolChains/Hexagon.cpp
+@@ -67,6 +67,7 @@ add_clang_library(clangDriver
+   ToolChains/HLSL.cpp
    ToolChains/Hurd.cpp
    ToolChains/Linux.cpp
 +  ToolChains/Managarm.cpp
@@ -103,10 +103,10 @@ index 78e8fd185..a3fbd19bd 100644
    ToolChains/MinGW.cpp
    ToolChains/Minix.cpp
 diff --git a/clang/lib/Driver/Driver.cpp b/clang/lib/Driver/Driver.cpp
-index 3bfddeefc..4d3341a1d 100644
+index a268f2fa8..fcc5eb38c 100644
 --- a/clang/lib/Driver/Driver.cpp
 +++ b/clang/lib/Driver/Driver.cpp
-@@ -30,6 +30,7 @@
+@@ -32,6 +32,7 @@
  #include "ToolChains/Hurd.h"
  #include "ToolChains/Lanai.h"
  #include "ToolChains/Linux.h"
@@ -114,7 +114,7 @@ index 3bfddeefc..4d3341a1d 100644
  #include "ToolChains/MSP430.h"
  #include "ToolChains/MSVC.h"
  #include "ToolChains/MinGW.h"
-@@ -5564,6 +5565,9 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
+@@ -6041,6 +6042,9 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
      case llvm::Triple::Fuchsia:
        TC = std::make_unique<toolchains::Fuchsia>(*this, Target, Args);
        break;
@@ -125,10 +125,10 @@ index 3bfddeefc..4d3341a1d 100644
        TC = std::make_unique<toolchains::Solaris>(*this, Target, Args);
        break;
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index 7a9570a68..5c561f970 100644
+index 4f2340316..73a0b6303 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -246,6 +246,8 @@ static const char *getLDMOption(const llvm::Triple &T, const ArgList &Args) {
+@@ -249,6 +249,8 @@ static const char *getLDMOption(const llvm::Triple &T, const ArgList &Args) {
        return "elf_iamcu";
      return "elf_i386";
    case llvm::Triple::aarch64:
@@ -137,7 +137,7 @@ index 7a9570a68..5c561f970 100644
      return "aarch64linux";
    case llvm::Triple::aarch64_be:
      return "aarch64linuxb";
-@@ -2073,7 +2075,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2218,7 +2220,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
    static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
    static const char *const AArch64Triples[] = {
        "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
@@ -147,7 +147,7 @@ index 7a9570a68..5c561f970 100644
    static const char *const AArch64beLibDirs[] = {"/lib"};
    static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
                                                   "aarch64_be-linux-gnu"};
-@@ -2099,7 +2102,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2248,7 +2251,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
        "x86_64-redhat-linux",    "x86_64-suse-linux",
        "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
        "x86_64-slackware-linux", "x86_64-unknown-linux",
@@ -157,7 +157,7 @@ index 7a9570a68..5c561f970 100644
    static const char *const X32Triples[] = {"x86_64-linux-gnux32",
                                             "x86_64-pc-linux-gnux32"};
    static const char *const X32LibDirs[] = {"/libx32", "/lib"};
-@@ -2171,7 +2175,10 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2324,7 +2328,10 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
    static const char *const RISCV64LibDirs[] = {"/lib64", "/lib"};
    static const char *const RISCV64Triples[] = {"riscv64-unknown-linux-gnu",
                                                 "riscv64-linux-gnu",
@@ -662,11 +662,11 @@ index 000000000..2d87decd8
 +} // end namespace clang
 +
 +#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_MANAGARM_H
-diff --git a/llvm/include/llvm/ADT/Triple.h b/llvm/include/llvm/ADT/Triple.h
-index 42277c013..e9db917ae 100644
---- a/llvm/include/llvm/ADT/Triple.h
-+++ b/llvm/include/llvm/ADT/Triple.h
-@@ -181,6 +181,7 @@ public:
+diff --git a/llvm/include/llvm/TargetParser/Triple.h b/llvm/include/llvm/TargetParser/Triple.h
+index 59513fa2f..21a54c99b 100644
+--- a/llvm/include/llvm/TargetParser/Triple.h
++++ b/llvm/include/llvm/TargetParser/Triple.h
+@@ -196,6 +196,7 @@ public:
      Linux,
      Lv2,        // PS3
      MacOSX,
@@ -674,22 +674,23 @@ index 42277c013..e9db917ae 100644
      NetBSD,
      OpenBSD,
      Solaris,
-@@ -232,7 +233,9 @@ public:
-     CoreCLR,
-     Simulator, // Simulator variants of other systems, e.g., Apple's iOS
-     MacABI, // Mac Catalyst variant of Apple's iOS deployment target.
--    LastEnvironmentType = MacABI
+@@ -273,8 +274,10 @@ public:
+     Callable,
+     Mesh,
+     Amplification,
 +    Kernel,
 +    System,
+ 
+-    LastEnvironmentType = Amplification
 +    LastEnvironmentType = System
    };
    enum ObjectFormatType {
      UnknownObjectFormat,
-diff --git a/llvm/lib/Support/Triple.cpp b/llvm/lib/Support/Triple.cpp
-index a9afcc9db..b1e7c8259 100644
---- a/llvm/lib/Support/Triple.cpp
-+++ b/llvm/lib/Support/Triple.cpp
-@@ -215,6 +215,7 @@ StringRef Triple::getOSTypeName(OSType Kind) {
+diff --git a/llvm/lib/TargetParser/Triple.cpp b/llvm/lib/TargetParser/Triple.cpp
+index a68035989..e5a69141e 100644
+--- a/llvm/lib/TargetParser/Triple.cpp
++++ b/llvm/lib/TargetParser/Triple.cpp
+@@ -227,6 +227,7 @@ StringRef Triple::getOSTypeName(OSType Kind) {
    case Linux: return "linux";
    case Lv2: return "lv2";
    case MacOSX: return "macosx";
@@ -697,7 +698,7 @@ index a9afcc9db..b1e7c8259 100644
    case Mesa3D: return "mesa3d";
    case Minix: return "minix";
    case NVCL: return "nvcl";
-@@ -251,6 +252,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
+@@ -268,6 +269,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
    case GNUX32: return "gnux32";
    case GNUILP32: return "gnu_ilp32";
    case Itanium: return "itanium";
@@ -705,15 +706,15 @@ index a9afcc9db..b1e7c8259 100644
    case MSVC: return "msvc";
    case MacABI: return "macabi";
    case Musl: return "musl";
-@@ -258,6 +260,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
+@@ -275,6 +277,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
    case MuslEABIHF: return "musleabihf";
    case MuslX32: return "muslx32";
    case Simulator: return "simulator";
 +  case System: return "system";
-   }
- 
-   llvm_unreachable("Invalid EnvironmentType!");
-@@ -523,6 +526,7 @@ static Triple::OSType parseOS(StringRef OSName) {
+   case Pixel: return "pixel";
+   case Vertex: return "vertex";
+   case Geometry: return "geometry";
+@@ -568,6 +571,7 @@ static Triple::OSType parseOS(StringRef OSName) {
      .StartsWith("linux", Triple::Linux)
      .StartsWith("lv2", Triple::Lv2)
      .StartsWith("macos", Triple::MacOSX)
@@ -721,15 +722,15 @@ index a9afcc9db..b1e7c8259 100644
      .StartsWith("netbsd", Triple::NetBSD)
      .StartsWith("openbsd", Triple::OpenBSD)
      .StartsWith("solaris", Triple::Solaris)
-@@ -574,6 +578,8 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
+@@ -625,6 +629,8 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
        .StartsWith("coreclr", Triple::CoreCLR)
        .StartsWith("simulator", Triple::Simulator)
        .StartsWith("macabi", Triple::MacABI)
 +      .StartsWith("kernel", Triple::Kernel)
 +      .StartsWith("system", Triple::System)
-       .Default(Triple::UnknownEnvironment);
- }
- 
+       .StartsWith("pixel", Triple::Pixel)
+       .StartsWith("vertex", Triple::Vertex)
+       .StartsWith("geometry", Triple::Geometry)
 -- 
-2.35.1
+2.40.0
 

--- a/patches/mesa/0001-Add-Managarm-support.patch
+++ b/patches/mesa/0001-Add-Managarm-support.patch
@@ -1,7 +1,7 @@
-From 9eb966dbf45e4d32b6cc1d008da3570f0f1398fc Mon Sep 17 00:00:00 2001
+From 0d4316091d39436e2aa0c5929348f97d27204270 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
-Date: Sun, 28 Nov 2021 13:34:43 +0100
-Subject: [PATCH 1/2] Add Managarm support
+Date: Sun, 16 Apr 2023 20:33:01 +0200
+Subject: [PATCH 1/3] Add Managarm support
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
@@ -10,16 +10,15 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  src/compiler/spirv/spirv_to_nir.c         | 1 +
  src/egl/main/egllog.c                     | 1 +
  src/gallium/drivers/llvmpipe/lp_texture.c | 1 -
- src/util/debug.c                          | 1 +
  src/util/detect_os.h                      | 8 ++++++++
  src/util/os_misc.c                        | 4 ++--
  src/util/os_time.c                        | 4 ++--
- src/util/u_printf.h                       | 2 ++
- src/util/u_thread.h                       | 4 ++--
- 11 files changed, 23 insertions(+), 10 deletions(-)
+ src/util/u_debug.c                        | 1 +
+ src/util/u_thread.c                       | 4 ++--
+ 10 files changed, 21 insertions(+), 10 deletions(-)
 
 diff --git a/include/drm-uapi/drm.h b/include/drm-uapi/drm.h
-index 5e54c3aa..631abe07 100644
+index c76325f..c42555b 100644
 --- a/include/drm-uapi/drm.h
 +++ b/include/drm-uapi/drm.h
 @@ -35,10 +35,11 @@
@@ -32,37 +31,37 @@ index 5e54c3aa..631abe07 100644
 +#include <sys/ioctl.h>
  #include <linux/types.h>
 -#include <asm/ioctl.h>
-+//#include <asm/ioctl.h>
++// #include <asm/ioctl.h>
  typedef unsigned int drm_handle_t;
  
  #else /* One of the BSDs */
 diff --git a/meson.build b/meson.build
-index 0aea3126..08dfafe3 100644
+index 4d26af3..d9cc4f0 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -164,7 +164,7 @@ with_any_opengl = with_opengl or with_gles1 or with_gles2
+@@ -174,7 +174,7 @@ with_any_opengl = with_opengl or with_gles1 or with_gles2
  # Only build shared_glapi if at least one OpenGL API is enabled
  with_shared_glapi = with_shared_glapi and with_any_opengl
  
--system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'gnu/kfreebsd', 'dragonfly', 'linux', 'sunos'].contains(host_machine.system())
-+system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'gnu/kfreebsd', 'dragonfly', 'linux', 'managarm', 'sunos'].contains(host_machine.system())
+-system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'gnu/kfreebsd', 'dragonfly', 'linux', 'sunos', 'android'].contains(host_machine.system())
++system_has_kms_drm = ['openbsd', 'netbsd', 'freebsd', 'gnu/kfreebsd', 'dragonfly', 'linux', 'sunos', 'android', 'managarm'].contains(host_machine.system())
  
- dri_drivers = get_option('dri-drivers')
- if dri_drivers.contains('auto')
+ with_freedreno_kgsl = get_option('freedreno-kgsl')
+ if with_freedreno_kgsl
 diff --git a/src/compiler/spirv/spirv_to_nir.c b/src/compiler/spirv/spirv_to_nir.c
-index 71cdc834..3d267050 100644
+index 5a21f4d..dbb9fd8 100644
 --- a/src/compiler/spirv/spirv_to_nir.c
 +++ b/src/compiler/spirv/spirv_to_nir.c
-@@ -37,6 +37,7 @@
- #include "util/u_string.h"
+@@ -38,6 +38,7 @@
+ #include "util/u_debug.h"
  
  #include <stdio.h>
 +#include <strings.h>
  
  #ifndef NDEBUG
- static enum nir_spirv_debug_level
+ uint32_t mesa_spirv_debug = 0;
 diff --git a/src/egl/main/egllog.c b/src/egl/main/egllog.c
-index 984dd5b1..6a919525 100644
+index 655e139..e4b88bd 100644
 --- a/src/egl/main/egllog.c
 +++ b/src/egl/main/egllog.c
 @@ -39,6 +39,7 @@
@@ -72,12 +71,12 @@ index 984dd5b1..6a919525 100644
 +#include <strings.h>
  #include "c11/threads.h"
  #include "util/macros.h"
- #include "util/u_string.h"
+ #include "util/simple_mtx.h"
 diff --git a/src/gallium/drivers/llvmpipe/lp_texture.c b/src/gallium/drivers/llvmpipe/lp_texture.c
-index 5bfc8dbc..d2b31e15 100644
+index c787167..37b6c95 100644
 --- a/src/gallium/drivers/llvmpipe/lp_texture.c
 +++ b/src/gallium/drivers/llvmpipe/lp_texture.c
-@@ -1102,7 +1102,6 @@ llvmpipe_resource_get_param(struct pipe_screen *screen,
+@@ -1151,7 +1151,6 @@ llvmpipe_resource_get_param(struct pipe_screen *screen,
     default:
        break;
     }
@@ -85,20 +84,8 @@ index 5bfc8dbc..d2b31e15 100644
     *value = 0;
     return false;
  }
-diff --git a/src/util/debug.c b/src/util/debug.c
-index 89ae6131..fbf45f4b 100644
---- a/src/util/debug.c
-+++ b/src/util/debug.c
-@@ -23,6 +23,7 @@
- 
- #include <errno.h>
- #include <string.h>
-+#include <strings.h>
- #include "debug.h"
- #include "u_string.h"
- 
 diff --git a/src/util/detect_os.h b/src/util/detect_os.h
-index 6506948e..469b502b 100644
+index 6506948..469b502 100644
 --- a/src/util/detect_os.h
 +++ b/src/util/detect_os.h
 @@ -81,6 +81,11 @@
@@ -123,7 +110,7 @@ index 6506948e..469b502b 100644
  
  #endif /* DETECT_OS_H */
 diff --git a/src/util/os_misc.c b/src/util/os_misc.c
-index 31f1c55d..71f3d600 100644
+index 538b3f6..b9ee3be 100644
 --- a/src/util/os_misc.c
 +++ b/src/util/os_misc.c
 @@ -57,7 +57,7 @@
@@ -135,7 +122,7 @@ index 31f1c55d..71f3d600 100644
  #  include <unistd.h>
  #elif DETECT_OS_OPENBSD || DETECT_OS_FREEBSD
  #  include <sys/resource.h>
-@@ -223,7 +223,7 @@ os_get_option(const char *name)
+@@ -246,7 +246,7 @@ exit_mutex:
  bool
  os_get_total_physical_memory(uint64_t *size)
  {
@@ -145,7 +132,7 @@ index 31f1c55d..71f3d600 100644
     const long page_size = sysconf(_SC_PAGE_SIZE);
  
 diff --git a/src/util/os_time.c b/src/util/os_time.c
-index d2edd881..c9fa9f8d 100644
+index c207b8f..3bf567a 100644
 --- a/src/util/os_time.c
 +++ b/src/util/os_time.c
 @@ -53,7 +53,7 @@
@@ -166,34 +153,33 @@ index d2edd881..c9fa9f8d 100644
     struct timespec time;
     time.tv_sec = usecs / 1000000;
     time.tv_nsec = (usecs % 1000000) * 1000;
-diff --git a/src/util/u_printf.h b/src/util/u_printf.h
-index 44dcce55..e9e23ba3 100644
---- a/src/util/u_printf.h
-+++ b/src/util/u_printf.h
-@@ -22,6 +22,8 @@
- #ifndef U_PRINTF_H
- #define U_PRINTF_H
+diff --git a/src/util/u_debug.c b/src/util/u_debug.c
+index a5f8512..d3d46d3 100644
+--- a/src/util/u_debug.c
++++ b/src/util/u_debug.c
+@@ -33,6 +33,7 @@
+ #include <inttypes.h>
  
-+#include <stdarg.h>
-+
- #ifdef __cplusplus
+ #include <stdio.h>
++#include <strings.h>
+ #include <limits.h> /* CHAR_BIT */
+ #include <ctype.h> /* isalnum */
  
- #include <string>
-diff --git a/src/util/u_thread.h b/src/util/u_thread.h
-index 013e8be6..d0a35829 100644
---- a/src/util/u_thread.h
-+++ b/src/util/u_thread.h
-@@ -129,7 +129,7 @@ static inline thrd_t u_thread_create(int (*routine)(void *), void *param)
- static inline void u_thread_setname( const char *name )
+diff --git a/src/util/u_thread.c b/src/util/u_thread.c
+index 55b6b68..c508733 100644
+--- a/src/util/u_thread.c
++++ b/src/util/u_thread.c
+@@ -75,7 +75,7 @@ int u_thread_create(thrd_t *thrd, int (*routine)(void *), void *param)
+ void u_thread_setname( const char *name )
  {
  #if defined(HAVE_PTHREAD)
--#if DETECT_OS_LINUX || DETECT_OS_CYGWIN || DETECT_OS_SOLARIS
-+#if DETECT_OS_LINUX || DETECT_OS_CYGWIN || DETECT_OS_SOLARIS || DETECT_OS_MANAGARM
+-#if DETECT_OS_LINUX || DETECT_OS_CYGWIN || DETECT_OS_SOLARIS || defined(__GLIBC__)
++#if DETECT_OS_LINUX || DETECT_OS_CYGWIN || DETECT_OS_SOLARIS || defined(__GLIBC__) || DETECT_OS_MANAGARM
     int ret = pthread_setname_np(pthread_self(), name);
     if (ret == ERANGE) {
        char buf[16];
-@@ -242,7 +242,7 @@ util_set_current_thread_affinity(const uint32_t *mask,
- static inline int64_t
+@@ -154,7 +154,7 @@ util_set_thread_affinity(thrd_t thread,
+ int64_t
  util_thread_get_time_nano(thrd_t thread)
  {
 -#if defined(HAVE_PTHREAD) && !defined(__APPLE__) && !defined(__HAIKU__)
@@ -202,5 +188,5 @@ index 013e8be6..d0a35829 100644
     clockid_t cid;
  
 -- 
-2.35.1
+2.40.0
 

--- a/patches/mesa/0002-Enable-DMABUF-for-managarm.patch
+++ b/patches/mesa/0002-Enable-DMABUF-for-managarm.patch
@@ -1,39 +1,26 @@
-From 93c64c34ef4428f7a3c99d8daaf463714fc58cdf Mon Sep 17 00:00:00 2001
-From: no92 <no92.mail@gmail.com>
-Date: Sun, 13 Feb 2022 20:59:57 +0100
-Subject: [PATCH 2/2] Enable DMABUF for managarm
+From 2e33718d41362fd893aee44a4200fbb38ae99253 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 16 Apr 2023 20:35:30 +0200
+Subject: [PATCH 2/3] Enable DMABUF for managarm
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  src/gallium/auxiliary/util/u_screen.c | 2 +-
- src/gallium/include/pipe/p_config.h   | 4 ++++
- 2 files changed, 5 insertions(+), 1 deletion(-)
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/gallium/auxiliary/util/u_screen.c b/src/gallium/auxiliary/util/u_screen.c
-index eba55460..a3dba010 100644
+index f0e1b7e..b6a1622 100644
 --- a/src/gallium/auxiliary/util/u_screen.c
 +++ b/src/gallium/auxiliary/util/u_screen.c
-@@ -411,7 +411,7 @@ u_pipe_screen_get_param_defaults(struct pipe_screen *pscreen,
+@@ -423,7 +423,7 @@ u_pipe_screen_get_param_defaults(struct pipe_screen *pscreen,
        return 0;
  
     case PIPE_CAP_DMABUF:
--#if defined(PIPE_OS_LINUX) || defined(PIPE_OS_BSD)
-+#if defined(PIPE_OS_LINUX) || defined(PIPE_OS_BSD) || defined(PIPE_OS_MANAGARM)
+-#if DETECT_OS_LINUX || DETECT_OS_BSD
++#if DETECT_OS_LINUX || DETECT_OS_BSD || DETECT_OS_MANAGARM
        return 1;
  #else
        return 0;
-diff --git a/src/gallium/include/pipe/p_config.h b/src/gallium/include/pipe/p_config.h
-index 978aa455..2a0d3679 100644
---- a/src/gallium/include/pipe/p_config.h
-+++ b/src/gallium/include/pipe/p_config.h
-@@ -197,4 +197,8 @@
- #define PIPE_OS_CYGWIN
- #endif
- 
-+#if DETECT_OS_MANAGARM
-+#define PIPE_OS_MANAGARM
-+#endif
-+
- #endif /* P_CONFIG_H_ */
 -- 
-2.35.1
+2.40.0
 

--- a/patches/mesa/0003-Disable-futex-for-managarm.patch
+++ b/patches/mesa/0003-Disable-futex-for-managarm.patch
@@ -1,6 +1,6 @@
-From 684cc3c8de02bb0d2184415627316433b907f3ff Mon Sep 17 00:00:00 2001
-From: no92 <no92.mail@gmail.com>
-Date: Wed, 8 Feb 2023 08:10:04 +0100
+From ec2e4bb1f1b14fe7e377d73f50bef3ddb209b18e Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 16 Apr 2023 20:36:43 +0200
 Subject: [PATCH 3/3] Disable futex for managarm
 
 With the new linux-headers, we now have a <linux/futex.h> present. mesa
@@ -9,12 +9,14 @@ the presence of this header, and not by OS - which is incorrect, as the
 code assumes Linux due to raw syscalls. Here, we change it to force both
 the header to be present and to be linux to use that path, and use the
 fallback for managarm (as has been the case previously)
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  src/util/futex.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/util/futex.h b/src/util/futex.h
-index 43097f4..98af1db 100644
+index c397507..995c1e2 100644
 --- a/src/util/futex.h
 +++ b/src/util/futex.h
 @@ -24,7 +24,7 @@
@@ -24,8 +26,8 @@ index 43097f4..98af1db 100644
 -#if defined(HAVE_LINUX_FUTEX_H)
 +#if defined(HAVE_LINUX_FUTEX_H) && defined(__linux__)
  #define UTIL_FUTEX_SUPPORTED 1
- 
- #include <limits.h>
+ #elif defined(__FreeBSD__)
+ #define UTIL_FUTEX_SUPPORTED 1
 -- 
-2.39.0
+2.40.0
 

--- a/scripts/cross-llvm-config
+++ b/scripts/cross-llvm-config
@@ -4,11 +4,11 @@ import argparse
 import os
 import sys
 
-our_version = 14
+our_version = 16
 
 
 def do_version():
-    return "{}.0.5".format(our_version)
+    return "{}.0.6".format(our_version)
 
 
 def do_components():


### PR DESCRIPTION
Also includes a bump for `mesa`. This LLVM version is needed for the `.clang-format` file I'm about to PR in.