### PR TITLE
gtklife: update checksum, use https

### DIFF
--- a/bootstrap.d/games-misc.yml
+++ b/bootstrap.d/games-misc.yml
@@ -3,9 +3,9 @@ packages:
     architecture: '@OPTION:arch@'
     source:
       subdir: 'ports'
-      url: 'http://ironphoenix.org/gtklife/gtklife-5.2.tar.gz'
+      url: 'https://ironphoenix.org/gtklife/gtklife-5.2.tar.gz'
       format: 'tar.gz'
-      checksum: blake2b:c6eb8e8fac94db2872a83060ed1b5fc96bb097dc2e43e90b0b82acdc65e36774e9e655a4cd523693cbe6f0d8bf8646b3fbd3fa7ea4fc01e9d60b5173d1199be9
+      checksum: blake2b:6da6de391d7cea869d387eda1310e59b1cd3ee251fd37e6c36807260585f9839f6c246d8f5dffc394fad4d633f910df744e7c5f617ca6c82d8416a79f832ebb5
       extract_path: 'gtklife-5.2'
       patch-path-strip: 1
       version: '5.2'
@@ -23,7 +23,7 @@ packages:
       - cairo
       - libx11
       - glib
-    revision: 4
+    revision: 5
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:


### PR DESCRIPTION
Apparently, the checksum for the archive changed despite not receiving a version bump. Checking with gpg against the authors public key is fine, though, so we need to update our blake2b hash.