### PR TITLE
system-gcc: Disable decimal float support

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -584,6 +584,7 @@ tools:
         - '--enable-languages=c,c++,lto'
         - '--enable-initfini-array'
         - '--enable-libstdcxx-filesystem-ts'
+        - '--disable-decimal-float'
         # -g blows up GCC's binary size.
         - 'CFLAGS=-O2'
         - 'CXXFLAGS=-O2'
@@ -650,6 +651,7 @@ tools:
         - '--disable-libssp'
         - '--disable-libsanitizer'
         - '--disable-libquadmath'
+        - '--disable-decimal-float'
         # -g blows up GCC's binary size.
         - 'CFLAGS=-O2'
         - 'CXXFLAGS=-O2'


### PR DESCRIPTION
Disable gcc decimal float support because the lack of emulation routines for it in our AArch64 libgcc build causes issues in mpfr. This shouldn't affect most other packages in any way because decimal floats aren't used on most of them.