### PR TITLE
Port gnome-calculator

### DIFF
--- a/bootstrap.d/app-crypt.yml
+++ b/bootstrap.d/app-crypt.yml
@@ -1,4 +1,99 @@
 packages:
+  - name: libsecret
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: GObject library for accessing the freedesktop.org Secret Service API
+      description: This package contains a GObject based library for accessing the Secret Service API.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://wiki.gnome.org/Projects/Libsecret'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-crypt']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/libsecret.git'
+      tag: '0.21.3'
+      version: '0.21.3'
+    tools_required:
+      - host-pkg-config
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: '@OPTION:arch-triple@'
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
+      - host-glib
+      - host-vala
+    pkgs_required:
+      - mlibc
+      - glib
+      - libgcrypt
+      - gobject-introspection
+      - libxslt
+    configure:
+      - args:
+          - 'meson'
+          - 'setup'
+          - '--cross-file'
+          - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+          - '--prefix=/usr'
+          - '--wrap-mode=nofallback'
+          - '--sysconfdir=/etc'
+          - '-Dgtk_doc=false'
+          - '-Dintrospection=true'
+          - '-Dvapi=true'
+          - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+    build:
+      - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VALAC: 'cross-valac'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VALAC: 'cross-valac'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+
   - name: p11-kit
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/app-text.yml
+++ b/bootstrap.d/app-text.yml
@@ -1,0 +1,31 @@
+packages:
+  - name: iso-codes
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: ISO language, territory, currency, script codes and their translations
+      description: This package contains a list of country, language and currency names and it is used as a central database for accessing this data.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://salsa.debian.org/iso-codes-team/iso-codes'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['app-text']
+    source:
+      subdir: ports
+      url: 'https://ftp.debian.org/debian/pool/main/i/iso-codes/iso-codes_4.16.0.orig.tar.xz'
+      format: 'tar.xz'
+      extract_path: 'iso-codes-4.16.0'
+      checksum: blake2b:16baf4732392a976ab46efaa6c1c9bd19d3a08bd217f19c5e781db9ea81240b1adfb6063873ecbb97a5134ef990c9bfe98bc2bbecb791213afccb734f228fd4a
+      version: '4.16.0'
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -63,7 +63,8 @@ tools:
     tools_required:
       - host-llvm-toolchain
       - host-python
-    revision: 1
+      - host-libffi
+    revision: 2
     compile:
       - args: |
             cat << EOF > config.toml

--- a/bootstrap.d/dev-lang.yml
+++ b/bootstrap.d/dev-lang.yml
@@ -25,6 +25,14 @@ sources:
     tag: '1.77.1'
     version: '1.77.1'
 
+  - name: vala
+    subdir: 'ports'
+    url: 'https://download.gnome.org/sources/vala/0.56/vala-0.56.14.tar.xz'
+    format: 'tar.xz'
+    checksum: blake2b:db6ccca635122ff2089cd61fd8335376eed435f15d9bd7c20837829fe5acc8df49a51194e3bc17d0c24567240cf2519348cc2b0a7b177b971dc037ed39e893de
+    extract_path: 'vala-0.56.14'
+    version: '0.56.14'
+
   - name: host-bootstrap-cargo
     subdir: 'ports'
     url: 'https://static.rust-lang.org/dist/cargo-1.75.0-x86_64-unknown-linux-gnu.tar.xz'
@@ -128,6 +136,27 @@ tools:
         - '--root'
         - '@PREFIX@'
         isolate_network: false
+
+  - name: host-vala
+    architecture: noarch
+    from_source: vala
+    tools_required:
+      - host-glib
+      - virtual: pkgconfig-for-host
+        program_name: host-pkg-config
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--prefix=@PREFIX@'
+        - '--disable-valadoc'
+        environ:
+          PKG_CONFIG: host-pkg-config
+    compile:
+      - args: ['make', '-j@PARALLELISM@']
+    install:
+      - args: ['make', 'install']
+      - args: ['cp', '-pv', '@SOURCE_ROOT@/scripts/cross-valac', '@PREFIX@/bin']
+      - args: ['cp', '-pv', '@SOURCE_ROOT@/scripts/cross-vapigen', '@PREFIX@/bin']
 
 packages:
   - name: lua

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -25,6 +25,21 @@ sources:
           '@BUILD_ROOT@/tools/host-automake-v1.15/share/automake-1.15/config.sub',
           '@THIS_SOURCE_DIR@/icu4c/source']
 
+  - name: libffi
+    subdir: 'ports'
+    git: 'https://github.com/libffi/libffi.git'
+    tag: 'v3.4.4'
+    version: '3.4.4'
+    tools_required:
+      - host-autoconf-v2.71
+      - host-automake-v1.11
+      - host-libtool
+    regenerate:
+      - args: ['./autogen.sh']
+      - args: ['cp',
+          '@BUILD_ROOT@/tools/host-automake-v1.11/share/automake-1.11/config.sub',
+          '@THIS_SOURCE_DIR@/']
+
   - name: nss
     subdir: 'ports'
     git: 'https://github.com/nss-dev/nss.git'
@@ -84,6 +99,19 @@ tools:
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/icu4c/source/configure'
+        - '--prefix=@PREFIX@'
+    compile:
+      - args: ['make', '-j@PARALLELISM@']
+    install:
+      - args: ['make', 'install']
+  
+  - name: host-libffi
+    labels: [aarch64]
+    architecture: '@OPTION:arch@'
+    from_source: libffi
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
         - '--prefix=@PREFIX@'
     compile:
       - args: ['make', '-j@PARALLELISM@']
@@ -630,20 +658,7 @@ packages:
   - name: libffi
     labels: [aarch64]
     architecture: '@OPTION:arch@'
-    source:
-      subdir: 'ports'
-      git: 'https://github.com/libffi/libffi.git'
-      tag: 'v3.4.4'
-      version: '3.4.4'
-      tools_required:
-        - host-autoconf-v2.71
-        - host-automake-v1.11
-        - host-libtool
-      regenerate:
-        - args: ['./autogen.sh']
-        - args: ['cp',
-            '@BUILD_ROOT@/tools/host-automake-v1.11/share/automake-1.11/config.sub',
-            '@THIS_SOURCE_DIR@/']
+    from_source: libffi
     tools_required:
       - system-gcc
     pkgs_required:

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -91,6 +91,61 @@ tools:
       - args: ['make', 'install']
 
 packages:
+  - name: appstream
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Cross-distro effort for providing metadata for software in the Linux ecosystem
+      description: This package provides a library and tool that is useful for retrieving software metadata and making it easily accessible to programs which need it.
+      spdx: 'LGPL-2.1-or-later GPL-2.0-or-later'
+      website: 'https://www.freedesktop.org/wiki/Distributions/AppStream/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/ximion/appstream.git'
+      tag: 'v0.16.4'
+      version: '0.16.4'
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - curl
+      - glib
+      - libxml
+      - libxmlb
+      - libyaml
+    configure:
+      - args: ['mkdir', '-pv', '@THIS_BUILD_DIR@/data']
+      - args: ['cp', '-r', '@THIS_SOURCE_DIR@/data/org.freedesktop.appstream.cli.metainfo.xml', '@THIS_BUILD_DIR@/data/nol10n_withrelinfo_org.freedesktop.appstream.cli.metainfo.xml']
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--buildtype=release'
+        - '-Dapidocs=false'
+        - '-Ddocs=false'
+        - '-Dcompose=false'
+        - '-Dmaintainer=false'
+        - '-Dstatic-analysis=false'
+        - '-Dstemming=false'
+        - '-Dvapi=false'
+        - '-Dapt-support=false'
+        - '-Dinstall-docs=false'
+        - '-Dgir=false'
+        - '-Dqt=false'
+        - '-Dsystemd=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: atk
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -710,6 +710,49 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
 
+  - name: libgee
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: GObject-based interfaces and classes for commonly used data structures
+      description: This package provides acollection library providing GObject based interfaces and classes for commonly used data structures.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://wiki.gnome.org/Projects/Libgee'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: 'ports'
+      url: 'http://ftp.gnome.org/pub/gnome/sources/libgee/0.20/libgee-0.20.6.tar.xz'
+      format: 'tar.xz'
+      checksum: 'blake2b:cdb88719e0e1bceccefd6a824823e6e514bf1f4d6b8cf5330d6d83f781649312b23554c7dfc4a6b4eeb3bbcd81ca42843666d596b85634ff95fc90e90fea44bd'
+      extract_path: 'libgee-0.20.6'
+      version: '0.20.6'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+      - host-vala
+    pkgs_required:
+      - mlibc
+      - glib
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--enable-vala=yes'
+        - '--enable-introspection=no'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   # Updating to 1.47 broke libgcrypt, must be investigated
   - name: libgpg-error
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -1148,6 +1148,45 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libxmlb
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Library to help create and query binary XML blobs
+      description: This package provides a library and a tool which help create and query binary XML blobs.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://github.com/hughsie/libxmlb'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/hughsie/libxmlb.git'
+      tag: '0.3.15'
+      version: '0.3.15'
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--buildtype=release'
+        - '-Dgtkdoc=false'
+        - '-Dintrospection=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: libxslt
     architecture: '@OPTION:arch@'
     source:

--- a/bootstrap.d/dev-libs.yml
+++ b/bootstrap.d/dev-libs.yml
@@ -1231,6 +1231,43 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libyaml
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: YAML 1.1 parser and emitter written in C
+      description: This package contains a C library for parsing and emitting YAML (YAML Ain't Markup Language) code.
+      spdx: 'MIT'
+      website: 'https://github.com/yaml/libyaml'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['dev-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/yaml/libyaml.git'
+      tag: '0.2.5'
+      version: '0.2.5'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+      regenerate:
+        - args: ['autoreconf', '-f', '-i']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: mpc
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/gnome-extra.yml
+++ b/bootstrap.d/gnome-extra.yml
@@ -1,0 +1,62 @@
+packages:
+  - name: gnome-calculator
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: A calculator application for GNOME
+      description: This package provides a powerful graphical calculator with financial, logical and scientific modes. It uses a multiple precision package to do its arithmetic to give a high degree of accuracy.
+      spdx: 'GPL-3.0-or-later'
+      website: 'https://wiki.gnome.org/Apps/Calculator'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['gnome-extra']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/gnome-calculator.git'
+      tag: '45.0.2'
+      version: '45.0.2'
+    tools_required:
+      - system-gcc
+      - wayland-scanner
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - host-vala
+    pkgs_required:
+      - mlibc
+      - glib
+      - gtk4
+      - libxml
+      - libsoup3
+      - libgee
+      - mpfr
+      - mpc
+      - libadwaita
+      - gtksourceview5
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--native-file'
+        - '@SOURCE_ROOT@/scripts/meson.native-file'
+        - '--prefix=/usr'
+        - '--buildtype=release'
+        - '--wrap-mode=nodownload'
+        - '-Dgcalc=true'
+        - '-Dgci=true'
+        - '-Dapp=true'
+        - '-Ddoc=false'
+        - '@THIS_SOURCE_DIR@'
+        environ:
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+    build:
+      - args: ['ninja']
+        environ:
+          VALAC: 'cross-valac'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+    scripts:
+        post_install:
+          - args: ['glib-compile-schemas', '/usr/share/glib-2.0/schemas']
+          - args: ['gtk4-update-icon-cache', '-q', '-t', '-f', '/usr/share/icons/hicolor']

--- a/bootstrap.d/gui-libs.yml
+++ b/bootstrap.d/gui-libs.yml
@@ -116,6 +116,90 @@ packages:
         post_install:
           - args: ['glib-compile-schemas', '/usr/share/glib-2.0/schemas']
 
+  - name: gtksourceview5
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: A text widget implementing syntax highlighting and other features
+      description: This package contains a library used for extending the GTK text functions to include syntax highlighting.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://wiki.gnome.org/Projects/GtkSourceView'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['gui-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/gtksourceview.git'
+      tag: '5.11.0'
+      version: '5.11.0'
+    tools_required:
+      - system-gcc
+      - wayland-scanner
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - host-vala
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
+    pkgs_required:
+      - mlibc
+      - glib
+      - gtk4
+      - libxml
+      - fribidi
+      - fontconfig 
+      - pango
+      - pcre2
+      - gobject-introspection
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--buildtype=release'
+        - '--wrap-mode=nodownload'
+        - '-Dinstall_tests=false'
+        - '-Dintrospection=enabled'
+        - '-Dvapi=true'
+        - '-Dgtk_doc=false'
+        - '-Dsysprof=false'
+        - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+    build:
+      - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VALAC: 'cross-valac'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+    scripts:
+        post_install:
+          - args: ['gtk4-update-icon-cache', '-q', '-t', '-f', '/usr/share/icons/hicolor']
+
   - name: libadwaita
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/gui-libs.yml
+++ b/bootstrap.d/gui-libs.yml
@@ -1,4 +1,121 @@
 packages:
+  - name: gtk4
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: GTK is a multi-platform toolkit for creating graphical user interfaces
+      description: This package provides libraries used for creating graphical user interfaces for applications.
+      spdx: 'LGPL-2.0-or-later'
+      website: 'https://www.gtk.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['gui-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/gtk.git'
+      tag: '4.12.5'
+      version: '4.12.5'
+    tools_required:
+      - system-gcc
+      - wayland-scanner
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
+      - host-glib
+    pkgs_required:
+      - mlibc
+      - glib
+      - cairo
+      - pango
+      - fribidi
+      - harfbuzz
+      - gdk-pixbuf
+      - libpng
+      - libtiff
+      - libjpeg-turbo
+      - libepoxy
+      - libxkbcommon
+      - graphene
+      - iso-codes
+      - wayland
+      - wayland-protocols
+      - libx11
+      - libxrandr
+      - libxrender
+      - libxi
+      - libxext
+      - libxcursor
+      - libxdamage
+      - libxfixes
+      - fontconfig
+      - libxinerama
+      - gobject-introspection
+      - gst-plugins-good
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--buildtype=release'
+        - '--wrap-mode=nodownload'
+        - '-Dintrospection=enabled'
+        - '-Dbroadway-backend=true'
+        - '-Dwayland-backend=true'
+        - '-Dx11-backend=true'
+        - '-Dcloudproviders=disabled'
+        - '-Dtracker=disabled'
+        - '-Dcolord=disabled'
+        - '-Dman-pages=false'
+        - '-Dsysprof=disabled'
+        - '-Dvulkan=disabled'
+        - '-Dprint-cups=disabled'
+        - '-Ddocumentation=false'
+        - '-Dscreenshots=false'
+        - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+    build:
+      - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
+    scripts:
+        post_install:
+          - args: ['glib-compile-schemas', '/usr/share/glib-2.0/schemas']
+
   - name: libwpe
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/gui-libs.yml
+++ b/bootstrap.d/gui-libs.yml
@@ -116,6 +116,87 @@ packages:
         post_install:
           - args: ['glib-compile-schemas', '/usr/share/glib-2.0/schemas']
 
+  - name: libadwaita
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Building blocks for modern GNOME applications
+      description: This package provides additional GTK4 UI widgets for use in developing user interfaces. It is used primarily for GNOME applications.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://gnome.pages.gitlab.gnome.org/libadwaita/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['gui-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/libadwaita.git'
+      tag: '1.4.2'
+      version: '1.4.2'
+    tools_required:
+      - system-gcc
+      - wayland-scanner
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - host-vala
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
+    pkgs_required:
+      - mlibc
+      - glib
+      - gtk4
+      - appstream
+      - fribidi
+      - gobject-introspection
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--native-file'
+        - '@SOURCE_ROOT@/scripts/meson.native-file'
+        - '--prefix=/usr'
+        - '--buildtype=release'
+        - '--wrap-mode=nodownload'
+        - '-Dprofiling=false'
+        - '-Dintrospection=enabled'
+        - '-Dvapi=true'
+        - '-Dgtk_doc=false'
+        - '-Dtests=false'
+        - '-Dexamples=false'
+        - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+    build:
+      - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VALAC: 'cross-valac'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libwpe
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -585,6 +585,10 @@ packages:
       - host-pkg-config
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
+      - host-glib
     pkgs_required:
       - mlibc
       - graphite2
@@ -593,7 +597,7 @@ packages:
       - freetype
       - cairo
       - icu
-    revision: 9
+    revision: 10
     configure:
       - args:
         - 'meson'
@@ -606,16 +610,35 @@ packages:
         - '--buildtype=debugoptimized'
         - '-Dgraphite2=enabled'
         - '-Dglib=enabled'
-        - '-Dgobject=disabled'
+        - '-Dgobject=enabled'
         - '-Dicu=enabled'
         - '-Dfreetype=enabled'
         - '-Dcairo=enabled'
-        - '-Dintrospection=disabled'
+        - '-Dintrospection=enabled'
         - '-Ddocs=disabled'
         - '-Dtests=disabled' # Disabled due to a linking error
         - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
     build:
       - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -294,6 +294,47 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: graphene
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: A thin layer of types for graphic libraries
+      description: This package provides a thin layer of types for graphics libraries.
+      spdx: 'MIT'
+      website: 'https://ebassi.github.io/graphene/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['media-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/ebassi/graphene.git'
+      tag: '1.10.8'
+      version: '1.10.8'
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - glib
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--buildtype=release'
+        - '-Dgtk_doc=false'
+        - '-Dintrospection=disabled'
+        - '-Dtests=false'
+        - '-Dinstalled_tests=false'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+        quiet: true
+
   - name: gst-plugins-bad
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/media-libs.yml
+++ b/bootstrap.d/media-libs.yml
@@ -312,9 +312,14 @@ packages:
       - system-gcc
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
+      - host-glib
     pkgs_required:
       - mlibc
       - glib
+      - gobject-introspection
     configure:
       - args:
         - 'meson'
@@ -324,12 +329,31 @@ packages:
         - '--prefix=/usr'
         - '--buildtype=release'
         - '-Dgtk_doc=false'
-        - '-Dintrospection=disabled'
+        - '-Dintrospection=enabled'
         - '-Dtests=false'
         - '-Dinstalled_tests=false'
         - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
     build:
       - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/net-dns.yml
+++ b/bootstrap.d/net-dns.yml
@@ -1,4 +1,34 @@
 packages:
+  - name: c-ares
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: C library that resolves names asynchronously
+      description: This package contains a C library for asynchronous DNS requests.
+      spdx: 'MIT'
+      website: 'https://c-ares.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-dns']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/c-ares/c-ares.git'
+      tag: 'cares-1_18_1'
+      version: '1.18.1'
+    tools_required:
+      - system-gcc
+      - host-cmake
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        - '-DCMAKE_TOOLCHAIN_FILE=@SOURCE_ROOT@/scripts/CMakeToolchain-@OPTION:arch-triple@.txt'
+        - '-DCMAKE_INSTALL_PREFIX=/usr'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libidn2
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -250,6 +250,92 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libsoup3
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: HTTP client/server library for GNOME
+      description: This package provides a HTTP client/server library for GNOME. It uses GObject and the GLib main loop to integrate with GNOME applications and it also has an asynchronous API for use in threaded applications.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://wiki.gnome.org/Projects/libsoup'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-libs']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.gnome.org/GNOME/libsoup.git'
+      tag: '3.4.4'
+      version: '3.4.4'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
+      - host-vala
+      - host-glib
+    pkgs_required:
+      - mlibc
+      - glib
+      - glib-networking
+      - nghttp2
+      - sqlite
+      - brotli
+      - libpsl
+      - zlib
+      - gobject-introspection
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--wrap-mode=nofallback'
+        - '--buildtype=debugoptimized'
+        - '-Dintrospection=enabled'
+        - '-Dinstalled_tests=false'
+        - '-Dsysprof=disabled'
+        - '-Dvapi=enabled'
+        - '-Dtls_check=false'
+        - '-Dbrotli=disabled'
+        - '-Dntlm=disabled'
+        - '-Dgssapi=disabled'
+        - '-Dtests=false'
+        - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+    build:
+      - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
+          VALADIR: '@SYSROOT_DIR@/usr/share/vala/vapi'
+          # Wrapper to add our valadir
+          VALAC: 'cross-valac'
+          # Wrapper to add our valadir
+          VAPIGEN: 'cross-vapigen'
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: nghttp2
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/net-libs.yml
+++ b/bootstrap.d/net-libs.yml
@@ -250,6 +250,58 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: nghttp2
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: HTTP/2 C Library
+      description: This package provides an implementation of HTTP/2 and its header compression algorithm, HPACK.
+      spdx: 'MIT'
+      website: 'https://nghttp2.org/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['net-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/nghttp2/nghttp2.git'
+      tag: 'v1.46.0'
+      version: '1.46.0'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+        - host-xorg-macros
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+      - openssl
+      - libevent
+      - libxml
+      - zlib
+      - c-ares
+      - boost
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+        - '--disable-static'
+        - '--enable-lib-only'
+        - '--docdir=/usr/share/doc/nghttp2-1.46.0'
+        - '--disable-examples'
+        - '--disable-failmalloc'
+        - '--disable-python-bindings'
+        - '--disable-werror'
+        - '--without-cython'
+        - '--enable-threads'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: webkitgtk
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/sys-libs.yml
+++ b/bootstrap.d/sys-libs.yml
@@ -283,11 +283,14 @@ packages:
         - '--prefix=/usr'
         - '--disable-static'
         - '--enable-multibyte'
+        - '--with-curses'
     build:
-      - args: ['make', '-j@PARALLELISM@']
-      - args: ['make', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
+      - args: ['make', 'SHLIB_LIBS="-lncursesw"', '-j@PARALLELISM@']
+      - args: ['make', 'SHLIB_LIBS="-lncursesw"', 'DESTDIR=@THIS_COLLECT_DIR@', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['patchelf', '--set-soname', 'libreadline.so.8', '@THIS_COLLECT_DIR@/usr/lib/libreadline.so.8']
+      - args: ['patchelf', '--set-soname', 'libhistory.so.8', '@THIS_COLLECT_DIR@/usr/lib/libhistory.so.8']
 
   - name : tzdata
     labels: [aarch64]

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -1920,6 +1920,9 @@ packages:
       - host-glib
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
     pkgs_required:
       - mlibc
       - glib
@@ -1934,7 +1937,7 @@ packages:
       - harfbuzz
       - libxft
       - pcre
-    revision: 4
+    revision: 5
     configure:
       - args:
         - 'meson'
@@ -1942,11 +1945,30 @@ packages:
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
         - '--buildtype=release'
-        - '-Dintrospection=disabled'
+        - '-Dintrospection=enabled'
         - '--wrap-mode=nofallback'
         - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
     build:
       - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -110,6 +110,10 @@ packages:
       - host-pkg-config
       - virtual: pkgconfig-for-target
         triple: "@OPTION:arch-triple@"
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
+      - host-glib
     pkgs_required:
       - mlibc
       - glib
@@ -117,20 +121,39 @@ packages:
       - libpng
       - shared-mime-info
       - libx11
-    revision: 6
+    revision: 7
     configure:
       - args:
         - 'meson'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
-        - '-Dintrospection=disabled'
+        - '-Dintrospection=enabled'
         - '-Dman=false'
         - '-Dgtk_doc=false'
         - '-Ddocs=false'
         - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
     build:
       - args: ['ninja']
+        environ:
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'

--- a/bootstrap.d/x11-libs.yml
+++ b/bootstrap.d/x11-libs.yml
@@ -283,6 +283,9 @@ packages:
         triple: "@OPTION:arch-triple@"
       - wayland-scanner
       - host-glib
+      - host-mlibc
+      - host-gobject-introspection
+      - host-python
     pkgs_required:
       - mlibc
       - at-spi2-core
@@ -310,7 +313,7 @@ packages:
       - gsettings-desktop-schemas
       - dbus
       - libxinerama
-    revision: 6
+    revision: 7
     configure:
       - args:
         - 'meson'
@@ -323,20 +326,51 @@ packages:
         - '--libdir=lib'
         - '--buildtype=debugoptimized'
         - '-Dprint_backends=file'
-        - '-Dintrospection=false'
+        - '-Dintrospection=true'
         - '-Dx11_backend=true'
         - '-Dbroadway_backend=true'
         - '-Dwayland_backend=true'
         - '-Dgtk_doc=false'
         - '-Dcolord=no'
         - '@THIS_SOURCE_DIR@'
+        environ:
+          # Same as below
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
     build:
       - args: ['ninja']
         environ:
-          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu'
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
       - args: ['ninja', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+          # Make python load host libraries instead of the ones in the rootfs
+          LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-glib/lib:@BUILD_ROOT@/tools/host-glib/lib/x86_64-linux-gnu:@BUILD_ROOT@/tools/host-gobject-introspection/lib/x86_64-linux-gnu'
+          # Library path for our run-wrapper that allows it to load managarm libraries
+          RUN_WRAPPER_LD_LIBRARY_PATH: '@BUILD_ROOT@/tools/host-mlibc/lib:@SYSROOT_DIR@/usr/lib:@SYSROOT_DIR@/usr/lib64:@THIS_BUILD_DIR@/girepository'
+          # Similar to above, but using a nasty (but working) hack lets us use a Linux mlibc build to execute an
+          # executable that was cross-compiled for managarm
+          RUN_WRAPPER_INTERP: '@BUILD_ROOT@/tools/host-mlibc/lib/ld.so'
+          # This is a custom environment variable which tells g-ir-scanner what to use instead of ldd
+          # We point it at our native ldd-wrapper that's installed as part of host-gobject-introspection
+          GI_LDD_WRAPPER: ldd-wrapper
+          # This tells g-ir-scanner what program should be used for "cross-launching" the executables it builds
+          GI_CROSS_LAUNCHER: run-wrapper
+          # Path to the introspection data installed by other packages
+          GI_GIR_PATH: '@SYSROOT_DIR@/usr/share/gir-1.0'
     scripts:
         post_install:
           - args: ['gtk-query-immodules-3.0', '--update-cache']

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -7,6 +7,7 @@ imports:
   - file: bootstrap.d/app-emulation.yml
   - file: bootstrap.d/app-misc.yml
   - file: bootstrap.d/app-shells.yml
+  - file: bootstrap.d/app-text.yml
   - file: bootstrap.d/dev-db.yml
   - file: bootstrap.d/dev-lang.yml
   - file: bootstrap.d/dev-libs.yml

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1665,6 +1665,7 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
+      - args: ['patchelf', '--set-soname', 'libz.so.1.2.12', '@THIS_COLLECT_DIR@/usr/lib/libz.so.1.2.12']
       # This fails on ci, and needs further investigation.
       # - args:
       #   - '@THIS_SOURCE_DIR@/contrib/minizip/configure'

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -19,6 +19,7 @@ imports:
   - file: bootstrap.d/games-misc.yml
   - file: bootstrap.d/games-simulation.yml
   - file: bootstrap.d/gnome-base.yml
+  - file: bootstrap.d/gnome-extra.yml
   - file: bootstrap.d/gui-apps.yml
   - file: bootstrap.d/gui-libs.yml
   - file: bootstrap.d/gui-wm.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,8 @@ RUN apt-get update \
 		libexpat1-dev \
 		# Used by gtk+-2
 		libgdk-pixbuf2.0-bin \
+		# Used by vala
+		libglib2.0-dev \
 		# Used by gdk-pixbuf
 		libglib2.0-dev-bin \
 		# Used by host-qt6

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update \
 		libglib2.0-dev \
 		# Used by gdk-pixbuf
 		libglib2.0-dev-bin \
+		# Used by gtksourceview5
+		libgtk-4-bin \
 		# Used by host-qt6
 		libgl-dev \
 		# Used by GTK4

--- a/patches/appstream/0001-Add-Managarm-support.patch
+++ b/patches/appstream/0001-Add-Managarm-support.patch
@@ -1,0 +1,42 @@
+From 896f9880f471a051a2ac474c542965a6dc906701 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 21 Jan 2024 15:45:52 +0100
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ src/as-system-info.c | 3 +++
+ src/meson.build      | 3 +--
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/as-system-info.c b/src/as-system-info.c
+index 73e4746..37002ed 100644
+--- a/src/as-system-info.c
++++ b/src/as-system-info.c
+@@ -409,6 +409,9 @@ as_get_physical_memory_total (void)
+ 	unsigned long physmem;
+ 	sysctl ((int[]){ CTL_HW, HW_PHYSMEM }, 2, &physmem, &(size_t){ sizeof (physmem) }, NULL, 0);
+ 	return physmem / MB_IN_BYTES;
++#elif defined(__managarm__)
++	// NOT IMPLEMENTED
++	return 0;
+ #else
+ #error "Implementation of as_get_physical_memory_total() missing for this OS."
+ #endif
+diff --git a/src/meson.build b/src/meson.build
+index e098fab..a709b5e 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -194,8 +194,7 @@ appstream_lib = library ('appstream',
+     soversion: as_api_level,
+     version: as_version,
+     dependencies: [aslib_deps],
+-    include_directories: [stemmer_inc_dirs,
+-                          root_inc_dir],
++    include_directories: [root_inc_dir],
+     install: true
+ )
+ 
+-- 
+2.43.0
+

--- a/patches/gtk4/0001-Add-Managarm-support.patch
+++ b/patches/gtk4/0001-Add-Managarm-support.patch
@@ -1,0 +1,27 @@
+From 1048bcee7c52660b30c73b8b66464be2d59b6505 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 22 Jan 2024 19:44:13 +0100
+Subject: [PATCH] Add Managarm support
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ gdk/wayland/gdkdisplay-wayland.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gdk/wayland/gdkdisplay-wayland.c b/gdk/wayland/gdkdisplay-wayland.c
+index 80c7c99..f593547 100644
+--- a/gdk/wayland/gdkdisplay-wayland.c
++++ b/gdk/wayland/gdkdisplay-wayland.c
+@@ -30,7 +30,9 @@
+ #endif
+ 
+ #include <sys/mman.h>
++#ifndef __managarm__
+ #include <sys/syscall.h>
++#endif
+ 
+ #include <glib.h>
+ #include <gio/gio.h>
+-- 
+2.43.0
+

--- a/scripts/cross-valac
+++ b/scripts/cross-valac
@@ -1,0 +1,3 @@
+#!/bin/sh
+[ -z "$VALADIR" ] && ( echo "Please set VALADIR environment variable"; exit 1 )
+valac --vapidir="$VALADIR" "$@"

--- a/scripts/cross-vapigen
+++ b/scripts/cross-vapigen
@@ -1,0 +1,4 @@
+#!/bin/sh
+[ -z "$VALADIR" ] && ( echo "Please set VALADIR environment variable"; exit 1 )
+[ -z "$GI_GIR_PATH" ] && ( echo "Please set GI_GIR_PATH environment variable"; exit 1 )
+vapigen --vapidir="$VALADIR" --girdir="$GI_GIR_PATH" "$@"

--- a/scripts/meson-x86_64-managarm.cross-file
+++ b/scripts/meson-x86_64-managarm.cross-file
@@ -5,6 +5,7 @@ cpp = 'x86_64-managarm-g++'
 ar = 'x86_64-managarm-ar'
 strip = 'x86_64-managarm-strip'
 pkgconfig = 'x86_64-managarm-pkg-config'
+exe_wrapper = 'true'
 # sed adds binaries here.
 
 [host_machine]

--- a/scripts/meson.native-file
+++ b/scripts/meson.native-file
@@ -1,2 +1,3 @@
 [binaries]
 pkgconfig = 'host-pkg-config'
+vala = 'cross-valac'


### PR DESCRIPTION
This PR adds a port of `gnome-calculator` and enables introspection on large parts of the stack. It also comes with `host-vala`, so that we can process vala items. Along the way, a free fix to `readline` and `zlib` were added.