### PR TITLE
libdrm: rebase patches and enable linux codepaths for managarm

### DIFF
--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -325,6 +325,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/patches/libdrm/0001-Managarm-specific-changes.patch
+++ b/patches/libdrm/0001-Managarm-specific-changes.patch
@@ -1,7 +1,7 @@
-From 59b5784340338b7ccea2f3a84f09ec11ed018494 Mon Sep 17 00:00:00 2001
+From 9020688267a917418d164960d407f83310e83d6c Mon Sep 17 00:00:00 2001
 From: Alexander van der Grinten <alexander.vandergrinten@gmail.com>
 Date: Wed, 13 Dec 2017 16:32:55 +0100
-Subject: [PATCH] Managarm-specific changes
+Subject: [PATCH 1/3] Managarm-specific changes
 
 TODO: Check if everything still works on Linux.
 ---
@@ -10,10 +10,10 @@ TODO: Check if everything still works on Linux.
  2 files changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/include/drm/drm.h b/include/drm/drm.h
-index c7fd2a3..4a231e0 100644
+index 398c396..b00ebbc 100644
 --- a/include/drm/drm.h
 +++ b/include/drm/drm.h
-@@ -36,10 +36,11 @@
+@@ -35,10 +35,11 @@
  #ifndef _DRM_H_
  #define _DRM_H_
  
@@ -28,7 +28,7 @@ index c7fd2a3..4a231e0 100644
  
  #else /* One of the BSDs */
 diff --git a/xf86drm.h b/xf86drm.h
-index 7b85079..4e9e5c9 100644
+index 4badaae..061cf7e 100644
 --- a/xf86drm.h
 +++ b/xf86drm.h
 @@ -47,7 +47,7 @@ extern "C" {
@@ -41,5 +41,5 @@ index 7b85079..4e9e5c9 100644
  #define DRM_IOCTL_NR(n)		_IOC_NR(n)
  #define DRM_IOC_VOID		_IOC_NONE
 -- 
-2.29.2
+2.40.1
 

--- a/patches/libdrm/0002-Add-more-managarm-specific-changes.patch
+++ b/patches/libdrm/0002-Add-more-managarm-specific-changes.patch
@@ -1,19 +1,19 @@
-From aff8fca2a694871322affc8a582f41a00607e2df Mon Sep 17 00:00:00 2001
+From 15bb868ed023ca26114c1a50cfbf25d4665e69ae Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Kacper=20S=C5=82omi=C5=84ski?=
  <kacper.slominski72@gmail.com>
 Date: Tue, 10 Dec 2019 22:41:43 +0100
-Subject: [PATCH libdrm] Add more managarm-specific changes
+Subject: [PATCH 2/3] Add more managarm-specific changes
 
 ---
- xf86drm.c | 26 ++++++++++++------------
- 1 file changed, 12 insertions(+), 12 deletions(-)
+ xf86drm.c | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/xf86drm.c b/xf86drm.c
-index 728ac78..6ee0068 100644
+index 3bb024e..4248ef2 100644
 --- a/xf86drm.c
 +++ b/xf86drm.c
-@@ -2824,7 +2824,7 @@ drm_public int drmPrimeFDToHandle(int fd, int prime_fd, uint32_t *handle)
-
+@@ -3421,7 +3421,7 @@ drm_public int drmCloseBufferHandle(int fd, uint32_t handle)
+ 
  static char *drmGetMinorNameForFD(int fd, int type)
  {
 -#ifdef __linux__
@@ -21,7 +21,7 @@ index 728ac78..6ee0068 100644
      DIR *sysdir;
      struct dirent *ent;
      struct stat sbuf;
-@@ -2892,7 +2892,7 @@ char *drmGetRenderDeviceNameFromFd(int fd)
+@@ -3543,7 +3543,7 @@ drm_public char *drmGetRenderDeviceNameFromFd(int fd)
      return drmGetMinorNameForFD(fd, DRM_NODE_RENDER);
  }
  
@@ -30,7 +30,7 @@ index 728ac78..6ee0068 100644
  static char * DRM_PRINTFLIKE(2, 3)
  sysfs_uevent_get(const char *path, const char *fmt, ...)
  {
-@@ -3117,7 +3117,7 @@ static int get_subsystem_type(const char *device_path)
+@@ -3629,7 +3629,7 @@ static int get_subsystem_type(const char *device_path)
  
  static int drmParseSubsystemType(int maj, int min)
  {
@@ -39,8 +39,8 @@ index 728ac78..6ee0068 100644
      char path[PATH_MAX + 1] = "";
      char real_path[PATH_MAX + 1] = "";
      int subsystem_type;
-@@ -3023,7 +3023,7 @@ get_pci_path(int maj, int min, char *pci_path)
-
+@@ -3736,7 +3736,7 @@ static int get_sysctl_pci_bus_info(int maj, int min, drmPciBusInfoPtr info)
+ 
  static int drmParsePciBusInfo(int maj, int min, drmPciBusInfoPtr info)
  {
 -#ifdef __linux__
@@ -48,7 +48,7 @@ index 728ac78..6ee0068 100644
      unsigned int domain, bus, dev, func;
      char pci_path[PATH_MAX + 1], *value;
      int num;
-@@ -3083,7 +3083,7 @@ static int drmGetMaxNodeName(void)
+@@ -3845,7 +3845,7 @@ static int drmGetMaxNodeName(void)
             3 /* length of the node number */;
  }
  
@@ -57,7 +57,7 @@ index 728ac78..6ee0068 100644
  static int parse_separate_sysfs_files(int maj, int min,
                                        drmPciDeviceInfoPtr device,
                                        bool ignore_revision)
-@@ -3155,7 +3155,7 @@ static int drmParsePciDeviceInfo(int maj, int min,
+@@ -3923,7 +3923,7 @@ static int drmParsePciDeviceInfo(int maj, int min,
                                   drmPciDeviceInfoPtr device,
                                   uint32_t flags)
  {
@@ -66,7 +66,7 @@ index 728ac78..6ee0068 100644
      if (!(flags & DRM_DEVICE_GET_PCI_REVISION))
          return parse_separate_sysfs_files(maj, min, device, true);
  
-@@ -3339,7 +3339,7 @@ free_device:
+@@ -4194,7 +4194,7 @@ static int drm_usb_dev_path(int maj, int min, char *path, size_t len)
  
  static int drmParseUsbBusInfo(int maj, int min, drmUsbBusInfoPtr info)
  {
@@ -75,7 +75,7 @@ index 728ac78..6ee0068 100644
      char path[PATH_MAX + 1], *value;
      unsigned int bus, dev;
      int ret;
-@@ -3378,7 +3378,7 @@ static int drmParseUsbBusInfo(int maj, int min, drmUsbBusInfoPtr info)
+@@ -4235,7 +4235,7 @@ static int drmParseUsbBusInfo(int maj, int min, drmUsbBusInfoPtr info)
  
  static int drmParseUsbDeviceInfo(int maj, int min, drmUsbDeviceInfoPtr info)
  {
@@ -84,8 +84,8 @@ index 728ac78..6ee0068 100644
      char path[PATH_MAX + 1], *value;
      unsigned int vendor, product;
      int ret;
-@@ -4059,7 +4059,7 @@ drm_public int drmGetDevices(drmDevicePtr devices[], int max_devices)
-
+@@ -4835,7 +4835,7 @@ drm_public int drmGetDevices(drmDevicePtr devices[], int max_devices)
+ 
  drm_public char *drmGetDeviceNameFromFd2(int fd)
  {
 -#ifdef __linux__
@@ -94,5 +94,5 @@ index 728ac78..6ee0068 100644
      char path[PATH_MAX + 1], *value;
      unsigned int maj, min;
 -- 
-2.24.0
+2.40.1
 

--- a/patches/libdrm/0003-Even-more-managarm-specific-changes.patch
+++ b/patches/libdrm/0003-Even-more-managarm-specific-changes.patch
@@ -1,17 +1,26 @@
-From 6a0feed25f14d7368770123c30ce7ccfa1b45733 Mon Sep 17 00:00:00 2001
+From 14775fec817c747227da3b9a7f574c22a754d85b Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Sat, 23 Jan 2021 21:09:10 +0100
-Subject: [PATCH] Even more managarm-specific changes
+Subject: [PATCH 3/3] Even more managarm-specific changes
 
 ---
- xf86drm.c | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ xf86drm.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/xf86drm.c b/xf86drm.c
-index 4396369..39b4309 100644
+index 4248ef2..929f6a1 100644
 --- a/xf86drm.c
 +++ b/xf86drm.c
-@@ -3078,7 +3078,7 @@ sysfs_uevent_get(const char *path, const char *fmt, ...)
+@@ -3333,7 +3333,7 @@ drm_public char *drmGetDeviceNameFromFd(int fd)
+ 
+ static bool drmNodeIsDRM(int maj, int min)
+ {
+-#ifdef __linux__
++#if defined(__linux__) || defined(__managarm__)
+     char path[64];
+     struct stat sbuf;
+ 
+@@ -3590,7 +3590,7 @@ sysfs_uevent_get(const char *path, const char *fmt, ...)
  /* Little white lie to avoid major rework of the existing code */
  #define DRM_BUS_VIRTIO 0x10
  
@@ -20,7 +29,7 @@ index 4396369..39b4309 100644
  static int get_subsystem_type(const char *device_path)
  {
      char path[PATH_MAX + 1] = "";
-@@ -3144,7 +3144,7 @@ static int drmParseSubsystemType(int maj, int min)
+@@ -3656,7 +3656,7 @@ static int drmParseSubsystemType(int maj, int min)
  #endif
  }
  
@@ -29,7 +38,7 @@ index 4396369..39b4309 100644
  static void
  get_pci_path(int maj, int min, char *pci_path)
  {
-@@ -3631,7 +3631,7 @@ free_device:
+@@ -4147,7 +4147,7 @@ free_device:
      return ret;
  }
  
@@ -38,6 +47,24 @@ index 4396369..39b4309 100644
  static int drm_usb_dev_path(int maj, int min, char *path, size_t len)
  {
      char *value, *tmp_path, *slash;
+@@ -4305,7 +4305,7 @@ free_device:
+ 
+ static int drmParseOFBusInfo(int maj, int min, char *fullname)
+ {
+-#ifdef __linux__
++#if defined(__linux__) || defined(__managarm__)
+     char path[PATH_MAX + 1], *name, *tmp_name;
+ 
+     snprintf(path, sizeof(path), "/sys/dev/char/%d:%d/device", maj, min);
+@@ -4340,7 +4340,7 @@ static int drmParseOFBusInfo(int maj, int min, char *fullname)
+ 
+ static int drmParseOFDeviceInfo(int maj, int min, char ***compatible)
+ {
+-#ifdef __linux__
++#if defined(__linux__) || defined(__managarm__)
+     char path[PATH_MAX + 1], *value, *tmp_name;
+     unsigned int count, i;
+     int err;
 -- 
-2.29.2
+2.40.1
 


### PR DESCRIPTION
This allows for successfully running `drmGetDevice` et al. when the necessary sysfs changes land in managarm. Without them, the function will still fail with an error, same as before.