### PR TITLE
Limine 6 fixes

### DIFF
--- a/scripts/grub.cfg
+++ b/scripts/grub.cfg
@@ -1,6 +1,5 @@
 
 menuentry "managarm (Weston, e9 output, 1024x768, plainfb)" {
-	search.fs_uuid @ROOT_UUID@ root
 	multiboot2 /boot/managarm/eir-mb2 bochs init.launch=weston plainfb.force=1
 	module2 /boot/managarm/thor
 	module2 /boot/managarm/initrd.cpio
@@ -8,7 +7,6 @@ menuentry "managarm (Weston, e9 output, 1024x768, plainfb)" {
 }
 
 menuentry "managarm (kmscon, e9 output, 1024x768, plainfb)" {
-	search.fs_uuid @ROOT_UUID@ root
 	multiboot2 /boot/managarm/eir-mb2 bochs init.launch=kmscon plainfb.force=1
 	module2 /boot/managarm/thor
 	module2 /boot/managarm/initrd.cpio
@@ -16,7 +14,6 @@ menuentry "managarm (kmscon, e9 output, 1024x768, plainfb)" {
 }
 
 menuentry "managarm (Weston, e9 output, 1024x768)" {
-	search.fs_uuid @ROOT_UUID@ root
 	multiboot2 /boot/managarm/eir-mb2 bochs init.launch=weston
 	module2 /boot/managarm/thor
 	module2 /boot/managarm/initrd.cpio
@@ -24,7 +21,6 @@ menuentry "managarm (Weston, e9 output, 1024x768)" {
 }
 
 menuentry "managarm (kmscon, e9 output, 1024x768)" {
-	search.fs_uuid @ROOT_UUID@ root
 	multiboot2 /boot/managarm/eir-mb2 bochs init.launch=kmscon
 	module2 /boot/managarm/thor
 	module2 /boot/managarm/initrd.cpio
@@ -32,7 +28,6 @@ menuentry "managarm (kmscon, e9 output, 1024x768)" {
 }
 
 menuentry "managarm (development: profiling)" {
-	search.fs_uuid @ROOT_UUID@ root
 	multiboot2 /boot/managarm/eir-mb2 bochs init.launch=weston plainfb.force=1 kernel-profile
 	module2 /boot/managarm/thor
 	module2 /boot/managarm/initrd.cpio
@@ -40,7 +35,6 @@ menuentry "managarm (development: profiling)" {
 }
 
 menuentry "managarm (sway, e9 output, 1024x768)" {
-	search.fs_uuid @ROOT_UUID@ root
 	multiboot2 /boot/managarm/eir-mb2 bochs init.launch=sway
 	module2 /boot/managarm/thor
 	module2 /boot/managarm/initrd.cpio

--- a/scripts/limine.cfg
+++ b/scripts/limine.cfg
@@ -2,76 +2,76 @@ TIMEOUT=3
 
 :managarm (Weston, e9 output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+KERNEL_PATH=boot:///managarm/eir-mb2
 PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=weston plainfb.force=1
 
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
+MODULE_PATH=boot:///managarm/thor
+MODULE_PATH=boot:///managarm/initrd.cpio
 
 :managarm (kmscon, e9 output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+KERNEL_PATH=boot:///managarm/eir-mb2
 PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=kmscon plainfb.force=1
 
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
+MODULE_PATH=boot:///managarm/thor
+MODULE_PATH=boot:///managarm/initrd.cpio
 
 :managarm (sway, e9 output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+KERNEL_PATH=boot:///managarm/eir-mb2
 PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=sway plainfb.force=1
 
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
+MODULE_PATH=boot:///managarm/thor
+MODULE_PATH=boot:///managarm/initrd.cpio
 
 :managarm (Weston, e9 output)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+KERNEL_PATH=boot:///managarm/eir-mb2
 PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=weston
 
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
+MODULE_PATH=boot:///managarm/thor
+MODULE_PATH=boot:///managarm/initrd.cpio
 
 :managarm (kmscon, e9 output)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+KERNEL_PATH=boot:///managarm/eir-mb2
 PROTOCOL=multiboot2
 CMDLINE=bochs init.launch=kmscon
 
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
+MODULE_PATH=boot:///managarm/thor
+MODULE_PATH=boot:///managarm/initrd.cpio
 
 :Physical hardware
 
 ::managarm (Weston, serial output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+KERNEL_PATH=boot:///managarm/eir-mb2
 PROTOCOL=multiboot2
 CMDLINE=serial init.launch=weston plainfb.force=1
 
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
+MODULE_PATH=boot:///managarm/thor
+MODULE_PATH=boot:///managarm/initrd.cpio
 
 ::managarm (kmscon, serial output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+KERNEL_PATH=boot:///managarm/eir-mb2
 PROTOCOL=multiboot2
 CMDLINE=serial init.launch=kmscon plainfb.force=1
 
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
+MODULE_PATH=boot:///managarm/thor
+MODULE_PATH=boot:///managarm/initrd.cpio
 
 :Expert options
 
 ::managarm (profiling, Weston, e9 output, plainfb)
 
-KERNEL_PATH=uuid://@ROOT_UUID@/boot/managarm/eir-mb2
+KERNEL_PATH=boot:///managarm/eir-mb2
 PROTOCOL=multiboot2
 CMDLINE=kernel-profile bochs init.launch=weston plainfb.force=1
 
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/thor
-MODULE_PATH=uuid://@ROOT_UUID@/boot/managarm/initrd.cpio
+MODULE_PATH=boot:///managarm/thor
+MODULE_PATH=boot:///managarm/initrd.cpio


### PR DESCRIPTION
Update the disk layout to accomodate Limine 6 dropping support for Ext2/3/4.

This will require everyone to create new disk images since the ESP needs to be
larger now. `update-image.py` will issue an

Depends on https://github.com/qookei/image_create/pull/1 for creating images
with the new partition table layout.