### PR TITLE
Update a few packages

### DIFF
--- a/bootstrap.d/app-accessibility.yml
+++ b/bootstrap.d/app-accessibility.yml
@@ -37,8 +37,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://gitlab.gnome.org/GNOME/at-spi2-core.git'
-      tag: 'AT_SPI2_CORE_2_38_0'
-      version: '2.38.0'
+      tag: 'AT_SPI2_CORE_2_48_3'
+      version: '2.48.3'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -48,16 +48,16 @@ packages:
       - mlibc
       - dbus
       - glib
-    revision: 2
     configure:
       - args:
           - 'meson'
+          - 'setup'
           - '--cross-file'
           - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
           - '--prefix=/usr'
           - '--sysconfdir=/etc'
           - '-Dsystemd_user_dir=/tmp'
-          - '-Dintrospection=no'
+          - '-Dintrospection=disabled'
           - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']

--- a/bootstrap.d/app-accessibility.yml
+++ b/bootstrap.d/app-accessibility.yml
@@ -1,4 +1,5 @@
 packages:
+  # Deprecated it seems?
   - name: at-spi2-atk
     architecture: '@OPTION:arch@'
     source:

--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -208,14 +208,13 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/lz4/lz4.git'
-      tag: 'v1.9.3'
-      version: '1.9.3'
+      tag: 'v1.9.4'
+      version: '1.9.4'
     tools_required:
       - host-cmake
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 5
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -168,8 +168,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/libarchive/libarchive.git'
-      tag: 'v3.6.1'
-      version: '3.6.1'
+      tag: 'v3.6.2'
+      version: '3.6.2'
     tools_required:
       - host-cmake
       - system-gcc
@@ -182,7 +182,6 @@ packages:
       - libexpat
       - libxml
       - zstd
-    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -240,14 +240,14 @@ packages:
       categories: ['app-arch']
     source:
       subdir: ports
-      git: 'https://git.savannah.gnu.org/git/tar.git'
-      tag: 'release_1_33'
-      version: '1.33'
+      url: 'https://ftp.gnu.org/gnu/tar/tar-1.34.tar.xz'
+      checksum: 'blake2b:741a662457509a6775338ffe5d2d84872fcf38b93ace70c8b748a81055b9b62f65a48c4e541955d08ae99e6f528509e89eacd7c799a65bcc3d017a259110c115'
+      format: tar.xz
+      extract_path: 'tar-1.34'
+      version: '1.34'
       tools_required:
-        - host-autoconf-v2.69
         - host-automake-v1.15
       regenerate:
-        - args: ['./bootstrap']
         - args: ['cp',
             '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
             '@THIS_SOURCE_DIR@/build-aux/']
@@ -255,7 +255,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -411,15 +411,14 @@ packages:
     source:
       subdir: ports
       git: 'https://github.com/facebook/zstd.git'
-      tag: 'v1.5.2'
-      version: '1.5.2'
+      tag: 'v1.5.5'
+      version: '1.5.5'
     tools_required:
       - system-gcc
     pkgs_required:
       - mlibc
       - zlib
       - xz-utils
-    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/app-arch.yml
+++ b/bootstrap.d/app-arch.yml
@@ -329,16 +329,16 @@ packages:
       categories: ['app-arch']
     source:
       subdir: ports
-      git: 'https://git.tukaani.org/xz.git'
-      tag: 'v5.2.5'
-      version: '5.2.5'
+      git: 'https://github.com/tukaani-project/xz.git'
+      tag: 'v5.4.3'
+      version: '5.4.3'
       disable_shallow_fetch: true
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
         - host-libtool
       regenerate:
-        - args: ['./autogen.sh', '--no-po4a']
+        - args: ['./autogen.sh', '--no-po4a', '--no-doxygen']
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -347,7 +347,6 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-crypt.yml
+++ b/bootstrap.d/app-crypt.yml
@@ -2,11 +2,18 @@ packages:
   - name: p11-kit
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: A standard configuration setup for installing PKCS#11
+      description: "This package provides a way to load and enumerate PKCS #11 (a Cryptographic Token Interface Standard) modules."
+      spdx: 'MIT'
+      website: 'https://p11-glue.github.io/p11-glue/p11-kit.html'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-crypt']
     source:
       subdir: ports
       git: 'https://github.com/p11-glue/p11-kit.git'
-      tag: '0.24.0'
-      version: '0.24.0'
+      tag: '0.25.0'
+      version: '0.25.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -22,7 +29,6 @@ packages:
       - mlibc
       - libffi
       - libtasn
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -33,6 +39,8 @@ packages:
         - '--without-systemd'
         - '--disable-doc-html'
         - '--disable-nls'
+        environ:
+          ac_cv_func_strerror_r: 'no'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/app-editors.yml
+++ b/bootstrap.d/app-editors.yml
@@ -2,11 +2,18 @@ packages:
   - name: nano
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: GNU GPL'd Pico clone with more functionality
+      description: This package provides a mall, simple text editor which aims to replace Pico, the default editor in the Pine package.
+      spdx: 'LGPL-2.1-or-later GPL-3.0-or-later'
+      website: 'https://www.nano-editor.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-editors']
     source:
       subdir: 'ports'
       git: 'https://git.savannah.gnu.org/git/nano.git'
-      tag: 'v5.9'
-      version: '5.9'
+      tag: 'v7.2'
+      version: '7.2'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -32,19 +39,17 @@ packages:
       - ncurses
       - libintl
       - zlib
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=@OPTION:arch-triple@'
         - '--prefix=/usr'
         - '--sysconfdir=/etc'
+        - '--docdir=/usr/share/doc/nano-7.2'
         - 'CFLAGS=-DSLOW_BUT_NO_HACKS'
         environ:
           PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'
           PKG_CONFIG_LIBDIR: '@BUILD_ROOT@/system-root/usr/lib/pkgconfig:@BUILD_ROOT@/system-root/usr/share/pkgconfig'
-          gl_cv_type_wctype_t: 'yes'
-          gl_cv_type_wctrans_t: 'yes'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -16,8 +16,8 @@ sources:
   - name: icu
     subdir: 'ports'
     git: 'https://github.com/unicode-org/icu.git'
-    tag: 'release-70-1'
-    version: '70.1'
+    tag: 'release-73-2'
+    version: '73.2'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -79,7 +79,6 @@ tools:
     labels: [aarch64]
     architecture: noarch
     from_source: icu
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/icu4c/source/configure'
@@ -337,7 +336,6 @@ packages:
       - host-icu
     pkgs_required:
       - mlibc
-    revision: 4
     configure:
       - args: ['cp',
           '@THIS_SOURCE_DIR@/icu4c/source/config/mh-linux',

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -381,14 +381,21 @@ packages:
   - name: libevdev
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: Handler library for evdev events
+      description: This package contains common functions for Xorg input drivers.
+      spdx: 'MIT'
+      website: 'https://www.freedesktop.org/wiki/Software/libevdev/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: 'ports'
       git: 'https://gitlab.freedesktop.org/libevdev/libevdev.git'
-      tag: 'libevdev-1.13.0'
-      version: '1.13.0'
+      tag: 'libevdev-1.13.1'
+      version: '1.13.1'
       tools_required:
         - host-autoconf-v2.69
-        - host-automake-v1.11
+        - host-automake-v1.15
         - host-libtool
         - host-pkg-config
       regenerate:
@@ -399,7 +406,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -861,11 +861,18 @@ packages:
   - name: libtasn
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: ASN.1 library
+      description: This package provides a highly portable C library that encodes and decodes DER/BER data following an ASN.1 schema.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://www.gnu.org/software/libtasn1/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: ports
       git: 'https://gitlab.com/gnutls/libtasn1.git'
-      tag: 'v4.18.0'
-      version: '4.18.0'
+      tag: 'v4.19.0'
+      version: '4.19.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -880,7 +887,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -220,8 +220,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/fribidi/fribidi.git'
-      tag: 'v1.0.12'
-      version: '1.0.12'
+      tag: 'v1.0.13'
+      version: '1.0.13'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -238,7 +238,6 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -458,11 +458,18 @@ packages:
   - name: libexpat
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: Stream-oriented XML parser library
+      description: This package contains a stream oriented C library for parsing XML.
+      spdx: 'MIT'
+      website: 'https://libexpat.github.io/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: 'ports'
       git: 'https://github.com/libexpat/libexpat.git'
-      tag: 'R_2_4_9'
-      version: '2.4.9'
+      tag: 'R_2_5_0'
+      version: '2.5.0'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -477,7 +484,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/expat/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -837,11 +837,18 @@ packages:
   - name: libpipeline
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: A pipeline manipulation library
+      description: This package provides a library for manipulating pipelines of subprocesses in a flexible and convenient way.
+      spdx: 'GPL-3.0-only'
+      website: 'https://libpipeline.nongnu.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
     source:
       subdir: ports
       git: 'https://gitlab.com/cjwatson/libpipeline.git'
-      tag: '1.5.6'
-      version: '1.5.6'
+      tag: '1.5.7'
+      version: '1.5.7'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -856,7 +863,6 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -588,6 +588,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  # Updating to 1.47 broke libgcrypt, must be investigated
   - name: libgpg-error
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -927,11 +927,11 @@ packages:
       categories: ['dev-libs']
     source:
       subdir: 'ports'
-      url: 'https://ftp.gnu.org/gnu/libunistring/libunistring-1.0.tar.xz'
+      url: 'https://ftp.gnu.org/gnu/libunistring/libunistring-1.1.tar.xz'
       format: 'tar.xz'
-      checksum: blake2b:8208fe33d4ac2f015b0efb56b0c7dd87afc4bb1c6ca4eb3ded86d7e2101d7b7f68bfd8991af4b6dd408282ec73f134ee0b884e761ff6d52e8a1e398326aec420
-      extract_path: 'libunistring-1.0'
-      version: '1.0'
+      checksum: blake2b:721adc90884006480055b95d0fa06cd862417aa02b467f1e14688292ad9c11f1e33520b14ed5dc2d2724c6df8713d3af1e8032014259d8355156cb72edfcb983
+      extract_path: 'libunistring-1.1'
+      version: '1.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -943,15 +943,14 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
-        - '--host=x86_64-managarm'
+        - '--host=@OPTION:arch-triple@'
         - '--prefix=/usr'
         - '--with-sysroot=@SYSROOT_DIR@' # Set libtool's lt_sysroot.
         - '--disable-static'
-        - '--docdir=/usr/share/doc/libunistring-1.0'
+        - '--docdir=/usr/share/doc/libunistring-1.1'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -182,14 +182,13 @@ packages:
     source:
       subdir: ports
       git: 'https://github.com/google/double-conversion.git'
-      tag: 'v3.2.1'
-      version: '3.2.1'
+      tag: 'v3.3.0'
+      version: '3.3.0'
     tools_required:
       - host-cmake
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -449,11 +449,18 @@ packages:
   - name: libjpeg-turbo
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: MMX, SSE, and SSE2 SIMD accelerated JPEG library
+      description: libjpeg-turbo is a fork of the original IJG libjpeg which uses SIMD to accelerate baseline JPEG compression and decompression. libjpeg is a library that implements JPEG image encoding, decoding and transcoding.
+      spdx: 'BSD-3-Clause ZLIB'
+      website: 'https://libjpeg-turbo.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['media-libs']
     source:
       subdir: 'ports'
       git: 'https://github.com/libjpeg-turbo/libjpeg-turbo.git'
-      tag: '2.1.4'
-      version: '2.1.4'
+      tag: '3.0.0'
+      version: '3.0.0'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -462,7 +469,6 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -470,7 +476,7 @@ packages:
         - '-DCMAKE_INSTALL_PREFIX=/usr'
         - '-DCMAKE_BUILD_TYPE=RELEASE'
         - '-DENABLE_STATIC=FALSE'
-        - '-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/libjpeg-turbo-2.1.4'
+        - '-DCMAKE_INSTALL_DOCDIR=/usr/share/doc/libjpeg-turbo-3.0.0'
         - '-DCMAKE_INSTALL_DEFAULT_LIBDIR=lib'
         - '-DWITH_JPEG8=ON'
         - '-DCMAKE_SYSTEM_PROCESSOR=@OPTION:arch@'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -599,8 +599,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://gitlab.com/libtiff/libtiff.git'
-      tag: 'v4.4.0'
-      version: '4.4.0'
+      tag: 'v4.5.1'
+      version: '4.5.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -609,7 +609,6 @@ packages:
       regenerate:
         - args: ['./autogen.sh']
     tools_required:
-      - host-cmake
       - system-gcc
     pkgs_required:
       - mlibc
@@ -618,7 +617,6 @@ packages:
       - zlib
       - zstd
       - xz-utils
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -626,7 +624,7 @@ packages:
         - '--prefix=/usr'
         - '--disable-static'
         - '--enable-shared'
-        - '--with-docdir=/usr/share/doc/libtiff-4.4.0'
+        - '--with-docdir=/usr/share/doc/libtiff-4.5.1'
         - '--without-x'
         - '--enable-zlib'
         - '--enable-zstd'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -727,8 +727,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://github.com/webmproject/libwebp.git'
-      tag: 'v1.2.4'
-      version: '1.2.4'
+      tag: 'v1.3.1'
+      version: '1.3.1'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -745,7 +745,6 @@ packages:
       - freeglut
       - sdl2
       - libtiff
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -3,9 +3,6 @@ packages:
   - name: base
     labels: [aarch64]
     architecture: noarch
-    source:
-      subdir: meta-sources
-      version: '1.0'
     metadata:
       summary: Minimum meta-package to provide a useful environment
       description: This meta-package provides a useful terminal only environment with various common unix tools and the xbps package manager.
@@ -13,7 +10,9 @@ packages:
       website: 'https://managarm.org'
       maintainer: "Dennis Bonke <dennis@managarm.org>"
       categories: ['meta-pkgs']
-    revision: 3
+    source:
+      subdir: meta-sources
+      version: '1.0'
     pkgs_required:
       - mlibc
       - core-files
@@ -45,6 +44,9 @@ packages:
       - libxcrypt
       - gcc # Temporary solution to remove the need to copy libstdc++.so and libgcc.so from system-gcc
       - man-db
+      - man-pages-posix
+      - iproute2
+    revision: 4
     configure: []
     build: []
 

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -351,26 +351,30 @@ packages:
   - name: gawk
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: GNU awk pattern-matching language
+      description: This package contains programs for manipulating text files.
+      spdx: 'GPL-3.0-or-later'
+      website: 'https://www.gnu.org/software/gawk/gawk.html'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-apps']
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/gawk.git'
-      tag: 'gawk-4.2.1'
-      version: '4.2.1'
+      tag: 'gawk-5.2.2'
+      version: '5.2.2'
       tools_required:
-        - host-autoconf-v2.69
-        - host-automake-v1.15
+        - host-autoconf-v2.71
+        - host-automake-v1.16
       regenerate:
         - args: sed -i 's/extras//' @THIS_SOURCE_DIR@/Makefile.in
-        - args: ['cp',
-            '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
-            '@THIS_SOURCE_DIR@/']
+        - args: ['autoreconf', '-fvi']
     tools_required:
       - system-gcc
-      - host-autoconf-v2.69
-      - host-automake-v1.15
+      - host-autoconf-v2.71
+      - host-automake-v1.16
     pkgs_required:
       - mlibc
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -2,8 +2,8 @@ sources:
   - name: file
     subdir: ports
     git: 'https://github.com/file/file.git'
-    tag: 'FILE5_43'
-    version: '5.43'
+    tag: 'FILE5_44'
+    version: '5.44'
     tools_required:
       - host-autoconf-v2.69
       - host-automake-v1.15
@@ -33,7 +33,6 @@ tools:
       - host-autoconf-v2.69
       - host-automake-v1.15
       - host-libtool
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -287,6 +286,13 @@ packages:
   - name: file
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: Identify a file's format by scanning binary data for patterns
+      description: This package contains an utility for determining the type of a given file or files.
+      spdx: 'BSD-2-Clause'
+      website: 'https://www.darwinsys.com/file/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-apps']
     from_source: file
     tools_required:
       - system-gcc
@@ -294,7 +300,6 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -391,11 +391,18 @@ packages:
   - name: grep
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: GNU regular expression matcher
+      description: This package contains for searching through the contents of files.
+      spdx: 'GPL-3.0-or-later'
+      website: 'https://www.gnu.org/software/grep/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-apps']
     source:
       subdir: ports
       git: 'https://git.savannah.gnu.org/git/grep.git'
-      tag: 'v3.7'
-      version: '3.7'
+      tag: 'v3.11'
+      version: '3.11'
       tools_required:
         - host-autoconf-v2.69
         - host-automake-v1.15
@@ -409,7 +416,6 @@ packages:
     pkgs_required:
       - mlibc
       - pcre
-    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -180,6 +180,7 @@ packages:
         post_install:
           - args: ['gdk-pixbuf-query-loaders', '--update-cache']
 
+  # Deprecated, please don't depend on this anymore. Only here for gtklife and hexchat.
   - name: gtk+-2
     architecture: '@OPTION:arch@'
     source:

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -250,8 +250,8 @@ packages:
     source:
       subdir: 'ports'
       git: 'https://gitlab.gnome.org/GNOME/gtk.git'
-      tag: '3.24.23'
-      version: '3.24.23'
+      tag: '3.24.38'
+      version: '3.24.38'
     tools_required:
       - system-gcc
       - virtual: pkgconfig-for-target
@@ -260,7 +260,6 @@ packages:
       - wayland-scanner
     pkgs_required:
       - mlibc
-      - atk
       - at-spi2-atk
       - cairo
       - glib
@@ -285,10 +284,11 @@ packages:
       - libxcursor
       - gsettings-desktop-schemas
       - dbus
-    revision: 2
+      - libxinerama
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--native-file'
         - '@SOURCE_ROOT@/scripts/meson.native-file'
         - '--cross-file'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -321,6 +321,33 @@ tools:
       # Stop aclocal from complaining.
       - args: ['ln', '-sf', '@PREFIX@/share/aclocal-1.15', '@PREFIX@/share/aclocal']
 
+  - name: host-automake-v1.16
+    labels: [aarch64, riscv64]
+    architecture: noarch
+    source:
+      name: automake-v1.16
+      subdir: 'ports'
+      git: 'https://git.savannah.gnu.org/git/automake.git'
+      tag: 'v1.16.5'
+      version: '1.16.5'
+      tools_required:
+       - host-autoconf-v2.71
+      regenerate:
+       - args: ['./bootstrap']
+    tools_required:
+      - host-autoconf-v2.71
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--prefix=@PREFIX@'
+        - 'MAKEINFO=/bin/true'
+    compile:
+      - args: ['make', '-j@PARALLELISM@']
+    install:
+      - args: ['make', 'install']
+      # Stop aclocal from complaining.
+      - args: ['ln', '-sf', '@PREFIX@/share/aclocal-1.16', '@PREFIX@/share/aclocal']
+
   - name: host-managarm-tools
     labels: [aarch64, riscv64]
     architecture: noarch

--- a/extrafiles/nanorc
+++ b/extrafiles/nanorc
@@ -172,10 +172,6 @@ set regexp
 ## M = mark, L = hard-wrapping long lines, R = recording, S = soft-wrapping.
 # set stateflags
 
-## Allow nano to be suspended (with ^Z by default).
-set suspendable
-## (The old form of this option, 'set suspend', is deprecated.)
-
 ## Use this tab size instead of the default; it must be greater than 0.
 # set tabsize 8
 

--- a/extrafiles/root-nanorc
+++ b/extrafiles/root-nanorc
@@ -172,10 +172,6 @@ set regexp
 ## M = mark, L = hard-wrapping long lines, R = recording, S = soft-wrapping.
 # set stateflags
 
-## Allow nano to be suspended (with ^Z by default).
-set suspendable
-## (The old form of this option, 'set suspend', is deprecated.)
-
 ## Use this tab size instead of the default; it must be greater than 0.
 # set tabsize 8
 
@@ -227,9 +223,9 @@ set errorcolor bold,lightwhite,red
 set selectedcolor lightwhite,cyan
 set stripecolor ,yellow
 set scrollercolor magenta
-set numbercolor magenta
-set keycolor lightmagenta
-set functioncolor magenta
+set numbercolor bold,red
+set keycolor yellow
+set functioncolor blue
 
 
 ## === Syntax coloring ===

--- a/patches/automake-v1.16/0001-Add-Managarm-support.patch
+++ b/patches/automake-v1.16/0001-Add-Managarm-support.patch
@@ -1,0 +1,101 @@
+From 3795bc9b268c3c3025074a3511f8454066fe2ca6 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 3 Oct 2022 22:30:43 +0200
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ lib/config.guess |  6 ++++++
+ lib/config.sub   | 26 +++++++++++++++++++++++---
+ 2 files changed, 29 insertions(+), 3 deletions(-)
+
+diff --git a/lib/config.guess b/lib/config.guess
+index e81d3ae..9cafc6a 100755
+--- a/lib/config.guess
++++ b/lib/config.guess
+@@ -963,6 +963,12 @@ EOF
+ 	GNU_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
+ 	GUESS=$UNAME_MACHINE-unknown-$GNU_SYS$GNU_REL-$LIBC
+ 	;;
++	x86_64:[Mm]anagarm:*:*|i?86:[Mm]anagarm:*:*)
++		GUESS="$UNAME_MACHINE-pc-managarm-mlibc"
++		;;
++	*:[Mm]anagarm:*:*)
++		GUESS="$UNAME_MACHINE-unknown-managarm-mlibc"
++		;;
+     *:Minix:*:*)
+ 	GUESS=$UNAME_MACHINE-unknown-minix
+ 	;;
+diff --git a/lib/config.sub b/lib/config.sub
+index d74fb6d..ef0004f 100755
+--- a/lib/config.sub
++++ b/lib/config.sub
+@@ -145,7 +145,7 @@ case $1 in
+ 			nto-qnx* | linux-* | uclinux-uclibc* \
+ 			| uclinux-gnu* | kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* \
+ 			| netbsd*-eabi* | kopensolaris*-gnu* | cloudabi*-eabi* \
+-			| storm-chaos* | os2-emx* | rtmk-nova*)
++			| storm-chaos* | os2-emx* | rtmk-nova* | managarm-*)
+ 				basic_machine=$field1
+ 				basic_os=$maybe_os
+ 				;;
+@@ -1336,6 +1336,10 @@ EOF
+ 		kernel=linux
+ 		os=`echo "$basic_os" | sed -e 's|linux|gnu|'`
+ 		;;
++	managarm*)
++		kernel=managarm
++		os=$(echo $basic_os | sed -e 's|managarm|mlibc|')
++		;;
+ 	*)
+ 		kernel=
+ 		os=$basic_os
+@@ -1748,7 +1752,8 @@ case $os in
+ 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
+ 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
+ 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
+-	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr*)
++	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr* \
++	     | mlibc* )
+ 		;;
+ 	# This one is extra strict with allowed versions
+ 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
+@@ -1756,6 +1761,9 @@ case $os in
+ 		;;
+ 	none)
+ 		;;
++	kernel* )
++		# Restricted further below
++		;;
+ 	*)
+ 		echo Invalid configuration \`"$1"\': OS \`"$os"\' not recognized 1>&2
+ 		exit 1
+@@ -1770,12 +1778,24 @@ case $kernel-$os in
+ 		;;
+ 	uclinux-uclibc* )
+ 		;;
+-	-dietlibc* | -newlib* | -musl* | -relibc* | -uclibc* )
++	managarm-mlibc* )
++		;;
++	managarm-kernel* )
++		;;
++	-dietlibc* | -newlib* | -musl* | -relibc* | -uclibc* | -mlibc* )
+ 		# These are just libc implementations, not actual OSes, and thus
+ 		# require a kernel.
+ 		echo "Invalid configuration \`$1': libc \`$os' needs explicit kernel." 1>&2
+ 		exit 1
+ 		;;
++	-kernel* )
++		echo "Invalid configuration \`$1': -kernel must not appear on its own." 1>&2
++		exit 1
++		;;
++	*-kernel* )
++		echo "Invalid configuration \`$1': Kernel \`$kernel' does not support -kernel." 1>&2
++		exit 1
++		;;
+ 	kfreebsd*-gnu* | kopensolaris*-gnu*)
+ 		;;
+ 	vxworks-simlinux | vxworks-simwindows | vxworks-spe)
+-- 
+2.37.2
+

--- a/patches/p11-kit/0001-Fill-in-the-distribution-specific-anchor-hook-for-Ma.patch
+++ b/patches/p11-kit/0001-Fill-in-the-distribution-specific-anchor-hook-for-Ma.patch
@@ -1,7 +1,8 @@
-From 188d8ea3850074133889f2d00b082ccf89478881 Mon Sep 17 00:00:00 2001
+From e80a985d268d1a4f18eb6281fb974bfcf4205dd4 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Wed, 14 Jul 2021 03:10:06 +0200
-Subject: [PATCH 1/2] Fill in the distribution specific anchor hook for Managarm
+Subject: [PATCH 1/3] Fill in the distribution specific anchor hook for
+ Managarm
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
@@ -34,5 +35,5 @@ index b1b7a08..34051b3 100755
 +# Generate a new trust store
 +/usr/sbin/make-ca -f -g
 -- 
-2.32.0
+2.40.1
 

--- a/patches/p11-kit/0002-Work-around-an-issue-with-the-build-system.patch
+++ b/patches/p11-kit/0002-Work-around-an-issue-with-the-build-system.patch
@@ -1,11 +1,12 @@
-From 803f5cc37be8c6d5a71e570226276b0154a064ec Mon Sep 17 00:00:00 2001
+From 6ac94134fbb62488831af683c012aa89c39bcd37 Mon Sep 17 00:00:00 2001
 From: Dennisbonke <admin@dennisbonke.com>
 Date: Sat, 28 Nov 2020 02:24:47 +0100
-Subject: [PATCH 2/2] Work around an issue with the build system
+Subject: [PATCH 2/3] Work around an issue with the build system
 
 This is a massive hack and should be removed asap, but for now it works
 
 Signed-off-by: Dennisbonke <admin@dennisbonke.com>
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
  trust/basic.asn.h   |  13 ++
  trust/openssl.asn.h |  26 ++++
@@ -439,5 +440,5 @@ index 0000000..dc24f8c
 +  { NULL, 0, NULL }
 +};
 -- 
-2.29.2
+2.40.1
 

--- a/patches/p11-kit/0003-Make-Managarm-use-the-GNU-compatible-strerror_r.patch
+++ b/patches/p11-kit/0003-Make-Managarm-use-the-GNU-compatible-strerror_r.patch
@@ -1,0 +1,29 @@
+From 61549b277e40afce38bac60c5abd9671a8a852d8 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 25 Jul 2023 17:27:42 +0200
+Subject: [PATCH 3/3] Make Managarm use the GNU compatible strerror_r
+
+Managarm has a GNU compatible strerror_r, but the test for that can't be done at configure time because we're cross compiling.
+Force disable the test via autoconf cache variables and add us here to avoid hitting an #error further down.
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ common/compat.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/compat.c b/common/compat.c
+index 4e0c89c..2d648b3 100644
+--- a/common/compat.c
++++ b/common/compat.c
+@@ -1013,7 +1013,7 @@ p11_strerror_r (int errnum,
+ {
+ #if defined(HAVE_XSI_STRERROR_R)
+ 	strerror_r (errnum, buf, buflen);
+-#elif defined(HAVE_GNU_STRERROR_R)
++#elif defined(HAVE_GNU_STRERROR_R) || defined(__managarm__)
+ 	char *str = strerror_r (errnum, buf, buflen);
+ 	strncpy (buf, str, buflen);
+ #elif defined(OS_WIN32)
+-- 
+2.40.1
+


### PR DESCRIPTION
This PR updates a few ports and adds `iproute2` and `man-pages-posix` to the base image.

List of updated ports:
- `at-spi2-core`;
- `gtk3`;
- `libarchive`;
- `lz4`;
- `zstd`;
- `xz-utils`;
- `tar`;
- `libtasn`;
- `p11-kit`;
- `nano`;
- `fribidi`;
- `icu`;
- `libexpat`;
- `libevdev`;
- `libpipeline`;
- `libunistring`;
- `double-conversion`;
- `libjpeg-turbo`;
- `libwebp`;
- `libtiff`;
- `gawk`;
- `grep`;
- `file`.

Furthermore, `host-automake-v1.16` has been added as a tool.