### PR TITLE
Update the rust toolchain

### DIFF
--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -93,8 +93,8 @@ tools:
     source:
       subdir: 'ports'
       git: 'https://github.com/rust-lang/cargo.git'
-      tag: '0.68.0'
-      version: '0.68.0'
+      tag: '0.72.1'
+      version: '0.72.1'
     tools_required:
       - tool: host-rust
         recursive: true

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -27,11 +27,11 @@ sources:
 
   - name: host-bootstrap-cargo
     subdir: 'ports'
-    url: 'https://static.rust-lang.org/dist/2022-04-07/cargo-1.60.0-x86_64-unknown-linux-gnu.tar.xz'
+    url: 'https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-x86_64-unknown-linux-gnu.tar.xz'
     format: 'tar.xz'
-    checksum: blake2b:d60239d5977bfcf1c6f2d973d9d27e93d6d138ae6e929deb016afde8cd8e0ff0bba8396f8fa62d5e738be7bde7b91e9aa406ec2440e1ab50451c5b9ad2d8fdfb
-    extract_path: 'cargo-1.60.0-x86_64-unknown-linux-gnu'
-    version: '0.60.0'
+    checksum: blake2b:1c08994d28af4db6f69ce74a9cd90bbd9f66f011742d4f04f669ef5b8bf3942cc400d596e4698276fb9ef33b2bdbca5e006590ae49633f518c70ad54122e0e30
+    extract_path: 'cargo-1.70.0-x86_64-unknown-linux-gnu'
+    version: '1.70.0'
 
 tools:
   - name: host-python

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -22,8 +22,8 @@ sources:
   - name: rust
     subdir: 'ports'
     git: 'https://github.com/rust-lang/rust.git'
-    tag: '1.67.1'
-    version: '1.67.1'
+    tag: '1.71.0'
+    version: '1.71.0'
 
   - name: host-bootstrap-cargo
     subdir: 'ports'
@@ -56,7 +56,6 @@ tools:
     tools_required:
       - host-llvm-toolchain
       - host-python
-    revision: 2
     compile:
       - args: |
             cat << EOF > config.toml
@@ -64,6 +63,7 @@ tools:
 
             [llvm]
             targets = "X86"
+            download-ci-llvm = false
 
             [build]
             target = ["x86_64-unknown-managarm-system", "x86_64-unknown-linux-gnu"]

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -2,8 +2,8 @@ sources:
   - name: rust-libc
     subdir: 'ports'
     git: 'https://github.com/rust-lang/libc.git'
-    tag: '0.2.138'
-    version: '0.2.138'
+    tag: '0.2.147'
+    version: '0.2.147'
 
   - name: rust-num-cpus
     subdir: 'ports'

--- a/patches/rust-libc/0001-managarm-initial-port.patch
+++ b/patches/rust-libc/0001-managarm-initial-port.patch
@@ -1,7 +1,7 @@
-From 445e8861bba29d7b7af345b71dc43208dd2cb16c Mon Sep 17 00:00:00 2001
-From: Matt Taylor <mstaveleytaylor@gmail.com>
-Date: Thu, 8 Apr 2021 22:08:55 +0100
-Subject: [PATCH 1/4] managarm: initial port
+From 62582556af1e00008f3a2d28a325003d29b5f2f6 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 2 Aug 2023 04:43:10 +0200
+Subject: [PATCH 1/5] managarm: initial port
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
@@ -742,13 +742,13 @@ index 0000000..e7c4cc7
 +    pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
 +}
 diff --git a/src/unix/mod.rs b/src/unix/mod.rs
-index fb9ebf7..e50cca0 100644
+index 9b5ce0f..55b5ef5 100644
 --- a/src/unix/mod.rs
 +++ b/src/unix/mod.rs
-@@ -1517,6 +1517,9 @@ cfg_if! {
-     } else if #[cfg(target_os = "redox")] {
-         mod redox;
-         pub use self::redox::*;
+@@ -1594,6 +1594,9 @@ cfg_if! {
+     } else if #[cfg(target_os = "aix")] {
+         mod aix;
+         pub use self::aix::*;
 +    } else if #[cfg(target_os = "managarm")] {
 +        mod mlibc;
 +        pub use self::mlibc::*;
@@ -756,5 +756,5 @@ index fb9ebf7..e50cca0 100644
          // Unknown target_os
      }
 -- 
-2.39.1
+2.40.1
 

--- a/patches/rust-libc/0002-managarm-Add-missing-glue-for-memmap-num_cpus-and-us.patch
+++ b/patches/rust-libc/0002-managarm-Add-missing-glue-for-memmap-num_cpus-and-us.patch
@@ -1,7 +1,7 @@
-From 110c9f92fe8abd4ac3ad0137a39b68e127feccf5 Mon Sep 17 00:00:00 2001
-From: Matt Taylor <mstaveleytaylor@gmail.com>
-Date: Sat, 8 May 2021 19:33:53 +0100
-Subject: [PATCH 2/4] managarm: Add missing glue for memmap, num_cpus and users
+From 8fc0c1a48fe7421488b479f15f6bda0cbeb5cbee Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 2 Aug 2023 04:45:55 +0200
+Subject: [PATCH 2/5] managarm: Add missing glue for memmap, num_cpus and users
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
@@ -122,5 +122,5 @@ index e7c4cc7..eb8cdc6 100644
      pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
  }
 -- 
-2.39.1
+2.40.1
 

--- a/patches/rust-libc/0003-managarm-alacritty-updates.patch
+++ b/patches/rust-libc/0003-managarm-alacritty-updates.patch
@@ -1,15 +1,15 @@
-From b77abe3fc30d719c7588f6b12ac70176bb80ed13 Mon Sep 17 00:00:00 2001
-From: Matt Taylor <mstaveleytaylor@gmail.com>
-Date: Sat, 25 Jun 2022 03:43:30 +0100
-Subject: [PATCH 3/4] managarm: alacritty updates
+From 7895ffd3aaee0a2a6dd2a707c5b062decf69ae9b Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 2 Aug 2023 04:56:48 +0200
+Subject: [PATCH 3/5] managarm: alacritty updates
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- src/unix/mlibc/mod.rs | 395 ++++++++++++++++++++++++++++++++++++------
- 1 file changed, 345 insertions(+), 50 deletions(-)
+ src/unix/mlibc/mod.rs | 394 ++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 344 insertions(+), 50 deletions(-)
 
 diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
-index eb8cdc6..d734ca4 100644
+index eb8cdc6..1787268 100644
 --- a/src/unix/mlibc/mod.rs
 +++ b/src/unix/mlibc/mod.rs
 @@ -26,11 +26,24 @@ pub const MAP_SHARED: ::c_int = 2;
@@ -638,14 +638,13 @@ index eb8cdc6..d734ca4 100644
      pub fn pthread_condattr_setclock(
          attr: *mut pthread_condattr_t,
          clock_id: ::clockid_t,
-@@ -732,7 +1016,18 @@ extern "C" {
+@@ -732,7 +1016,17 @@ extern "C" {
          addr: *mut ::sockaddr,
          addrlen: *mut ::socklen_t,
      ) -> ::ssize_t;
 +    pub fn recvmsg(fd: ::c_int, msg: *mut ::msghdr, flags: ::c_int) -> ::ssize_t;
 +    pub fn sendmsg(fd: ::c_int, msg: *const ::msghdr, flags: ::c_int) -> ::ssize_t;
      pub fn setgroups(ngroups: ::c_int, ptr: *const ::gid_t) -> ::c_int;
-+    pub fn sethostname(name: *const ::c_char, len: ::size_t) -> ::c_int;
      pub fn setpwent();
 +    pub fn shm_open(name: *const c_char, oflag: ::c_int, mode: mode_t) -> ::c_int;
 +    pub fn shm_unlink(name: *const ::c_char) -> ::c_int;
@@ -658,5 +657,5 @@ index eb8cdc6..d734ca4 100644
      pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
  }
 -- 
-2.39.1
+2.40.1
 

--- a/patches/rust-libc/0004-managarm-More-additions-for-a-newer-nix-version.patch
+++ b/patches/rust-libc/0004-managarm-More-additions-for-a-newer-nix-version.patch
@@ -1,7 +1,7 @@
-From 2b9a1cf9a7abe31a2a4a5a525abda0d1df68265a Mon Sep 17 00:00:00 2001
+From d8fc7a90085b141b73d128e1ebd582687445128e Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
-Date: Thu, 23 Feb 2023 00:30:21 +0100
-Subject: [PATCH 4/4] managarm: More additions for a newer nix version
+Date: Wed, 2 Aug 2023 05:02:00 +0200
+Subject: [PATCH 4/5] managarm: More additions for a newer nix version
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  1 file changed, 174 insertions(+), 16 deletions(-)
 
 diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
-index d734ca4..9d73df8 100644
+index 1787268..db952e6 100644
 --- a/src/unix/mlibc/mod.rs
 +++ b/src/unix/mlibc/mod.rs
 @@ -8,8 +8,22 @@ pub type c_ulong = u64;
@@ -278,7 +278,7 @@ index d734ca4..9d73df8 100644
  // options/linux-headers/include/linux/if_packet.h
  s! {
      pub struct sockaddr_ll {
-@@ -1030,4 +1146,46 @@ extern "C" {
+@@ -1029,4 +1145,46 @@ extern "C" {
          flag: ::c_int,
      ) -> ::c_int;
      pub fn writev(fd: ::c_int, iov: *const ::iovec, count: ::c_int) -> ::ssize_t;
@@ -326,5 +326,5 @@ index d734ca4..9d73df8 100644
 +    pub fn clock_getres(clk_id: ::clockid_t, tp: *mut ::timespec) -> ::c_int;
  }
 -- 
-2.39.1
+2.40.1
 

--- a/patches/rust-libc/0005-More-fixes.patch
+++ b/patches/rust-libc/0005-More-fixes.patch
@@ -1,0 +1,205 @@
+From ce9ac32a6d5094afe5d982be7118373bdabc4827 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Wed, 2 Aug 2023 16:18:56 +0200
+Subject: [PATCH 5/5] More fixes
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ src/unix/mlibc/mod.rs | 127 ++++++++++++++++++++++++------------------
+ 1 file changed, 72 insertions(+), 55 deletions(-)
+
+diff --git a/src/unix/mlibc/mod.rs b/src/unix/mlibc/mod.rs
+index db952e6..c268125 100644
+--- a/src/unix/mlibc/mod.rs
++++ b/src/unix/mlibc/mod.rs
+@@ -203,7 +203,7 @@ s! {
+     }
+ }
+ 
+-// abis/mlibc/termios.h
++// abis/linux/termios.h
+ pub const B0: ::c_uint = 0;
+ pub const B50: ::c_uint = 1;
+ pub const B75: ::c_uint = 2;
+@@ -223,65 +223,65 @@ pub const B38400: ::c_uint = 15;
+ pub const B57600: ::c_uint = 16;
+ pub const B115200: ::c_uint = 17;
+ pub const B230400: ::c_uint = 18;
+-pub const BRKINT: ::c_uint = 0x0001;
++pub const BRKINT: ::c_uint = 0x0002;
+ pub const BS0: ::c_int = 0x0000;
+-pub const BS1: ::c_int = 0x1000;
+-pub const BSDLY: ::c_int = 0x1000;
+-pub const CLOCAL: ::c_int = 0x0080;
++pub const BS1: ::c_int = 0x2000;
++pub const BSDLY: ::c_int = 0x2000;
++pub const CLOCAL: ::c_int = 0x0800;
+ pub const CR0: ::c_int = 0x0000;
+-pub const CR1: ::c_int = 0x0100;
+-pub const CR2: ::c_int = 0x0200;
+-pub const CR3: ::c_int = 0x0300;
+-pub const CRDLY: ::c_int = 0x0300;
+-pub const CREAD: ::c_int = 0x0008;
++pub const CR1: ::c_int = 0x0200;
++pub const CR2: ::c_int = 0x0400;
++pub const CR3: ::c_int = 0x0600;
++pub const CRDLY: ::c_int = 0x0600;
++pub const CREAD: ::c_int = 0x0080;
+ pub const CS5: ::c_uint = 0x0000;
+-pub const CS6: ::c_int = 0x0001;
+-pub const CS7: ::c_int = 0x0002;
+-pub const CS8: ::c_int = 0x0003;
+-pub const CSIZE: ::c_int = 0x0003;
+-pub const CSTOPB: ::c_int = 0x0004;
+-pub const ECHO: ::c_uint = 0x0001;
+-pub const ECHOE: ::c_int = 0x0002;
+-pub const ECHOK: ::c_int = 0x0004;
+-pub const ECHONL: ::c_int = 0x0008;
+-pub const ECHOPRT: ::c_int = 0x0200;
++pub const CS6: ::c_int = 0x0010;
++pub const CS7: ::c_int = 0x0020;
++pub const CS8: ::c_int = 0x0030;
++pub const CSIZE: ::c_int = 0x0030;
++pub const CSTOPB: ::c_int = 0x0040;
++pub const ECHO: ::c_uint = 0x0008;
++pub const ECHOE: ::c_int = 0x0010;
++pub const ECHOK: ::c_int = 0x0020;
++pub const ECHONL: ::c_int = 0x0040;
++pub const ECHOPRT: ::c_int = 0x0400;
+ pub const FF0: ::c_int = 0x0000;
+-pub const FF1: ::c_int = 0x4000;
+-pub const FFDLY: ::c_int = 0x4000;
+-pub const HUPCL: ::c_int = 0x0040;
+-pub const ICANON: ::c_int = 0x0010;
+-pub const ICRNL: ::c_uint = 0x0002;
+-pub const IEXTEN: ::c_int = 0x0020;
+-pub const IGNBRK: ::c_uint = 0x0004;
+-pub const IGNCR: ::c_uint = 0x0008;
+-pub const IGNPAR: ::c_uint = 0x0010;
+-pub const INLCR: ::c_uint = 0x0020;
+-pub const INPCK: ::c_uint = 0x0040;
+-pub const ISIG: ::c_int = 0x0040;
+-pub const ISTRIP: ::c_uint = 0x0080;
+-pub const IXANY: ::c_uint = 0x0100;
+-pub const IXOFF: ::c_uint = 0x0200;
++pub const FF1: ::c_int = 0x8000;
++pub const FFDLY: ::c_int = 0x8000;
++pub const HUPCL: ::c_int = 0x0400;
++pub const ICANON: ::c_int = 0x0002;
++pub const ICRNL: ::c_uint = 0x0100;
++pub const IEXTEN: ::c_int = 0x8000;
++pub const IGNBRK: ::c_uint = 0x0001;
++pub const IGNCR: ::c_uint = 0x0080;
++pub const IGNPAR: ::c_uint = 0x0004;
++pub const INLCR: ::c_uint = 0x0080;
++pub const INPCK: ::c_uint = 0x0010;
++pub const ISIG: ::c_int = 0x0001;
++pub const ISTRIP: ::c_uint = 0x0020;
++pub const IXANY: ::c_uint = 0x0800;
++pub const IXOFF: ::c_uint = 0x1000;
+ pub const IXON: ::c_uint = 0x0400;
+-pub const NCCS: usize = 11;
++pub const NCCS: usize = 32;
+ pub const NL0: ::c_int = 0x0000;
+-pub const NL1: ::c_int = 0x0080;
+-pub const NLDLY: ::c_int = 0x0080;
++pub const NL1: ::c_int = 0x0100;
++pub const NLDLY: ::c_int = 0x0100;
+ pub const NOFLSH: ::c_int = 0x0080;
+-pub const OCRNL: ::c_int = 0x0004;
+-pub const OFDEL: ::c_int = 0x0020;
++pub const OCRNL: ::c_int = 0x0008;
++pub const OFDEL: ::c_int = 0x0080;
+ pub const OFILL: ::c_int = 0x0040;
+-pub const ONLCR: ::c_int = 0x0002;
+-pub const ONLRET: ::c_int = 0x0010;
+-pub const ONOCR: ::c_int = 0x0008;
++pub const ONLCR: ::c_int = 0x0004;
++pub const ONLRET: ::c_int = 0x0020;
++pub const ONOCR: ::c_int = 0x0010;
+ pub const OPOST: ::c_uint = 0x0001;
+-pub const PARENB: ::c_int = 0x0010;
+-pub const PARMRK: ::c_uint = 0x0800;
+-pub const PARODD: ::c_int = 0x0020;
++pub const PARENB: ::c_int = 0x0100;
++pub const PARMRK: ::c_uint = 0x0008;
++pub const PARODD: ::c_int = 0x0200;
+ pub const TAB0: ::c_int = 0x0000;
+-pub const TAB1: ::c_int = 0x0400;
+-pub const TAB2: ::c_int = 0x0800;
+-pub const TAB3: ::c_int = 0x0C00;
+-pub const TABDLY: ::c_int = 0x0C00;
++pub const TAB1: ::c_int = 0x0800;
++pub const TAB2: ::c_int = 0x01000;
++pub const TAB3: ::c_int = 0x01800;
++pub const TABDLY: ::c_int = 0x01800;
+ pub const TCIFLUSH: ::c_int = 1;
+ pub const TCIOFF: ::c_int = 1;
+ pub const TCIOFLUSH: ::c_int = 2;
+@@ -294,10 +294,26 @@ pub const TCSAFLUSH: ::c_int = 3;
+ pub const TCSANOW: ::c_int = 1;
+ pub const TOSTOP: ::c_int = 0x0100;
+ pub const VT0: ::c_int = 0x0000;
+-pub const VT1: ::c_int = 0x2000;
++pub const VT1: ::c_int = 0x4000;
+ 
+ // The following are usize since they are indices into termios.c_cc
+-pub const VEOF: usize = 0;
++pub const VINTR: usize = 0;
++pub const VQUIT: usize = 1;
++pub const VERASE: usize = 2;
++pub const VKILL: usize = 3;
++pub const VEOF: usize = 4;
++pub const VTIME: usize = 5;
++pub const VMIN: usize = 6;
++pub const VSWTC: usize = 7;
++pub const VSTART: usize = 8;
++pub const VSTOP: usize = 9;
++pub const VSUSP: usize = 10;
++pub const VEOL: usize = 11;
++pub const VREPRINT: usize = 12;
++pub const VDISCARD: usize = 13;
++pub const VWERASE: usize = 14;
++pub const VLNEXT: usize = 15;
++pub const VEOL2: usize = 16;
+ 
+ pub type speed_t = ::c_uint;
+ pub type tcflag_t = ::c_uint;
+@@ -307,6 +323,7 @@ s! {
+         pub c_oflag: tcflag_t,
+         pub c_cflag: tcflag_t,
+         pub c_lflag: tcflag_t,
++        pub c_line: ::cc_t,
+         pub c_cc: [::cc_t; NCCS],
+         pub ibaud: speed_t,
+         pub obaud: speed_t,
+@@ -371,7 +388,7 @@ pub const _SC_NPROCESSORS_ONLN: ::c_int = 6;
+ pub const _SC_PAGESIZE: ::c_int = _SC_PAGE_SIZE;
+ pub const _SC_PAGE_SIZE: ::c_int = 3;
+ 
+-// abis/mlibc/socket.h
++// abis/linux/socket.h
+ pub const AF_APPLETALK: ::c_int = PF_APPLETALK;
+ pub const AF_BLUETOOTH: ::c_int = PF_BLUETOOTH;
+ pub const AF_DECnet: ::c_int = PF_DECnet;
+@@ -441,7 +458,7 @@ pub const TCP_KEEPIDLE: ::c_int = 4;
+ pub const TCP_KEEPINTVL: ::c_int = 5;
+ pub const MSG_NOSIGNAL: ::c_int = 0x10;
+ 
+-pub type sa_family_t = ::c_int;
++pub type sa_family_t = ::c_uint;
+ s! {
+     pub struct sockaddr_storage {
+         pub ss_family: sa_family_t,
+@@ -625,7 +642,7 @@ pub const IFF_MULTICAST: ::c_int = 0x1000;
+ // options/posix/include/bits/posix/stat.h
+ pub const UTIME_OMIT: c_long = 1073741822;
+ 
+-// abis/mlibc/stat.h
++// abis/linux/stat.h
+ pub const S_IFBLK: mode_t = 0x6000;
+ pub const S_IFCHR: mode_t = 0x2000;
+ pub const S_IFDIR: mode_t = 0x4000;
+-- 
+2.40.1
+

--- a/patches/rust/0001-Add-initial-Managarm-support.patch
+++ b/patches/rust/0001-Add-initial-Managarm-support.patch
@@ -1,11 +1,11 @@
-From a45000403a46b40d88cbee88668f349a06178b7b Mon Sep 17 00:00:00 2001
+From b9a0979d3c95afba1471c35a6d01a8b43e64ed3f Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
-Date: Wed, 22 Feb 2023 02:05:24 +0100
+Date: Wed, 2 Aug 2023 04:22:24 +0200
 Subject: [PATCH 1/2] Add initial Managarm support
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- Cargo.lock                                    |  10 +-
+ Cargo.lock                                    |  12 +-
  Cargo.toml                                    |   1 +
  .../src/spec/managarm_system_base.rs          |  36 +++++
  compiler/rustc_target/src/spec/mod.rs         |   3 +
@@ -18,16 +18,16 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  library/std/src/os/managarm/raw.rs            |  74 +++++++++
  library/std/src/os/mod.rs                     |   2 +
  library/std/src/os/unix/mod.rs                |   2 +
- library/std/src/sys/unix/args.rs              |   3 +-
+ library/std/src/sys/unix/args.rs              |   1 +
  library/std/src/sys/unix/env.rs               |  11 ++
- library/std/src/sys/unix/fs.rs                |   3 +-
+ library/std/src/sys/unix/fs.rs                |   1 +
  library/std/src/sys/unix/os.rs                |  34 +++-
  library/std/src/sys/unix/thread.rs            |   7 +
- library/std/src/sys/unix/thread_local_dtor.rs |   3 +-
+ library/std/src/sys/unix/thread_local_dtor.rs |   2 +-
  library/unwind/build.rs                       |   2 +
  src/bootstrap/Cargo.lock                      |  12 ++
  src/tools/rust-analyzer/Cargo.lock            |  12 ++
- 22 files changed, 383 insertions(+), 10 deletions(-)
+ 22 files changed, 381 insertions(+), 9 deletions(-)
  create mode 100644 compiler/rustc_target/src/spec/managarm_system_base.rs
  create mode 100644 compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
  create mode 100644 library/std/src/os/managarm/fs.rs
@@ -35,21 +35,23 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  create mode 100644 library/std/src/os/managarm/raw.rs
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 6a151058..1c70bc35 100644
+index 8b097249..a065f0f8 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2126,8 +2126,6 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+@@ -1988,9 +1988,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+ 
  [[package]]
  name = "libc"
- version = "0.2.138"
+-version = "0.2.143"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+-checksum = "edc207893e85c5d6be840e969b496b53d94cec8be2d501b214f50daa97fa8024"
++version = "0.2.147"
  dependencies = [
   "rustc-std-workspace-core",
  ]
-@@ -5980,3 +5978,11 @@ dependencies = [
-  "syn",
-  "synstructure",
+@@ -5911,3 +5909,11 @@ dependencies = [
+  "syn 1.0.102",
+  "synstructure 0.12.6",
  ]
 +
 +[[patch.unused]]
@@ -60,10 +62,10 @@ index 6a151058..1c70bc35 100644
 +name = "users"
 +version = "0.11.0"
 diff --git a/Cargo.toml b/Cargo.toml
-index 000c10a1..8c36570f 100644
+index 8eb378af..c366dc81 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -111,6 +111,7 @@ rustc-workspace-hack = { path = 'src/tools/rustc-workspace-hack' }
+@@ -107,6 +107,7 @@ object.debug = 0
  rustc-std-workspace-core = { path = 'library/rustc-std-workspace-core' }
  rustc-std-workspace-alloc = { path = 'library/rustc-std-workspace-alloc' }
  rustc-std-workspace-std = { path = 'library/rustc-std-workspace-std' }
@@ -114,7 +116,7 @@ index 00000000..53e2b0f0
 +    }
 +}
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index d05b8aa4..30db6831 100644
+index ba4b89c9..486fcb47 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
 @@ -67,6 +67,7 @@
@@ -125,7 +127,7 @@ index d05b8aa4..30db6831 100644
  mod hermit_base;
  mod illumos_base;
  mod l4re_base;
-@@ -1104,6 +1105,8 @@ fn $module() {
+@@ -1111,6 +1112,8 @@ fn $module() {
      ("i686-unknown-haiku", i686_unknown_haiku),
      ("x86_64-unknown-haiku", x86_64_unknown_haiku),
  
@@ -133,7 +135,7 @@ index d05b8aa4..30db6831 100644
 +
      ("aarch64-apple-darwin", aarch64_apple_darwin),
      ("x86_64-apple-darwin", x86_64_apple_darwin),
-     ("i686-apple-darwin", i686_apple_darwin),
+     ("x86_64h-apple-darwin", x86_64h_apple_darwin),
 diff --git a/compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs b/compiler/rustc_target/src/spec/x86_64_unknown_managarm_system.rs
 new file mode 100644
 index 00000000..252d11c0
@@ -160,23 +162,23 @@ index 00000000..252d11c0
 +    }
 +}
 diff --git a/library/std/Cargo.toml b/library/std/Cargo.toml
-index a7aefc26..eac64160 100644
+index 09afc696..bc1758f0 100644
 --- a/library/std/Cargo.toml
 +++ b/library/std/Cargo.toml
 @@ -15,7 +15,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
  panic_unwind = { path = "../panic_unwind", optional = true }
  panic_abort = { path = "../panic_abort" }
  core = { path = "../core" }
--libc = { version = "0.2.138", default-features = false, features = ['rustc-dep-of-std'] }
+-libc = { version = "0.2.143", default-features = false, features = ['rustc-dep-of-std'] }
 +libc = { path = "../../../rust-libc", default-features = false, features = ['rustc-dep-of-std'] }
- compiler_builtins = { version = "0.1.82" }
+ compiler_builtins = { version = "0.1.92" }
  profiler_builtins = { path = "../profiler_builtins", optional = true }
  unwind = { path = "../unwind" }
 diff --git a/library/std/build.rs b/library/std/build.rs
-index 8b1a06ee..e4d98bd0 100644
+index 0fb03c8e..9f1d8820 100644
 --- a/library/std/build.rs
 +++ b/library/std/build.rs
-@@ -24,6 +24,7 @@ fn main() {
+@@ -27,6 +27,7 @@ fn main() {
          || target.contains("l4re")
          || target.contains("redox")
          || target.contains("haiku")
@@ -185,10 +187,10 @@ index 8b1a06ee..e4d98bd0 100644
          || target.contains("wasm32")
          || target.contains("wasm64")
 diff --git a/library/std/src/lib.rs b/library/std/src/lib.rs
-index 65d4c3c8..34edb9a9 100644
+index 318a46d1..bb33c3bc 100644
 --- a/library/std/src/lib.rs
 +++ b/library/std/src/lib.rs
-@@ -598,7 +598,7 @@ pub mod arch {
+@@ -604,7 +604,7 @@ pub mod arch {
  mod panicking;
  mod personality;
  
@@ -444,10 +446,10 @@ index 00000000..eabba1c4
 +    pub st_blocks: libc::blkcnt_t, 
 +}
 diff --git a/library/std/src/os/mod.rs b/library/std/src/os/mod.rs
-index 42773805..dcb46195 100644
+index 5b54cc5f..9c15b442 100644
 --- a/library/std/src/os/mod.rs
 +++ b/library/std/src/os/mod.rs
-@@ -133,6 +133,8 @@ pub mod windows {}
+@@ -125,6 +125,8 @@ pub mod windows {}
  pub mod l4re;
  #[cfg(target_os = "macos")]
  pub mod macos;
@@ -455,9 +457,9 @@ index 42773805..dcb46195 100644
 +pub mod managarm;
  #[cfg(target_os = "netbsd")]
  pub mod netbsd;
- #[cfg(target_os = "openbsd")]
+ #[cfg(target_os = "nto")]
 diff --git a/library/std/src/os/unix/mod.rs b/library/std/src/os/unix/mod.rs
-index f97fa0fb..3bb23800 100644
+index 6fe11111..d926709a 100644
 --- a/library/std/src/os/unix/mod.rs
 +++ b/library/std/src/os/unix/mod.rs
 @@ -63,6 +63,8 @@ mod platform {
@@ -468,26 +470,24 @@ index f97fa0fb..3bb23800 100644
 +    pub use crate::os::managarm::*;
      #[cfg(target_os = "netbsd")]
      pub use crate::os::netbsd::*;
-     #[cfg(target_os = "openbsd")]
+     #[cfg(target_os = "nto")]
 diff --git a/library/std/src/sys/unix/args.rs b/library/std/src/sys/unix/args.rs
-index a342f0f5..758300df 100644
+index 9ed4d9c1..c3de976a 100644
 --- a/library/std/src/sys/unix/args.rs
 +++ b/library/std/src/sys/unix/args.rs
-@@ -69,7 +69,8 @@ fn next_back(&mut self) -> Option<OsString> {
-     target_os = "fuchsia",
-     target_os = "redox",
+@@ -71,6 +71,7 @@ fn next_back(&mut self) -> Option<OsString> {
      target_os = "vxworks",
--    target_os = "horizon"
-+    target_os = "horizon",
-+    target_os = "managarm"
+     target_os = "horizon",
+     target_os = "nto",
++    target_os = "managarm",
  ))]
  mod imp {
      use super::Args;
 diff --git a/library/std/src/sys/unix/env.rs b/library/std/src/sys/unix/env.rs
-index c9ba661c..287e34fe 100644
+index 8c3ef88d..23022ea6 100644
 --- a/library/std/src/sys/unix/env.rs
 +++ b/library/std/src/sys/unix/env.rs
-@@ -217,3 +217,14 @@ pub mod os {
+@@ -239,3 +239,14 @@ pub mod os {
      pub const EXE_SUFFIX: &str = "";
      pub const EXE_EXTENSION: &str = "";
  }
@@ -503,24 +503,22 @@ index c9ba661c..287e34fe 100644
 +    pub const EXE_EXTENSION: &str = "";
 +}
 diff --git a/library/std/src/sys/unix/fs.rs b/library/std/src/sys/unix/fs.rs
-index 37a49f2d..b92982df 100644
+index 09e9ae27..f11522ae 100644
 --- a/library/std/src/sys/unix/fs.rs
 +++ b/library/std/src/sys/unix/fs.rs
-@@ -798,7 +798,8 @@ pub fn file_type(&self) -> io::Result<FileType> {
-         target_os = "redox",
-         target_os = "vxworks",
-         target_os = "espidf",
--        target_os = "horizon"
-+        target_os = "horizon",
-+        target_os = "managarm"
+@@ -885,6 +885,7 @@ pub fn file_type(&self) -> io::Result<FileType> {
+         target_os = "horizon",
+         target_os = "vita",
+         target_os = "nto",
++        target_os = "managarm",
      ))]
      pub fn ino(&self) -> u64 {
          self.entry.d_ino as u64
 diff --git a/library/std/src/sys/unix/os.rs b/library/std/src/sys/unix/os.rs
-index 2f2663db..eea1c15e 100644
+index 8edfd331..4cc4ed13 100644
 --- a/library/std/src/sys/unix/os.rs
 +++ b/library/std/src/sys/unix/os.rs
-@@ -41,7 +41,7 @@
+@@ -40,7 +40,7 @@
  }
  
  extern "C" {
@@ -575,7 +573,7 @@ index 2f2663db..eea1c15e 100644
  /// Gets a detailed string description for the given error number.
  pub fn error_string(errno: i32) -> String {
      extern "C" {
-@@ -241,6 +264,11 @@ fn description(&self) -> &str {
+@@ -244,6 +267,11 @@ fn description(&self) -> &str {
      }
  }
  
@@ -588,7 +586,7 @@ index 2f2663db..eea1c15e 100644
  pub fn current_exe() -> io::Result<PathBuf> {
      unsafe {
 diff --git a/library/std/src/sys/unix/thread.rs b/library/std/src/sys/unix/thread.rs
-index c1d30dd9..b87c74b8 100644
+index 7307d9b2..14853d27 100644
 --- a/library/std/src/sys/unix/thread.rs
 +++ b/library/std/src/sys/unix/thread.rs
 @@ -160,6 +160,13 @@ pub fn set_name(name: &CStr) {
@@ -606,19 +604,18 @@ index c1d30dd9..b87c74b8 100644
      pub fn set_name(name: &CStr) {
          unsafe {
 diff --git a/library/std/src/sys/unix/thread_local_dtor.rs b/library/std/src/sys/unix/thread_local_dtor.rs
-index d7fd2130..cc2e5a0b 100644
+index 236d2f2e..a19db54d 100644
 --- a/library/std/src/sys/unix/thread_local_dtor.rs
 +++ b/library/std/src/sys/unix/thread_local_dtor.rs
-@@ -15,7 +15,8 @@
-     target_os = "linux",
-     target_os = "fuchsia",
-     target_os = "redox",
--    target_os = "emscripten"
-+    target_os = "emscripten",
-+    target_os = "managarm"
- ))]
- #[cfg_attr(target_family = "wasm", allow(unused))] // might remain unused depending on target details (e.g. wasm32-unknown-emscripten)
+@@ -11,7 +11,7 @@
+ // Note, however, that we run on lots older linuxes, as well as cross
+ // compiling from a newer linux to an older linux, so we also have a
+ // fallback implementation to use as well.
+-#[cfg(any(target_os = "linux", target_os = "fuchsia", target_os = "redox"))]
++#[cfg(any(target_os = "linux", target_os = "fuchsia", target_os = "redox", target_os = "managarm"))]
  pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
+     use crate::mem;
+     use crate::sys_common::thread_local_dtor::register_dtor_fallback;
 diff --git a/library/unwind/build.rs b/library/unwind/build.rs
 index 5c3c02fb..9234a0b6 100644
 --- a/library/unwind/build.rs
@@ -632,17 +629,17 @@ index 5c3c02fb..9234a0b6 100644
      }
  }
 diff --git a/src/bootstrap/Cargo.lock b/src/bootstrap/Cargo.lock
-index efe8ae31..fb0c33f8 100644
+index 8f8778ef..795e2940 100644
 --- a/src/bootstrap/Cargo.lock
 +++ b/src/bootstrap/Cargo.lock
-@@ -797,3 +797,15 @@ name = "yansi"
+@@ -924,3 +924,15 @@ name = "yansi"
  version = "0.5.1"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 +
 +[[patch.unused]]
 +name = "libc"
-+version = "0.2.138"
++version = "0.2.147"
 +
 +[[patch.unused]]
 +name = "num_cpus"
@@ -652,17 +649,17 @@ index efe8ae31..fb0c33f8 100644
 +name = "users"
 +version = "0.11.0"
 diff --git a/src/tools/rust-analyzer/Cargo.lock b/src/tools/rust-analyzer/Cargo.lock
-index 41c5d366..c1410eed 100644
+index 25242c60..d327221b 100644
 --- a/src/tools/rust-analyzer/Cargo.lock
 +++ b/src/tools/rust-analyzer/Cargo.lock
-@@ -2149,3 +2149,15 @@ dependencies = [
-  "xflags",
-  "xshell",
+@@ -2218,3 +2218,15 @@ dependencies = [
+  "flate2",
+  "time",
  ]
 +
 +[[patch.unused]]
 +name = "libc"
-+version = "0.2.138"
++version = "0.2.147"
 +
 +[[patch.unused]]
 +name = "num_cpus"
@@ -672,5 +669,5 @@ index 41c5d366..c1410eed 100644
 +name = "users"
 +version = "0.11.0"
 -- 
-2.39.1
+2.40.1
 

--- a/patches/rust/0002-managarm-fix-build-target-in-x.py-and-bootstrap.patch
+++ b/patches/rust/0002-managarm-fix-build-target-in-x.py-and-bootstrap.patch
@@ -1,6 +1,6 @@
-From 5931d5f1a7c70b2a60f4bb93f62ab4727cd789da Mon Sep 17 00:00:00 2001
+From 7df7093c43aeb9fd1a24369a13b4f2e62a45b332 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
-Date: Wed, 22 Feb 2023 02:06:19 +0100
+Date: Wed, 2 Aug 2023 04:25:11 +0200
 Subject: [PATCH 2/2] managarm: fix build target in x.py and bootstrap
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
@@ -10,28 +10,28 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  2 files changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/src/bootstrap/bootstrap.py b/src/bootstrap/bootstrap.py
-index 2d5018d9..c7c31791 100644
+index 58d1926a..6ae93659 100644
 --- a/src/bootstrap/bootstrap.py
 +++ b/src/bootstrap/bootstrap.py
-@@ -708,7 +708,7 @@ class RustBuild(object):
+@@ -833,7 +833,7 @@ class RustBuild(object):
          ... "debug", "bootstrap")
          True
          """
 -        return os.path.join(self.build_dir, "bootstrap", "debug", "bootstrap")
 +        return os.path.join(self.build_dir, "bootstrap", self.build, "debug", "bootstrap")
  
-     def build_bootstrap(self, color):
+     def build_bootstrap(self, color, verbose_count):
          """Build bootstrap"""
-@@ -717,7 +717,7 @@ class RustBuild(object):
+@@ -845,7 +845,7 @@ class RustBuild(object):
+         build_dir = os.path.join(self.build_dir, "bootstrap")
          if self.clean and os.path.exists(build_dir):
              shutil.rmtree(build_dir)
-         env = os.environ.copy()
 -        # `CARGO_BUILD_TARGET` breaks bootstrap build.
 +        # `CARGO_BUILD_TARGET` and `build.target` breaks bootstrap build.
          # See also: <https://github.com/rust-lang/rust/issues/70208>.
          if "CARGO_BUILD_TARGET" in env:
              del env["CARGO_BUILD_TARGET"]
-@@ -779,6 +779,9 @@ class RustBuild(object):
+@@ -913,6 +913,9 @@ class RustBuild(object):
          elif color == "never":
              args.append("--color=never")
  
@@ -42,10 +42,10 @@ index 2d5018d9..c7c31791 100644
          run(args, env=env, verbose=self.verbose, cwd=self.rust_root)
  
 diff --git a/src/bootstrap/builder.rs b/src/bootstrap/builder.rs
-index 8ee6d49d..78373869 100644
+index 2fa44550..0fcfaed4 100644
 --- a/src/bootstrap/builder.rs
 +++ b/src/bootstrap/builder.rs
-@@ -1406,6 +1406,8 @@ pub fn cargo(
+@@ -1570,6 +1570,8 @@ pub fn cargo(
              self.clear_if_dirty(&out_dir, &self.rustc(compiler));
          }
  
@@ -54,7 +54,7 @@ index 8ee6d49d..78373869 100644
          // Customize the compiler we're running. Specify the compiler to cargo
          // as our shim and then pass it some various options used to configure
          // how the actual compiler itself is called.
-@@ -1418,7 +1420,7 @@ pub fn cargo(
+@@ -1582,7 +1584,7 @@ pub fn cargo(
              .env("RUSTC_STAGE", stage.to_string())
              .env("RUSTC_SYSROOT", &sysroot)
              .env("RUSTC_LIBDIR", &libdir)
@@ -63,7 +63,7 @@ index 8ee6d49d..78373869 100644
              .env(
                  "RUSTDOC_REAL",
                  if cmd == "doc" || cmd == "rustdoc" || (cmd == "test" && want_rustdoc) {
-@@ -1432,7 +1434,7 @@ pub fn cargo(
+@@ -1596,7 +1598,7 @@ pub fn cargo(
          // Clippy support is a hack and uses the default `cargo-clippy` in path.
          // Don't override RUSTC so that the `cargo-clippy` in path will be run.
          if cmd != "clippy" {
@@ -73,5 +73,5 @@ index 8ee6d49d..78373869 100644
  
          // Dealing with rpath here is a little special, so let's go into some
 -- 
-2.39.1
+2.40.1
 

--- a/scripts/cargo-inject-patches.py
+++ b/scripts/cargo-inject-patches.py
@@ -8,7 +8,7 @@ import subprocess
 patched_libs = {
     "backtrace": "0.3.64",
     "calloop": "0.10.0",
-    "libc": "0.2.138",
+    "libc": "0.2.147",
     "libloading": "0.7.4",
     "mio": ["0.6.23", "0.8.3"],
     "nix": "0.24.3",


### PR DESCRIPTION
Draft as both `exa` and `ripgrep` fail to work.

For `exa`, and I believe `ripgrep` has the same issue, the following crashlog is produced
```
thor: Unhandled page fault at 0x0, faulting ip: 0x21e1d2
posix: Page fault in process /bin/exa
rax: 0000000000000000, rbx: 00007fffff8bffb0, rcx: 0000000041616f85
rdx: 0000000000000000, rdi: 00007fffffffc7d0, rsi: 0000000000000000
 r8: 0000000000000000,  r9: 0000000000000140, r10: 000000000043be70
r11: 0000000000000072, r12: 0000000000000000, r13: 0000000000000000
r14: 0000000000000000, r15: 00007fffffa3ff00, rbp: 00007ffffffff830
rip: 000000000021e1d2, rsp: 00007fffffffc7f0
Mappings:
0000000000200000 - 0000000000494000 P xr- /usr/bin/exa + 0x0
               ^ IP is 0x1e1d2 bytes into this mapping
0000000000693000 - 00000000006a9000 P -rw /usr/bin/exa + 0x0
0000000040000000 - 000000004003b000 P xr- /usr/lib/ld.so + 0x0
000000004023a000 - 000000004023b000 P -rw /usr/lib/ld.so + 0x0
0000000041000000 - 000000004101a000 P xrw /usr/lib/libz.so.1.2.12 + 0x0
0000000041219000 - 000000004121a000 P -rw /usr/lib/libz.so.1.2.12 + 0x19000
0000000041400000 - 000000004166c000 P xrw /usr/lib/libc.so + 0x0
000000004186b000 - 0000000041873000 P -rw /usr/lib/libc.so + 0x26b000
0000000041873000 - 000000004187b000 P -rw anon + 0x0
0000000041a00000 - 0000000041a16000 P xrw /usr/lib64/libgcc_s.so.1 + 0x0
0000000041c16000 - 0000000041c17000 P -rw /usr/lib64/libgcc_s.so.1 + 0x16000
```

With the following backtrace
```
(gdb) bt
#0  0x000000000021e1d2 in std::sys_common::lazy_box::LazyBox<T>::initialize::hae99c45ba7bd69bf ()
#1  0x00000000003f9d8f in <&std::io::stdio::Stdout as std::io::Write>::write_fmt::h57aa13586fcb16d6 ()
#2  0x00000000003f9c63 in <std::io::stdio::Stdout as std::io::Write>::write_fmt::h0881267436918528 ()
#3  0x0000000000272acd in exa::output::lines::Render::render<std::io::stdio::Stdout> (self=..., w=0x7fffffffeef8) at src/output/lines.rs:25
#4  0x000000000022e793 in exa::Exa::print_files (self=0x7fffffffea88, dir=..., files=...) at src/main.rs:290
#5  0x000000000022dcec in exa::Exa::print_dirs (self=0x7fffffffea88, dir_files=..., is_only_dir=true, exit_status=0) at src/main.rs:264
#6  0x000000000022cff1 in exa::Exa::run (self=...) at src/main.rs:210
#7  0x000000000022bed0 in exa::main () at src/main.rs:81
(gdb)
```