### PR TITLE
nvme-cli: Add port

### DIFF
--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -709,6 +709,49 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: nvme-cli
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: NVM-Express user space tooling for Linux
+      description: NVM-Express user space tooling for Linux.
+      spdx: 'GPL-2.0-or-later'
+      website: 'https://github.com/linux-nvme/nvme-cli'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-apps']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/linux-nvme/nvme-cli.git'
+      tag: 'v2.11'
+      version: '2.11'
+    tools_required:
+      - system-gcc
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - libnvme
+      - json-c
+      - zlib
+    revision: 1
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '--sysconfdir=/etc'
+        - '--buildtype=release'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/share/zsh'] # Nuke zsh
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib/systemd'] # Nuke systemd
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib/dracut'] # Nuke dracut
+
   - name: pciutils
     architecture: '@OPTION:arch@'
     metadata:

--- a/bootstrap.d/sys-libs.y4.yml
+++ b/bootstrap.d/sys-libs.y4.yml
@@ -233,6 +233,52 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: libnvme
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: C Library for NVM Express on Linux
+      description: This package provides a library which provides type definitions for NVMe specification structures, enumerations, and bit fields, helper functions to construct, dispatch, and decode commands a>
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://github.com/linux-nvme/libnvme'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/linux-nvme/libnvme.git'
+      tag: 'v1.11.1'
+      version: '1.11.1'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - json-c
+      - dbus
+      - openssl
+      - util-linux-libs
+    revision: 1
+    configure:
+      - args:
+          - 'meson'
+          - 'setup'
+          - '--cross-file'
+          - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+          - '--prefix=/usr'
+          - '-Dbuildtype=release'
+          - '-Dpython=disabled'
+          - '-Djson-c=enabled'
+          - '-Dlibdbus=enabled'
+          - '-Dopenssl=enabled'
+          - '-Dtests=false'
+          - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: libxcrypt
     labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'

--- a/patches/nvme-cli/0001-Add-missing-include.patch
+++ b/patches/nvme-cli/0001-Add-missing-include.patch
@@ -1,0 +1,25 @@
+From 1da5792c2a07b44ca88564bd6f0a2338d2df9b8a Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Tue, 24 Dec 2024 01:39:32 +0100
+Subject: [PATCH] Add missing include
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ plugins/sed/sedopal_cmd.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/plugins/sed/sedopal_cmd.c b/plugins/sed/sedopal_cmd.c
+index 017649d..ba64c39 100644
+--- a/plugins/sed/sedopal_cmd.c
++++ b/plugins/sed/sedopal_cmd.c
+@@ -7,6 +7,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ #include <errno.h>
++#include <endian.h>
+ #include <sys/types.h>
+ #include <sys/ioctl.h>
+ #include <sys/mount.h>
+-- 
+2.45.2
+


### PR DESCRIPTION
This PR adds a port of the following packages:

- `libnvme`;
- `nvme-cli`.

Blocked on managarm/mlibc#1206