### PR TITLE
procps: Add port

### DIFF
--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -303,6 +303,66 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: elfutils
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Libraries/utilities to handle ELF objects
+      description: Elfutils is a collection of utilities, including eu-ld (a linker), eu-nm (for listing symbols from object files), eu-size (for listing the section sizes of an object or archive file), eu-strip (for discarding  symbols), eu-readelf (to see the raw ELF file structures), and eu-elflint (to check for well-formed ELF files).
+      spdx: 'LGPL-3.0-or-later GPL-2.0-or-later GPL-3.0-or-later'
+      website: 'https://sourceware.org/elfutils/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: ports
+      url: 'https://sourceware.org/elfutils/ftp/0.189/elfutils-0.189.tar.bz2'
+      format: 'tar.bz2'
+      extract_path: 'elfutils-0.189'
+      checksum: blake2b:30596271e14cf3408326abc38a9775b849b8cb0ee119a5455df9434a7d3b9a57afb15e0236a179a26c7bd400d303749964c9d6350c419f747784fd99d12517e0
+      version: '0.189'
+      patch-path-strip: 1
+      tools_required:
+        - host-autoconf-archive
+        - host-autoconf-v2.71
+        - host-automake-v1.16
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - bzip2
+      - xz-utils
+      - zlib
+      - zstd
+      - argp-standalone
+      - fts-standalone
+      - obstack-standalone
+      - libintl
+      - libiconv
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--build=x86_64-linux-gnu'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--program-prefix=eu-'
+        - '--disable-debuginfod'
+        - '--disable-libdebuginfod'
+        - '--disable-valgrind'
+        - '--with-bzlib'
+        - '--with-lzma'
+        - '--with-zstd'
+        - '--with-zlib'
+        - '--disable-nls'
+        - '--enable-thread-safety'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: fribidi
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/meta-pkgs.yml
+++ b/bootstrap.d/meta-pkgs.yml
@@ -47,7 +47,9 @@ packages:
       - man-pages-posix
       - iproute2
       - dhcpcd
-    revision: 5
+      - procps
+      - htop
+    revision: 6
     configure: []
     build: []
 

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -79,7 +79,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 8
+    revision: 9
     configure:
       # Huge hack: coreutils does not compile the build-machine binary make-prime-list
       # using the build-machine compiler. Hence, build and invoke the binary manually here.
@@ -94,7 +94,7 @@ packages:
         - '@THIS_SOURCE_DIR@/configure'
         - '--host=@OPTION:arch-triple@'
         - '--prefix=/usr'
-        - '--enable-no-install-program=kill'
+        - '--enable-no-install-program=kill,uptime'
         - 'CFLAGS=-DSLOW_BUT_NO_HACKS -Wno-error'
         environ:
           gl_cv_have_proc_uptime: 'yes'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -109,6 +109,49 @@ sources:
         recursive: true
 
 packages:
+  - name: argp-standalone
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Standalone argp library for use with musl and mlibc
+      description: Standalone argp library for use with musl and mlibc
+      spdx: 'GPL-2.0-only GPL-3.0-only'
+      website: 'https://github.com/argp-standalone/argp-standalone'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/argp-standalone/argp-standalone.git'
+      tag: '1.5.0'
+      version: '1.5.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - libintl
+    configure:
+      - args:
+          - 'meson'
+          - 'setup'
+          - '--cross-file'
+          - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+          - '--prefix=/usr'
+          - '-Dbuildtype=release'
+          - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/include']
+      - args: ['cp', '-v', '@THIS_SOURCE_DIR@/argp.h', '@THIS_COLLECT_DIR@/usr/include']
+
   - name: gdbm
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -152,6 +152,42 @@ packages:
       - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/include']
       - args: ['cp', '-v', '@THIS_SOURCE_DIR@/argp.h', '@THIS_COLLECT_DIR@/usr/include']
 
+  - name: fts-standalone
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Standalone fts library for use with musl and mlibc
+      description: Standalone fts library for use with musl and mlibc
+      spdx: 'BSD'
+      website: 'https://github.com/pullmoll/musl-fts'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/pullmoll/musl-fts.git'
+      tag: 'v1.2.7'
+      version: '1.2.7'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./bootstrap.sh']
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--enable-shared'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: gdbm
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -341,6 +341,42 @@ packages:
           echo "INPUT(-lncursesw)" > @THIS_COLLECT_DIR@/usr/lib/libcursesw.so
           ln -sfv libncurses.so      @THIS_COLLECT_DIR@/usr/lib/libcurses.so
 
+  - name: obstack-standalone
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: A standalone library to implement GNU libc's obstack
+      description: A standalone library to implement GNU libc's obstack
+      spdx: 'GPL-2.0-only'
+      website: 'https://github.com/void-linux/musl-obstack'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/void-linux/musl-obstack.git'
+      tag: 'v1.2.3'
+      version: '1.2.3'
+      tools_required:
+        - host-autoconf-v2.71
+        - host-automake-v1.16
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./bootstrap.sh']
+    tools_required:
+      - system-gcc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--enable-shared'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: readline
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/sys-process.yml
+++ b/bootstrap.d/sys-process.yml
@@ -1,5 +1,6 @@
 packages:
   - name: htop
+    labels: [aarch64]
     architecture: '@OPTION:arch@'
     metadata:
       summary: An interactive process viewer

--- a/bootstrap.d/sys-process.yml
+++ b/bootstrap.d/sys-process.yml
@@ -47,3 +47,53 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+
+  - name: procps
+    labels: [aarch64]
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Standard informational utilities and process-handling tools
+      description: The Procps-ng package contains programs for monitoring processes.
+      spdx: 'GPL-2.0-or-later LGPL-2.0-or-later LGPL-2.1-or-later'
+      website: 'https://gitlab.com/procps-ng/procps'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-process']
+    source:
+      subdir: ports
+      git: 'https://gitlab.com/procps-ng/procps.git'
+      tag: 'v4.0.4'
+      version: '4.0.4'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - ncurses
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--disable-kill'
+        - '--docdir=/usr/share/doc/procps-ng-4.0.4'
+        - '--disable-numa'
+        - '--enable-colorwatch'
+        - '--disable-nls'
+        - '--disable-w'
+        environ:
+          ac_cv_func_malloc_0_nonnull: 'yes'
+          ac_cv_func_realloc_0_nonnull: 'yes'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/patches/elfutils/0001-Add-Managarm-support.patch
+++ b/patches/elfutils/0001-Add-Managarm-support.patch
@@ -1,0 +1,113 @@
+From 35ff4bece8b47447b28ac8ac4f7cdb371b762492 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 30 Oct 2023 22:19:28 +0100
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ configure.ac       |  2 +-
+ libasm/Makefile.am |  2 +-
+ libdw/Makefile.am  |  2 +-
+ libelf/Makefile.am |  2 +-
+ src/Makefile.am    | 32 ++++++++++++++++----------------
+ 5 files changed, 20 insertions(+), 20 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 6e881fa..25fab84 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -636,7 +636,7 @@ CFLAGS="$old_CFLAGS"])
+ AS_IF([test "x$ac_cv_fno_addrsig" = "xyes"], CFLAGS="$CFLAGS -fno-addrsig")
+ 
+ saved_LIBS="$LIBS"
+-AC_SEARCH_LIBS([argp_parse], [argp])
++AC_SEARCH_LIBS([argp_parse], [argp], [], [], [-lintl])
+ LIBS="$saved_LIBS"
+ case "$ac_cv_search_argp_parse" in
+         no) AC_MSG_FAILURE([failed to find argp_parse]) ;;
+diff --git a/libasm/Makefile.am b/libasm/Makefile.am
+index 1e6b63e..d14b60d 100644
+--- a/libasm/Makefile.am
++++ b/libasm/Makefile.am
+@@ -55,7 +55,7 @@ libasm_pic_a_SOURCES =
+ am_libasm_pic_a_OBJECTS = $(libasm_a_SOURCES:.c=.os)
+ 
+ libasm_so_DEPS = ../lib/libeu.a ../libebl/libebl_pic.a ../libelf/libelf.so ../libdw/libdw.so
+-libasm_so_LDLIBS = $(libasm_so_DEPS)
++libasm_so_LDLIBS = $(libasm_so_DEPS) -lintl
+ if USE_LOCKS
+ libasm_so_LDLIBS += -lpthread
+ endif
+diff --git a/libdw/Makefile.am b/libdw/Makefile.am
+index e548f38..5e13077 100644
+--- a/libdw/Makefile.am
++++ b/libdw/Makefile.am
+@@ -110,7 +110,7 @@ libdw_so_LIBS = ../libebl/libebl_pic.a ../backends/libebl_backends_pic.a \
+ 		../libcpu/libcpu_pic.a libdw_pic.a ../libdwelf/libdwelf_pic.a \
+ 		../libdwfl/libdwfl_pic.a
+ libdw_so_DEPS = ../lib/libeu.a ../libelf/libelf.so
+-libdw_so_LDLIBS = $(libdw_so_DEPS) -ldl -lz $(argp_LDADD) $(fts_LIBS) $(obstack_LIBS) $(zip_LIBS) -pthread
++libdw_so_LDLIBS = $(libdw_so_DEPS) -ldl -lz $(argp_LDADD) $(fts_LIBS) $(obstack_LIBS) $(zip_LIBS) -pthread -lintl
+ libdw.so: $(srcdir)/libdw.map $(libdw_so_LIBS) $(libdw_so_DEPS)
+ 	$(AM_V_CCLD)$(LINK) $(dso_LDFLAGS) -o $@ \
+ 		-Wl,--soname,$@.$(VERSION),--enable-new-dtags \
+diff --git a/libelf/Makefile.am b/libelf/Makefile.am
+index aabce43..25d75ab 100644
+--- a/libelf/Makefile.am
++++ b/libelf/Makefile.am
+@@ -106,7 +106,7 @@ libelf_pic_a_SOURCES =
+ am_libelf_pic_a_OBJECTS = $(libelf_a_SOURCES:.c=.os)
+ 
+ libelf_so_DEPS = ../lib/libeu.a
+-libelf_so_LDLIBS = $(libelf_so_DEPS) -lz $(zstd_LIBS)
++libelf_so_LDLIBS = $(libelf_so_DEPS) -lz $(zstd_LIBS) -lintl
+ if USE_LOCKS
+ libelf_so_LDLIBS += -lpthread
+ endif
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 6cc019d..d2f926a 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -67,23 +67,23 @@ ranlib_no_Wstack_usage = yes
+ ar_no_Wstack_usage = yes
+ unstrip_no_Wstack_usage = yes
+ 
+-readelf_LDADD = $(libdw) $(libebl) $(libelf) $(libeu) $(argp_LDADD)
++readelf_LDADD = $(libdw) $(libebl) $(libelf) $(libeu) $(argp_LDADD) -lintl
+ nm_LDADD = $(libdw) $(libebl) $(libelf) $(libeu) $(argp_LDADD) $(obstack_LIBS) \
+-	   $(demanglelib)
+-size_LDADD = $(libelf) $(libeu) $(argp_LDADD)
+-strip_LDADD = $(libebl) $(libelf) $(libdw) $(libeu) $(argp_LDADD)
+-elflint_LDADD  = $(libebl) $(libdw) $(libelf) $(libeu) $(argp_LDADD)
+-findtextrel_LDADD = $(libdw) $(libelf) $(libeu) $(argp_LDADD)
+-addr2line_LDADD = $(libdw) $(libelf) $(libeu) $(argp_LDADD) $(demanglelib)
+-elfcmp_LDADD = $(libebl) $(libdw) $(libelf) $(libeu) $(argp_LDADD)
+-objdump_LDADD  = $(libasm) $(libebl) $(libdw) $(libelf) $(libeu) $(argp_LDADD)
+-ranlib_LDADD = libar.a $(libelf) $(libeu) $(argp_LDADD) $(obstack_LIBS)
+-strings_LDADD = $(libelf) $(libeu) $(argp_LDADD)
+-ar_LDADD = libar.a $(libelf) $(libeu) $(argp_LDADD) $(obstack_LIBS)
+-unstrip_LDADD = $(libebl) $(libelf) $(libdw) $(libeu) $(argp_LDADD)
+-stack_LDADD = $(libebl) $(libelf) $(libdw) $(libeu) $(argp_LDADD) $(demanglelib)
+-elfcompress_LDADD = $(libebl) $(libelf) $(libdw) $(libeu) $(argp_LDADD)
+-elfclassify_LDADD = $(libelf) $(libdw) $(libeu) $(argp_LDADD)
++	   $(demanglelib) -lintl
++size_LDADD = $(libelf) $(libeu) $(argp_LDADD) -lintl
++strip_LDADD = $(libebl) $(libelf) $(libdw) $(libeu) $(argp_LDADD) -lintl
++elflint_LDADD  = $(libebl) $(libdw) $(libelf) $(libeu) $(argp_LDADD) -lintl
++findtextrel_LDADD = $(libdw) $(libelf) $(libeu) $(argp_LDADD) -lintl
++addr2line_LDADD = $(libdw) $(libelf) $(libeu) $(argp_LDADD) $(demanglelib) -lintl
++elfcmp_LDADD = $(libebl) $(libdw) $(libelf) $(libeu) $(argp_LDADD) -lintl
++objdump_LDADD  = $(libasm) $(libebl) $(libdw) $(libelf) $(libeu) $(argp_LDADD) -lintl
++ranlib_LDADD = libar.a $(libelf) $(libeu) $(argp_LDADD) $(obstack_LIBS) -lintl
++strings_LDADD = $(libelf) $(libeu) $(argp_LDADD) -lintl
++ar_LDADD = libar.a $(libelf) $(libeu) $(argp_LDADD) $(obstack_LIBS) -lintl
++unstrip_LDADD = $(libebl) $(libelf) $(libdw) $(libeu) $(argp_LDADD) -lintl
++stack_LDADD = $(libebl) $(libelf) $(libdw) $(libeu) $(argp_LDADD) $(demanglelib) -lintl
++elfcompress_LDADD = $(libebl) $(libelf) $(libdw) $(libeu) $(argp_LDADD) -lintl
++elfclassify_LDADD = $(libelf) $(libdw) $(libeu) $(argp_LDADD) -lintl
+ 
+ installcheck-binPROGRAMS: $(bin_PROGRAMS)
+ 	bad=0; pid=$$$$; list="$(bin_PROGRAMS)"; for p in $$list; do \
+-- 
+2.42.0
+

--- a/patches/procps/0001-Add-Managarm-support.patch
+++ b/patches/procps/0001-Add-Managarm-support.patch
@@ -1,0 +1,26 @@
+From 9f45d4f4a58b7a71c1d8b233290b75d373e7012f Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 30 Oct 2023 20:43:47 +0100
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ local/signals.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/local/signals.c b/local/signals.c
+index caff420..23b5612 100644
+--- a/local/signals.c
++++ b/local/signals.c
+@@ -121,7 +121,7 @@ static const mapstruct sigtable[] = {
+ #define STATIC_ASSERT(x) typedef int XJOIN(static_assert_on_line_,__LINE__)[(x) ? 1 : -1]
+ 
+ /* sanity check */
+-#if defined(__linux__)
++#if defined(__linux__) || defined(__managarm__)
+ STATIC_ASSERT(number_of_signals == 31);
+ #elif defined(__FreeBSD_kernel__) || defined(__FreeBSD__)
+ STATIC_ASSERT(number_of_signals == 30);
+-- 
+2.42.0
+


### PR DESCRIPTION
Add `procps` and mark `htop` and `procps` as buildable for AArch64. Also add them to the `base` package. Tell `coreutils` to not install `uptime`, `procps` provides that.

Also adds `argp-standalone`, `fts-standalone`, `obstack-standalone` and `elfutils` as ports.

Depends on managarm/mlibc#941
Depends on managarm/mlibc#942
Depends on managarm/mlibc#943