### PR TITLE
host-managarm-tools: bump revision

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -356,7 +356,7 @@ tools:
       - host-frigg
       - virtual: pkgconfig-for-host
         program_name: host-pkg-config
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'


### PR DESCRIPTION
This is necessary to update the xbbs-built version, as it continues to rely on protobuf, which we recently removed.