### PR TITLE
Add two USB related ports

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -937,6 +937,44 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libusb
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Library for interacting with USB devices
+      description: This package provides a library used by some applications for USB device access.
+      spdx: 'LGPL-2.1-only'
+      website: 'https://github.com/libusb/libusb'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: 'ports'
+      url: 'https://github.com/libusb/libusb/releases/download/v1.0.26/libusb-1.0.26.tar.bz2'
+      format: 'tar.bz2'
+      extract_path: 'libusb-1.0.26'
+      version: '1.0.26'
+      tools_required:
+        - host-automake-v1.15
+      regenerate:
+        - args: ['cp',
+            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
+            '@THIS_SOURCE_DIR@/']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: libuv
     architecture: '@OPTION:arch@'
     source:

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -722,6 +722,49 @@ packages:
       - args: ['rm', '-v', '@THIS_COLLECT_DIR@/usr/.crates.toml']
       - args: ['rm', '-v', '@THIS_COLLECT_DIR@/usr/.crates2.json']
 
+  - name: usbutils
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: USB enumeration utilities
+      description: The USB Utils package contains utilities used to display information about USB buses in the system and the devices connected to them.
+      spdx: 'GPL-2.0-only'
+      website: 'https://www.kernel.org/pub/linux/utils/usb/usbutils/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-apps']
+    source:
+      subdir: 'ports'
+      url: 'https://github.com/gregkh/usbutils/archive/v015/usbutils-015.tar.gz'
+      format: 'tar.gz'
+      extract_path: 'usbutils-015'
+      version: '015'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+        - args: ['wget', 'https://raptor.dennisbonke.com/usb.ids', '-O', '@THIS_SOURCE_DIR@/usb.ids'] # Version 20230724
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - libusb
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--datadir=/usr/share/hwdata'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/share/hwdata/']
+      - args: ['cp', '-f', '@THIS_SOURCE_DIR@/usb.ids', '@THIS_COLLECT_DIR@/usr/share/hwdata/usb.ids']
+
   - name: util-linux-libs
     labels: [aarch64]
     architecture: '@OPTION:arch@'


### PR DESCRIPTION
This PR adds a port of the following packages:

- `libusb`;
- `usbutils`.

`usbutils` doesn't display anything yet because we're missing the sysfs interfaces for it, but @no92 wanted to work on that after his vacation.