### PR TITLE
Small fixes

### DIFF
--- a/bootstrap.d/dev-qt.yml
+++ b/bootstrap.d/dev-qt.yml
@@ -80,6 +80,7 @@ packages:
       - xcb-util-keysyms
       - xcb-util-wm
       - xcb-util-render-util
+      - xcb-util-cursor
       - openssl
       - wayland
       - wayland-protocols

--- a/bootstrap.d/sys-apps.yml
+++ b/bootstrap.d/sys-apps.yml
@@ -698,6 +698,7 @@ packages:
     pkgs_required:
       - mlibc
       - eudev
+      - zlib
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1875,11 +1875,18 @@ packages:
   - name: pango
     labels: [aarch64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: Internationalized text layout and rendering library
+      description: Pango is a library for laying out and rendering text, with an emphasis on internationalization. It can be used anywhere that text layout is needed, though most of the work on Pango so far has been done in the context of the GTK+ widget toolkit.
+      spdx: 'LGPL-2.0-or-later'
+      website: 'https://gitlab.gnome.org/GNOME/pango'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['x11-libs']
     source:
       subdir: ports
       git: 'https://gitlab.gnome.org/GNOME/pango.git'
-      tag: '1.50.14'
-      version: '1.50.14'
+      tag: '1.51.1'
+      version: '1.51.1'
     tools_required:
       - host-pkg-config
       - system-gcc
@@ -1900,7 +1907,6 @@ packages:
       - harfbuzz
       - libxft
       - pcre
-    revision: 3
     configure:
       - args:
         - 'meson'


### PR DESCRIPTION
This PR fixes a Werror warning in `pango` by updating it and adds a missing dependency on `zlib` for `pciutils` and on `xcb-util-cursor` for `qtbase6`.