### PR TITLE
mesa-git: add port

### DIFF
--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -871,6 +871,93 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: mesa-git
+    labels: [aarch64]
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: OpenGL-like graphic library for Linux
+      description: This package provides an open source implementation of OpenGL, OpenGL ES, Vulkan, and other APIs. Rolling Version.
+      spdx: 'MIT'
+      website: 'https://www.mesa3d.org/'
+      maintainer: "Alexander Richards <electrodeyt@gmail.com>"
+      categories: ['media-libs']
+      replaces: ['mesa']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.freedesktop.org/mesa/mesa.git'
+      branch: 'main'
+      rolling_version: true
+      version: '0.0pl@ROLLING_ID@'
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - wayland-scanner
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - virtual: pkgconfig-for-host
+        program_name: host-pkg-config
+    pkgs_required:
+      - mlibc
+      - libdrm
+      - llvm
+      - wayland
+      - wayland-protocols
+      - zlib
+      - libxshmfence
+      - libxrandr
+      - libxdamage
+      - libxxf86vm
+      - libxfixes
+      - libx11
+      - libxext
+      - libxcb
+      - libglvnd
+      - libexpat
+      - zstd
+    configure:
+      - args: ['cp', '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file', 'meson.cross-file']
+      - args:
+        - 'sed'
+        - '-i'
+        - "/^# sed adds binaries here.$/a llvm-config = '@SOURCE_ROOT@/scripts/cross-llvm-config'"
+        - 'meson.cross-file'
+      - args:
+        - 'meson'
+        - '--native-file'
+        - '@SOURCE_ROOT@/scripts/meson.native-file'
+        - '--cross-file'
+        - 'meson.cross-file'
+        - '--prefix=/usr'
+        - '--libdir=lib'
+        # The debug build type enables some additional output from Mesa.
+        - '--buildtype=debugoptimized'
+        #- '--buildtype=debug'
+        - '-Dglx=dri'
+        - '-Dplatforms=wayland,x11'
+        - '-Dgallium-drivers=swrast'
+        - '-Dvulkan-drivers='
+        - '-Dglvnd=true'
+        # Force Mesa to build with LLVM.
+        - '-Dllvm=enabled'
+        - '-Dgallium-nine=false'
+        - '-Dgallium-va=disabled'
+        - '-Dgallium-vdpau=disabled'
+        - '-Dgallium-xa=disabled'
+        - '-Dshared-glapi=enabled'
+        - '-Ddri3=enabled'
+        - '-Degl=enabled'
+        - '-Dgbm=enabled'
+        - '-Dgles1=enabled'
+        - '-Dgles2=enabled'
+        - '-Dzstd=enabled'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: vulkan-loader
     architecture: '@OPTION:arch@'
     metadata:


### PR DESCRIPTION
This package is effectively a rolling-release version of mesa, tracking the upstream main branch.

This port does not require any patches, due to the recent up streaming of our patches into mainline mesa.