### PR TITLE
managarm-system: Build on RISC-V

### DIFF
--- a/bootstrap.d/dev-libs.y4.yml
+++ b/bootstrap.d/dev-libs.y4.yml
@@ -2369,7 +2369,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: boost
-    labels: [aarch64]
+    labels: [aarch64, riscv64]
     architecture: noarch
     metadata:
       summary: Boost development headers

--- a/bootstrap.d/managarm-libs.y4.yml
+++ b/bootstrap.d/managarm-libs.y4.yml
@@ -64,7 +64,7 @@ tools:
 
 packages:
   - name: fafnir
-    labels: [aarch64]
+    labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
     source:
       rolling_version: true
@@ -172,7 +172,7 @@ packages:
         quiet: true
 
   - name: lewis
-    labels: [aarch64]
+    labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
     source:
       rolling_version: true
@@ -203,7 +203,7 @@ packages:
         quiet: true
 
   - name: libasync
-    labels: [aarch64]
+    labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
     source:
       subdir: 'ports'
@@ -234,7 +234,7 @@ packages:
         quiet: true
 
   - name: libsmarter
-    labels: [aarch64]
+    labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
     source:
       rolling_version: true

--- a/bootstrap.d/managarm-system.y4.yml
+++ b/bootstrap.d/managarm-system.y4.yml
@@ -205,7 +205,7 @@ packages:
       website: 'https://managarm.org'
       maintainer: "Alexander van der Grinten <avdgrinten@managarm.org>"
       categories: ['sys-kernel']
-    labels: [aarch64]
+    labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
     default: true
     from_source: managarm

--- a/bootstrap.d/x11-libs.y4.yml
+++ b/bootstrap.d/x11-libs.y4.yml
@@ -452,7 +452,7 @@ packages:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
   - name: libdrm
-    labels: [aarch64]
+    labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
     metadata:
       summary: X.Org libdrm library

--- a/scripts/meson-clang-riscv64-managarm.cross-file
+++ b/scripts/meson-clang-riscv64-managarm.cross-file
@@ -1,0 +1,23 @@
+[binaries]
+c = 'clang'
+cpp = 'clang++'
+ar = 'riscv64-managarm-ar'
+strip = 'riscv64-managarm-strip'
+pkg-config = 'riscv64-managarm-pkg-config'
+
+[constants]
+# common args that c and cxx need
+args = ['-fdebug-default-version=4', '-target', 'riscv64-managarm', '-march=rv64gc', '--gcc-toolchain=_BUILD_ROOT_/tools/system-gcc']
+cxx = args + [ '-fsized-deallocation' ]
+
+[built-in options]
+c_args = args
+c_link_args = args
+cpp_args = cxx
+cpp_link_args = cxx
+
+[host_machine]
+system = 'managarm'
+cpu_family = 'riscv64'
+cpu = 'cortex-a72'
+endian = 'little'


### PR DESCRIPTION
Needs to be merged after LLVM toolchain finishes on builds.managarm.org.