### PR TITLE
Add `evtest` and `mtview` ports

### DIFF
--- a/bootstrap.d/app-misc.y4.yml
+++ b/bootstrap.d/app-misc.y4.yml
@@ -76,6 +76,42 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: evtest
+    labels: [aarch64]
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: kernel input device debugging
+      description: evtest is a tool to print evdev kernel events. It reads directly from the kernel device and prints a device description and the events with the value and the symbolic name.
+      spdx: 'GPL-2.0-or-later'
+      website: 'https://gitlab.freedesktop.org/libevdev/evtest'
+      maintainer: "no92 <leo@managarm.org>"
+      categories: ['app-misc']
+    source:
+      subdir: 'ports'
+      git: 'https://gitlab.freedesktop.org/libevdev/evtest.git'
+      tag: 'evtest-1.35'
+      version: '1.35'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+      regenerate:
+        - args: ['autoreconf', '-fvi']
+    tools_required:
+      - system-gcc
+    pkgs_required:
+      - mlibc
+    revision: 1
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: sl
     labels: [aarch64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/x11-apps.y4.yml
+++ b/bootstrap.d/x11-apps.y4.yml
@@ -52,6 +52,55 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: mtview
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Multitouch Viewer
+      description: The mtview tool shows a graphical view of a kernel multitouch device. It reads events directly off the kernel device and is thus unaffected by any userspace processing.
+      spdx: 'GPL-3.0-or-later'
+      website: 'https://github.com/whot/mtview'
+      maintainer: "no92 <leo@managarm.org>"
+      categories: ['x11-apps']
+    source:
+      subdir: 'ports'
+      git: 'https://github.com/whot/mtview'
+      branch: master
+      commit: '8a20a569664cf52db0ca688200747c148b80e967'
+      version: '1'
+      tools_required:
+        - host-autoconf-v2.69
+        - host-automake-v1.15
+        - host-libtool
+        - host-pkg-config
+      regenerate:
+        - args: ['./autogen.sh']
+          environ:
+            NOCONFIGURE: 'yes'
+    tools_required:
+      - system-gcc
+      - host-autoconf-v2.69
+      - host-automake-v1.15
+      - host-libtool
+      - host-pkg-config
+    pkgs_required:
+      - cairo
+      - libevdev
+      - libx11
+      - libxi
+      - mlibc
+      - mtdev
+    revision: 1
+    configure:
+      - args:
+        - '@THIS_SOURCE_DIR@/configure'
+        - '--host=@OPTION:arch-triple@'
+        - '--prefix=/usr'
+    build:
+      - args: ['make', '-j@PARALLELISM@']
+      - args: ['make', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+
   - name: xclock
     labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'


### PR DESCRIPTION
These were useful for evdev testing, specifically for multitouch.