### PR TITLE
bootstrap: Run {initialize-empty,remake}-image tasks in the container

### DIFF
--- a/bootstrap.d/sys-boot.y4.yml
+++ b/bootstrap.d/sys-boot.y4.yml
@@ -27,7 +27,8 @@ tools:
     architecture: '@OPTION:arch@'
     labels: [aarch64]
     from_source: limine
-    containerless: true
+    tools_required:
+      - host-llvm-toolchain
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/tasks.y4.yml
+++ b/bootstrap.d/tasks.y4.yml
@@ -32,9 +32,6 @@ tasks:
     tools_required:
       - host-limine
     args: |
-      if [ "@OPTION:mount-using@" == guestfs ]; then
-          elevation=-g # Use libguestfs for root-less image creation.
-      fi
       if [ "@OPTION:arch@" == x86_64 ]; then
           biosboot=-b # Install the BIOS bootloader only on x86_64.
       fi
@@ -44,17 +41,18 @@ tasks:
       -pgpt \
       -text2 \
       -llimine \
+      -a@OPTION:arch@ \
       -e \
-      $biosboot \
-      $elevation
+      $biosboot
     environ:
-      'LIMINE_PATH': '@BUILD_ROOT@/tools/host-limine/share/limine'
+      'LIMINE_BIN_DIR': '@BUILD_ROOT@/tools/host-limine/share/limine'
+      'LIMINE_TOOL': '@BUILD_ROOT@/tools/host-limine/share/limine/limine'
       'GPT_TYPE': '64212B3B-56A1-4DFB-971E-BC8CD027996A'
     workdir: '@BUILD_ROOT@'
-    containerless: true
 
   - name: make-image
     tools_required:
+      - cross-binutils
       - host-limine
     pkgs_required:
       - managarm-kernel
@@ -72,6 +70,7 @@ tasks:
 
   - name: remake-image
     tools_required:
+      - cross-binutils
       - host-limine
     pkgs_required:
       - managarm-kernel
@@ -84,7 +83,6 @@ tasks:
       - '@OPTION:arch-triple@'
       - 'remake'
     workdir: '@BUILD_ROOT@'
-    containerless: true
 
   - name: xz-image
     tasks_required:

--- a/bootstrap.d/tasks.y4.yml
+++ b/bootstrap.d/tasks.y4.yml
@@ -37,7 +37,7 @@ tasks:
       fi
       @SOURCE_ROOT@/ports/image_create/image_create.sh \
       -oimage \
-      -s4G \
+      -s@OPTION:image-size@ \
       -pgpt \
       -text2 \
       -llimine \

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -81,3 +81,5 @@ declare_options:
     default: x86_64-managarm
   - name: mount-using
     default: guestfs
+  - name: image-size
+    default: 4G


### PR DESCRIPTION
Also make host-limine not a containerless tool and build it using host-llvm-toolchain.

The make-image task is still containerless because it actually mounts the disk image (either via loopback or guestfs), but ideally it shouldn't be, because it invokes 'strip' from cross-binutils, which just happens to work outside the container.

Depends on https://github.com/qookei/image_create/pull/2.