### PR TITLE
Systemd boot

### DIFF
--- a/bootstrap.d/dev-libs.y4.yml
+++ b/bootstrap.d/dev-libs.y4.yml
@@ -1147,7 +1147,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-      - systemd-utils
+      - systemd
       - libevdev
       - mtdev
     revision: 7
@@ -1615,7 +1615,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-      - systemd-utils
+      - systemd
     revision: 9
     configure:
       - args:

--- a/bootstrap.d/gui-libs.y4.yml
+++ b/bootstrap.d/gui-libs.y4.yml
@@ -379,7 +379,7 @@ packages:
         program_name: host-pkg-config
     pkgs_required:
       - mlibc
-      - systemd-utils
+      - systemd
       - libdisplay-info
       - libdrm
       - libinput

--- a/bootstrap.d/kde-frameworks.y4.yml
+++ b/bootstrap.d/kde-frameworks.y4.yml
@@ -776,7 +776,7 @@ packages:
       - mlibc
       - qtbase6
       - qtdeclarative6
-      - systemd-utils
+      - systemd
     revision: 1
     configure:
       - args:
@@ -2035,7 +2035,7 @@ packages:
       - qtbase6
       - qtdeclarative6
       - util-linux-libs
-      - systemd-utils
+      - systemd
     revision: 1
     configure:
       - args:

--- a/bootstrap.d/managarm-system.y4.yml
+++ b/bootstrap.d/managarm-system.y4.yml
@@ -237,7 +237,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-      - systemd-utils
+      - systemd
       - fafnir
       - frigg
       - lewis

--- a/bootstrap.d/managarm-system.y4.yml
+++ b/bootstrap.d/managarm-system.y4.yml
@@ -271,6 +271,10 @@ packages:
         environ:
           'DESTDIR': '@THIS_COLLECT_DIR@'
         quiet: true
+      # Workaround for drivers that are not integrated into udev yet with systemd
+      - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sysinit.target.wants/']
+      - args: ['cp', '-v', '@THIS_SOURCE_DIR@/drivers/usb/runsvr-usbhid.service', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/']
+      - args: ['ln', '-svn', '../runsvr-usbhid.service', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sysinit.target.wants/']
     tasks:
     - name: clang-tidy
       args:

--- a/bootstrap.d/media-libs.y4.yml
+++ b/bootstrap.d/media-libs.y4.yml
@@ -1468,7 +1468,7 @@ packages:
     pkgs_required:
       - mlibc
       - libdrm
-      - systemd-utils
+      - systemd
       - mesa
       - wayland
       - wayland-protocols

--- a/bootstrap.d/net-misc.y4.yml
+++ b/bootstrap.d/net-misc.y4.yml
@@ -63,7 +63,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-      - systemd-utils
+      - systemd
     revision: 3
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -807,7 +807,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-      - systemd-utils
+      - systemd
       - hwdata
       - zlib
     revision: 2
@@ -993,7 +993,7 @@ packages:
     pkgs_required:
       - mlibc
       - libusb
-      - systemd-utils
+      - systemd
       - hwdata
       - libiconv
     revision: 2
@@ -1170,7 +1170,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-      - systemd-utils
+      - systemd
       - util-linux-libs
       - readline
       - ncurses
@@ -1351,7 +1351,7 @@ packages:
       - libxkbcommon
       - libdrm
       - libtsm
-      - systemd-utils
+      - systemd
     revision: 9
     configure:
       - args:
@@ -1378,7 +1378,7 @@ packages:
   - name: eudev
     labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
-    # API mismatch with systemd-utils's udevd, hence unusable
+    # API mismatch with systemd's udevd, hence unusable
     stability_level: broken
     source:
       subdir: 'ports'
@@ -1422,17 +1422,17 @@ packages:
         quiet: true
       - args: ['touch', '@THIS_COLLECT_DIR@/usr/etc/udev/rules.d/.keep']
 
-  - name: systemd-utils
+  - name: systemd
     labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
     metadata:
-      summary: Utilities for the systemd System and Service Manager
+      summary: System and service manager for Linux and Managarm
       description: systemd is a suite of basic building blocks for a Linux system. It provides a system and service manager that runs as PID 1 and starts the rest of the system.
-      spdx: 'GPL-2.0-or-later'
+      spdx: 'GPL-2.0-only'
       website: 'https://systemd.io'
-      maintainer: "no92 <leo@managarm.org>"
+      maintainer: "no92 <leo@managarm.org> && Dennis Bonke <dennis@managarm.org>"
       categories: ['sys-apps']
-      replaces: ['eudev']
+      replaces: ['eudev', 'systemd-utils']
     source:
       subdir: 'ports'
       git: 'https://github.com/systemd/systemd.git'
@@ -1530,6 +1530,8 @@ packages:
         - '-Dxz=false'
         - '-Dzlib=false'
         - '-Dzstd=false'
+        - '-Dtests=true'
+        - '-Dinstall-tests=true'
         - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']
@@ -1537,3 +1539,33 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
+      # These don't work on Managarm, remove them so we don't get a degraded system
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-ask-password-console.path']
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sysinit.target.wants/systemd-ask-password-console.path']
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-ask-password-console.service']
+      # Touch up empty directories
+      - args: ['touch',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel1.target.wants/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel2.target.wants/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel3.target.wants/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel4.target.wants/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel5.target.wants/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/user-generators/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system-shutdown/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system-sleep/.keep',
+          '@THIS_COLLECT_DIR@/etc/credstore.encrypted/.keep',
+          '@THIS_COLLECT_DIR@/etc/kernel/install.d/.keep',
+          '@THIS_COLLECT_DIR@/etc/systemd/network/.keep',
+          '@THIS_COLLECT_DIR@/etc/systemd/system/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/credstore/.keep',
+          '@THIS_COLLECT_DIR@/etc/udev/rules.d/.keep',
+          '@THIS_COLLECT_DIR@/etc/systemd/user/.keep',
+          '@THIS_COLLECT_DIR@/var/log/journal/.keep',
+          '@THIS_COLLECT_DIR@/etc/udev/hwdb.d/.keep',
+          '@THIS_COLLECT_DIR@/var/lib/systemd/.keep',
+          '@THIS_COLLECT_DIR@/etc/tmpfiles.d/.keep',
+          '@THIS_COLLECT_DIR@/etc/credstore/.keep',
+          '@THIS_COLLECT_DIR@/etc/sysctl.d/.keep',
+          '@THIS_COLLECT_DIR@/etc/kernel/.keep'
+        ]
+      - args: ['dbus-uuidgen', '--ensure=@THIS_COLLECT_DIR@/etc/machine-id']

--- a/bootstrap.d/x11-apps.y4.yml
+++ b/bootstrap.d/x11-apps.y4.yml
@@ -542,7 +542,7 @@ packages:
       - elfutils
       - pixman
       - cairo
-      - systemd-utils
+      - systemd
     revision: 3
     configure:
       - args:

--- a/bootstrap.d/x11-base.y4.yml
+++ b/bootstrap.d/x11-base.y4.yml
@@ -108,7 +108,7 @@ packages:
       - xcb-proto
       - xorg-proto
       - libdrm
-      - systemd-utils
+      - systemd
       - libxshmfence
       - libx11
       - libxxf86vm

--- a/patches/systemd/0001-Add-managarm-support.patch
+++ b/patches/systemd/0001-Add-managarm-support.patch
@@ -1,7 +1,7 @@
-From 7358a1c31a63ebdb2495cff5a26858319c27f116 Mon Sep 17 00:00:00 2001
+From b665ef017d518f835115ace004591663bd5e34d9 Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Tue, 18 Feb 2025 23:40:13 +0100
-Subject: [PATCH] Add managarm support
+Subject: [PATCH 1/3] Add managarm support
 
 ---
  meson.build                        |  8 ++--
@@ -509,5 +509,5 @@ index c236a70..8314e2c 100644
          if (getuid() == 0) {
                  _cleanup_(udev_ctrl_unrefp) UdevCtrl *uctrl = NULL;
 -- 
-2.48.1
+2.39.5
 

--- a/patches/systemd/0002-Add-support-for-systemd-boot-for-Managarm.patch
+++ b/patches/systemd/0002-Add-support-for-systemd-boot-for-Managarm.patch
@@ -1,0 +1,567 @@
+From c02304e2d1f9a5e95832104eb5c533afee403964 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Fri, 10 Jan 2025 00:55:19 +0100
+Subject: [PATCH 2/3] Add support for systemd boot for Managarm
+
+---
+ src/basic/capability-util.c              |  2 ++
+ src/basic/process-util.c                 |  8 ++++++--
+ src/basic/raw-clone.h                    |  6 ++----
+ src/basic/stdio-util.h                   |  1 +
+ src/core/exec-credential.c               |  4 ++++
+ src/core/exec-invoke.c                   | 11 ++++++++++
+ src/core/main.c                          |  3 +++
+ src/core/mount.c                         | 11 ++++++++++
+ src/journal/journald-native.c            |  3 +++
+ src/journal/journald-server.c            |  9 ++++++++
+ src/journal/journald-syslog.c            |  3 +++
+ src/journal/journald.conf                |  6 +++---
+ src/libsystemd/sd-journal/journal-send.c |  1 +
+ src/shared/async.c                       |  4 ++++
+ src/shared/mount-setup.c                 | 10 +++++++++
+ src/shared/mount-util.c                  |  7 +++++++
+ src/udev/udev.conf                       |  2 +-
+ units/systemd-journald.service.in        | 10 ++++-----
+ units/systemd-udevd.service.in           | 26 ++++++++++++------------
+ 19 files changed, 99 insertions(+), 28 deletions(-)
+
+diff --git a/src/basic/capability-util.c b/src/basic/capability-util.c
+index e9b41fe..ed8472c 100644
+--- a/src/basic/capability-util.c
++++ b/src/basic/capability-util.c
+@@ -333,6 +333,7 @@ int drop_privileges(uid_t uid, gid_t gid, uint64_t keep_capabilities) {
+         if (prctl(PR_SET_KEEPCAPS, 0) < 0)
+                 return log_error_errno(errno, "Failed to disable keep capabilities flag: %m");
+ 
++#ifndef __managarm__
+         /* Drop all caps from the bounding set (as well as the inheritable/permitted/effective sets), except
+          * the ones we want to keep */
+         r = capability_bounding_set_drop(keep_capabilities, true);
+@@ -365,6 +366,7 @@ int drop_privileges(uid_t uid, gid_t gid, uint64_t keep_capabilities) {
+                 if (cap_set_proc(d) < 0)
+                         return log_error_errno(errno, "Failed to increase capabilities: %m");
+         }
++#endif
+ 
+         return 0;
+ }
+diff --git a/src/basic/process-util.c b/src/basic/process-util.c
+index 6a1e496..48a5b76 100644
+--- a/src/basic/process-util.c
++++ b/src/basic/process-util.c
+@@ -1621,6 +1621,8 @@ int safe_fork_full(
+                 }
+         }
+ 
++// TODO: Managarm dies if the first or third argument to mount are null, untill we implement that, we should comment it out.
++#ifndef __managarm__
+         if (FLAGS_SET(flags, FORK_NEW_MOUNTNS | FORK_MOUNTNS_SLAVE)) {
+                 /* Optionally, make sure we never propagate mounts to the host. */
+                 if (mount(NULL, "/", NULL, MS_SLAVE | MS_REC, NULL) < 0) {
+@@ -1628,6 +1630,7 @@ int safe_fork_full(
+                         _exit(EXIT_FAILURE);
+                 }
+         }
++#endif
+ 
+         if (FLAGS_SET(flags, FORK_PRIVATE_TMP)) {
+                 assert(FLAGS_SET(flags, FORK_NEW_MOUNTNS));
+@@ -1973,8 +1976,9 @@ _noreturn_ void freeze(void) {
+         }
+ 
+         /* waitid() failed with an unexpected error, things are really borked. Freeze now! */
+-        for (;;)
+-                pause();
++        // TODO: Implement sys_pause
++        for (;;);
++                // pause();
+ }
+ 
+ int get_process_threads(pid_t pid) {
+diff --git a/src/basic/raw-clone.h b/src/basic/raw-clone.h
+index c5bfc10..c03adcc 100644
+--- a/src/basic/raw-clone.h
++++ b/src/basic/raw-clone.h
+@@ -78,11 +78,9 @@ static inline pid_t raw_clone(unsigned long flags) {
+         }
+ #elif defined(__managarm__)
+         int helout = open("/dev/helout", O_RDWR);
+-        dprintf(helout, "systemd: clone unsupported\n");
++        dprintf(helout, "systemd: clone unsupported, falling back to fork\n");
+         close(helout);
+-
+-        errno = ENOSYS;
+-        ret = -1;
++        ret = fork();
+ #else
+         ret = (pid_t) syscall(__NR_clone, flags, NULL);
+ #endif
+diff --git a/src/basic/stdio-util.h b/src/basic/stdio-util.h
+index 0a2239d..2e55e94 100644
+--- a/src/basic/stdio-util.h
++++ b/src/basic/stdio-util.h
+@@ -7,6 +7,7 @@
+ #include <sys/types.h>
+ 
+ #include "macro.h"
++#include "parse-printf-format.h"
+ 
+ _printf_(3, 4)
+ static inline char* snprintf_ok(char *buf, size_t len, const char *format, ...) {
+diff --git a/src/core/exec-credential.c b/src/core/exec-credential.c
+index 6157ac4..d508df7 100644
+--- a/src/core/exec-credential.c
++++ b/src/core/exec-credential.c
+@@ -908,6 +908,7 @@ static int setup_credentials_internal(
+ 
+         if (workspace_mounted) {
+                 if (!final_mounted) {
++#ifndef __managarm__
+                         /* Make workspace read-only now, so that any bind mount we make from it defaults to
+                          * read-only too */
+                         r = mount_nofollow_verbose(LOG_DEBUG, NULL, workspace, NULL, MS_BIND|MS_REMOUNT|credentials_fs_mount_flags(/* ro= */ true), NULL);
+@@ -916,6 +917,7 @@ static int setup_credentials_internal(
+ 
+                         /* And mount it to the final place, read-only */
+                         r = mount_nofollow_verbose(LOG_DEBUG, workspace, final, NULL, MS_MOVE, NULL);
++#endif
+                 } else
+                         /* Otherwise we just get rid of the bind mount of final place */
+                         r = umount_verbose(LOG_DEBUG, workspace, MNT_DETACH|UMOUNT_NOFOLLOW);
+@@ -1036,9 +1038,11 @@ int exec_setup_credentials(
+                  * no one else sees this should be OK to do. */
+ 
+                 /* Turn off propagation from our namespace to host */
++#ifndef __managarm__
+                 r = mount_nofollow_verbose(LOG_DEBUG, NULL, "/dev", NULL, MS_SLAVE|MS_REC, NULL);
+                 if (r < 0)
+                         goto child_fail;
++#endif
+ 
+                 r = setup_credentials_internal(
+                                 context,
+diff --git a/src/core/exec-invoke.c b/src/core/exec-invoke.c
+index f72eccf..dd75336 100644
+--- a/src/core/exec-invoke.c
++++ b/src/core/exec-invoke.c
+@@ -226,8 +226,13 @@ static int connect_logger_as(
+         if (r < 0)
+                 return r;
+ 
++        // TODO: Managarm does not implement shutdown
++#ifdef __managarm__
++        log_debug("Not shutting down socket as shutdown is not implemented!");
++#else
+         if (shutdown(fd, SHUT_RD) < 0)
+                 return -errno;
++#endif
+ 
+         (void) fd_inc_sndbuf(fd, SNDBUF_SIZE);
+ 
+@@ -4687,6 +4692,7 @@ int exec_invoke(
+ #endif
+         }
+ 
++#ifndef __managarm__
+         if (needs_sandboxing) {
+                 int which_failed;
+ 
+@@ -4699,6 +4705,7 @@ int exec_invoke(
+                         return log_exec_error_errno(context, params, r, "Failed to adjust resource limit RLIMIT_%s: %m", rlimit_to_string(which_failed));
+                 }
+         }
++#endif
+ 
+         if (needs_setuid && context->pam_name && username) {
+                 /* Let's call into PAM after we set up our own idea of resource limits so that pam_limits
+@@ -5005,6 +5012,7 @@ int exec_invoke(
+                 }
+ #endif
+ 
++#ifndef __managarm__
+                 if (!cap_test_all(bset)) {
+                         r = capability_bounding_set_drop(bset, /* right_now= */ false);
+                         if (r < 0) {
+@@ -5012,6 +5020,7 @@ int exec_invoke(
+                                 return log_exec_error_errno(context, params, r, "Failed to drop capabilities: %m");
+                         }
+                 }
++#endif
+ 
+                 /* Ambient capabilities are cleared during setresuid() (in enforce_user()) even with
+                  * keep-caps set.
+@@ -5129,6 +5138,7 @@ int exec_invoke(
+                 }
+ #endif
+ 
++#ifndef __managarm__
+                 /* PR_GET_SECUREBITS is not privileged, while PR_SET_SECUREBITS is. So to suppress potential
+                  * EPERMs we'll try not to call PR_SET_SECUREBITS unless necessary. Setting securebits
+                  * requires CAP_SETPCAP. */
+@@ -5160,6 +5170,7 @@ int exec_invoke(
+                                 *exit_status = EXIT_NO_NEW_PRIVILEGES;
+                                 return log_exec_error_errno(context, params, errno, "Failed to disable new privileges: %m");
+                         }
++#endif
+ 
+ #if HAVE_SECCOMP
+                 r = apply_address_families(context, params);
+diff --git a/src/core/main.c b/src/core/main.c
+index 5b11c79..d79d48b 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -2380,7 +2380,10 @@ static int initialize_runtime(
+                         (void) hostname_setup(true);
+                         /* Force transient machine-id on first boot. */
+                         machine_id_setup(/* root= */ NULL, /* force_transient= */ first_boot, arg_machine_id, /* ret_machine_id */ NULL);
++// Managarm does not support loopback devices yet
++#ifndef __managarm__
+                         (void) loopback_setup();
++#endif
+                         bump_unix_max_dgram_qlen();
+                         bump_file_max_and_nr_open();
+                         test_usr();
+diff --git a/src/core/mount.c b/src/core/mount.c
+index 66917df..405dd2b 100644
+--- a/src/core/mount.c
++++ b/src/core/mount.c
+@@ -1553,6 +1553,12 @@ static void mount_sigchld_event(Unit *u, pid_t pid, int code, int status) {
+                         f == MOUNT_SUCCESS,
+                         code, status);
+ 
++// TODO: Remove this hack once /proc/self/mounts and friends are merged.
++#ifdef __managarm__
++        if(m->state == MOUNT_MOUNTING && f == MOUNT_SUCCESS)
++                m->state = MOUNT_MOUNTING_DONE;
++#endif
++
+         /* Note that due to the io event priority logic, we can be sure the new mountinfo is loaded
+          * before we process the SIGCHLD for the mount command. */
+ 
+@@ -2124,6 +2130,10 @@ static int drain_libmount(Manager *m) {
+ }
+ 
+ static int mount_process_proc_self_mountinfo(Manager *m) {
++// TODO: Remove this hack once /proc/self/mounts and friends are merged.
++#ifdef __managarm__
++        return 0;
++#else
+         _cleanup_set_free_ Set *around = NULL, *gone = NULL;
+         const char *what;
+         int r;
+@@ -2236,6 +2246,7 @@ static int mount_process_proc_self_mountinfo(Manager *m) {
+         }
+ 
+         return 0;
++#endif
+ }
+ 
+ static int mount_dispatch_io(sd_event_source *source, int fd, uint32_t revents, void *userdata) {
+diff --git a/src/journal/journald-native.c b/src/journal/journald-native.c
+index 0600102..817bc7c 100644
+--- a/src/journal/journald-native.c
++++ b/src/journal/journald-native.c
+@@ -493,9 +493,12 @@ int server_open_native_socket(Server *s, const char *native_socket) {
+                         log_warning_errno(r, "SO_PASSSEC failed: %m");
+         }
+ 
++// TODO: Remove this hack once SO_TIMESTAMP is merged
++#ifndef __managarm__
+         r = setsockopt_int(s->native_fd, SOL_SOCKET, SO_TIMESTAMP, true);
+         if (r < 0)
+                 return log_error_errno(r, "SO_TIMESTAMP failed: %m");
++#endif
+ 
+         r = sd_event_add_io(s->event, &s->native_event_source, s->native_fd, EPOLLIN, server_process_datagram, s);
+         if (r < 0)
+diff --git a/src/journal/journald-server.c b/src/journal/journald-server.c
+index 07748f0..3f05328 100644
+--- a/src/journal/journald-server.c
++++ b/src/journal/journald-server.c
+@@ -162,9 +162,15 @@ static int cache_space_refresh(Server *s, JournalStorage *storage) {
+         if (space->timestamp != 0 && usec_add(space->timestamp, RECHECK_SPACE_USEC) > ts)
+                 return 0;
+ 
++// TODO: Managarm does not implement fstatvfs
++#ifndef __managarm__
+         r = server_determine_path_usage(s, storage->path, &vfs_used, &vfs_avail);
+         if (r < 0)
+                 return r;
++#else
++        vfs_used = 0;
++        vfs_avail = 16384;
++#endif
+ 
+         space->vfs_used = vfs_used;
+         space->vfs_available = vfs_avail;
+@@ -2817,9 +2823,12 @@ int server_init(Server *s, const char *namespace) {
+         if (r < 0)
+                 return r;
+ 
++// TODO: Managarm does not implement /proc/sys/kernel/hostname yet
++#ifndef __managarm__
+         r = server_open_hostname(s);
+         if (r < 0)
+                 return r;
++#endif
+ 
+         r = server_setup_signals(s);
+         if (r < 0)
+diff --git a/src/journal/journald-syslog.c b/src/journal/journald-syslog.c
+index 4ad73ed..d2436c5 100644
+--- a/src/journal/journald-syslog.c
++++ b/src/journal/journald-syslog.c
+@@ -495,9 +495,12 @@ int server_open_syslog_socket(Server *s, const char *syslog_socket) {
+                         log_warning_errno(r, "SO_PASSSEC failed: %m");
+         }
+ 
++// TODO: Remove this hack once SO_TIMESTAMP is merged
++#ifndef __managarm__
+         r = setsockopt_int(s->syslog_fd, SOL_SOCKET, SO_TIMESTAMP, true);
+         if (r < 0)
+                 return log_error_errno(r, "SO_TIMESTAMP failed: %m");
++#endif
+ 
+         r = sd_event_add_io(s->event, &s->syslog_event_source, s->syslog_fd, EPOLLIN, server_process_datagram, s);
+         if (r < 0)
+diff --git a/src/journal/journald.conf b/src/journal/journald.conf
+index 9a12ca7..828dee0 100644
+--- a/src/journal/journald.conf
++++ b/src/journal/journald.conf
+@@ -35,16 +35,16 @@
+ #MaxRetentionSec=0
+ #MaxFileSec=1month
+ #ForwardToSyslog=no
+-#ForwardToKMsg=no
++ForwardToKMsg=yes
+ #ForwardToConsole=no
+ #ForwardToWall=yes
+ #TTYPath=/dev/console
+ #MaxLevelStore=debug
+ #MaxLevelSyslog=debug
+-#MaxLevelKMsg=notice
++MaxLevelKMsg=debug
+ #MaxLevelConsole=info
+ #MaxLevelWall=emerg
+ #MaxLevelSocket=debug
+ #LineMax=48K
+-#ReadKMsg=yes
++ReadKMsg=no
+ #Audit=yes
+diff --git a/src/libsystemd/sd-journal/journal-send.c b/src/libsystemd/sd-journal/journal-send.c
+index 7d02b57..a085889 100644
+--- a/src/libsystemd/sd-journal/journal-send.c
++++ b/src/libsystemd/sd-journal/journal-send.c
+@@ -28,6 +28,7 @@
+ #include "stdio-util.h"
+ #include "string-util.h"
+ #include "tmpfile-util.h"
++#include "parse-printf-format.h"
+ 
+ #define SNDBUF_SIZE (8*1024*1024)
+ 
+diff --git a/src/shared/async.c b/src/shared/async.c
+index bd043c8..524c550 100644
+--- a/src/shared/async.c
++++ b/src/shared/async.c
+@@ -86,6 +86,9 @@ static int close_func(void *p) {
+ }
+ 
+ int asynchronous_close(int fd) {
++#ifdef __managarm__
++        safe_close(fd); /* local fallback */
++#else
+         unsigned v;
+         pid_t pid;
+         int r;
+@@ -129,6 +132,7 @@ int asynchronous_close(int fd) {
+                         if (waitpid(pid, NULL, __WCLONE) >= 0 || errno != EINTR)
+                                 break;
+         }
++#endif
+ 
+         return -EBADF; /* return an invalidated fd */
+ }
+diff --git a/src/shared/mount-setup.c b/src/shared/mount-setup.c
+index d5009fb..741d912 100644
+--- a/src/shared/mount-setup.c
++++ b/src/shared/mount-setup.c
+@@ -57,6 +57,8 @@ typedef struct MountPoint {
+  * SMACK is enabled we need smackfs, too, so it's a fifth one. */
+ #if ENABLE_SMACK
+ #define N_EARLY_MOUNT 5
++#elif defined __managarm__
++#define N_EARLY_MOUNT 3
+ #else
+ #define N_EARLY_MOUNT 4
+ #endif
+@@ -83,8 +85,10 @@ static const MountPoint mount_table[] = {
+           NULL,          MNT_FATAL|MNT_IN_CONTAINER },
+         { "devtmpfs",    "/dev",                      "devtmpfs",   "mode=0755" TMPFS_LIMITS_DEV,               MS_NOSUID|MS_STRICTATIME,
+           NULL,          MNT_FATAL|MNT_IN_CONTAINER },
++#ifndef __managarm__
+         { "securityfs",  "/sys/kernel/security",      "securityfs", NULL,                                       MS_NOSUID|MS_NOEXEC|MS_NODEV,
+           NULL,          MNT_NONE                   },
++#endif
+ #if ENABLE_SMACK
+         { "smackfs",     "/sys/fs/smackfs",           "smackfs",    "smackfsdef=*",                             MS_NOSUID|MS_NOEXEC|MS_NODEV,
+           mac_smack_use, MNT_FATAL                  },
+@@ -101,10 +105,12 @@ static const MountPoint mount_table[] = {
+ #endif
+         { "tmpfs",       "/run",                      "tmpfs",      "mode=0755" TMPFS_LIMITS_RUN,               MS_NOSUID|MS_NODEV|MS_STRICTATIME,
+           NULL,          MNT_FATAL|MNT_IN_CONTAINER },
++#ifndef __managarm__
+         { "cgroup2",     "/sys/fs/cgroup",            "cgroup2",    "nsdelegate,memory_recursiveprot",          MS_NOSUID|MS_NOEXEC|MS_NODEV,
+           check_recursiveprot_supported, MNT_IN_CONTAINER|MNT_CHECK_WRITABLE },
+         { "cgroup2",     "/sys/fs/cgroup",            "cgroup2",    "nsdelegate",                               MS_NOSUID|MS_NOEXEC|MS_NODEV,
+           cg_is_unified_wanted, MNT_IN_CONTAINER|MNT_CHECK_WRITABLE },
++#endif
+         { "cgroup2",     "/sys/fs/cgroup",            "cgroup2",    NULL,                                       MS_NOSUID|MS_NOEXEC|MS_NODEV,
+           cg_is_unified_wanted, MNT_IN_CONTAINER|MNT_CHECK_WRITABLE },
+ #if ENABLE_PSTORE
+@@ -115,8 +121,10 @@ static const MountPoint mount_table[] = {
+         { "efivarfs",    "/sys/firmware/efi/efivars", "efivarfs",   NULL,                                       MS_NOSUID|MS_NOEXEC|MS_NODEV,
+           is_efi_boot,   MNT_NONE                   },
+ #endif
++#ifndef __managarm__
+         { "bpf",         "/sys/fs/bpf",               "bpf",        "mode=0700",                                MS_NOSUID|MS_NOEXEC|MS_NODEV,
+           NULL,          MNT_NONE,                  },
++#endif
+ };
+ 
+ assert_cc(N_EARLY_MOUNT <= ELEMENTSOF(mount_table));
+@@ -437,9 +445,11 @@ int mount_setup(bool loaded_policy, bool leave_propagation) {
+          * needed. Note that we set this only when we are invoked directly by the kernel. If we are invoked by a
+          * container manager we assume the container manager knows what it is doing (for example, because it set up
+          * some directories with different propagation modes). */
++#ifndef __managarm__
+         if (detect_container() <= 0 && !leave_propagation)
+                 if (mount(NULL, "/", NULL, MS_REC|MS_SHARED, NULL) < 0)
+                         log_warning_errno(errno, "Failed to set up the root directory for shared mount propagation: %m");
++#endif
+ 
+         /* Create a few directories we always want around, Note that sd_booted() checks for /run/systemd/system, so
+          * this mkdir really needs to stay for good, otherwise software that copied sd-daemon.c into their sources will
+diff --git a/src/shared/mount-util.c b/src/shared/mount-util.c
+index f932a5e..f3b5660 100644
+--- a/src/shared/mount-util.c
++++ b/src/shared/mount-util.c
+@@ -152,6 +152,10 @@ int bind_remount_recursive_with_mountinfo(
+                 char **deny_list,
+                 FILE *proc_self_mountinfo) {
+ 
++// TODO: Remove once mountinfo is a thing
++#ifdef __managarm__
++        return -ENOENT;
++#endif
+         _cleanup_fclose_ FILE *proc_self_mountinfo_opened = NULL;
+         _cleanup_set_free_ Set *done = NULL;
+         unsigned n_tries = 0;
+@@ -1708,6 +1712,8 @@ int mount_credentials_fs(const char *path, size_t size, bool ro) {
+                         return r;
+         }
+ 
++// TODO: Investigate if we need this
++#ifndef __managarm__
+         r = mount_nofollow_verbose(
+                         LOG_DEBUG,
+                         "ramfs",
+@@ -1717,6 +1723,7 @@ int mount_credentials_fs(const char *path, size_t size, bool ro) {
+                         "mode=0700");
+         if (r >= 0)
+                 return r;
++#endif
+ 
+         if (asprintf(&opts, "mode=0700,nr_inodes=1024,size=%zu", size) < 0)
+                 return -ENOMEM;
+diff --git a/src/udev/udev.conf b/src/udev/udev.conf
+index 07d7f0c..5914775 100644
+--- a/src/udev/udev.conf
++++ b/src/udev/udev.conf
+@@ -3,7 +3,7 @@
+ # udevd is also started in the initrd.  When this file is modified you might
+ # also want to rebuild the initrd, so that it will include the modified configuration.
+ 
+-#udev_log=info
++udev_log=debug
+ #children_max=
+ #exec_delay=
+ #event_timeout=180
+diff --git a/units/systemd-journald.service.in b/units/systemd-journald.service.in
+index 4404af9..c27be83 100644
+--- a/units/systemd-journald.service.in
++++ b/units/systemd-journald.service.in
+@@ -31,15 +31,15 @@ IgnoreOnIsolate=yes
+ [Service]
+ DeviceAllow=char-* rw
+ ExecStart={{LIBEXECDIR}}/systemd-journald
+-FileDescriptorStoreMax=4224
++FileDescriptorStoreMax=256
+ # Ensure services using StandardOutput=journal do not break when journald is stopped
+ FileDescriptorStorePreserve=yes
+ ImportCredential=journal.*
+-IPAddressDeny=any
++#IPAddressDeny=any
+ LockPersonality=yes
+ MemoryDenyWriteExecute=yes
+ NoNewPrivileges=yes
+-OOMScoreAdjust=-250
++#OOMScoreAdjust=-250
+ ProtectClock=yes
+ Restart=always
+ RestartSec=0
+@@ -64,8 +64,8 @@ PassEnvironment=TERM
+ # In case you're wondering why CAP_SYS_PTRACE is needed, access to
+ # /proc/<pid>/exe requires this capability. Thus if this capability is missing
+ # the _EXE=/OBJECT_EXE= fields will be missing from the journal entries.
+-CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_SYS_PTRACE CAP_SYSLOG CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_CHOWN CAP_DAC_READ_SEARCH CAP_FOWNER CAP_SETUID CAP_SETGID CAP_MAC_OVERRIDE
++#CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_OVERRIDE CAP_SYS_PTRACE CAP_SYSLOG CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_CHOWN CAP_DAC_READ_SEARCH CAP_FOWNER CAP_SETUID CAP_SETGID CAP_MAC_OVERRIDE
+ 
+ # If there are many split up journal files we need a lot of fds to access them
+ # all in parallel.
+-LimitNOFILE={{HIGH_RLIMIT_NOFILE}}
++#LimitNOFILE={{HIGH_RLIMIT_NOFILE}}
+diff --git a/units/systemd-udevd.service.in b/units/systemd-udevd.service.in
+index f4a4482..29a22b5 100644
+--- a/units/systemd-udevd.service.in
++++ b/units/systemd-udevd.service.in
+@@ -22,23 +22,23 @@ Delegate=pids
+ DelegateSubgroup=udev
+ Type=notify-reload
+ # Note that udev will reset the value internally for its workers
+-OOMScoreAdjust=-1000
++#OOMScoreAdjust=-1000
+ Sockets=systemd-udevd-control.socket systemd-udevd-kernel.socket
+ Restart=always
+ RestartSec=0
+ ExecStart={{LIBEXECDIR}}/systemd-udevd
+ KillMode=mixed
+ TasksMax=infinity
+-PrivateMounts=yes
+-ProtectHostname=yes
+-MemoryDenyWriteExecute=yes
+-RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_INET AF_INET6
+-RestrictRealtime=yes
+-RestrictSUIDSGID=yes
+-SystemCallFilter=@system-service @module @raw-io bpf
+-SystemCallFilter=~@clock
+-SystemCallErrorNumber=EPERM
+-SystemCallArchitectures=native
+-LockPersonality=yes
+-IPAddressDeny=any
++#PrivateMounts=yes
++#ProtectHostname=yes
++#MemoryDenyWriteExecute=yes
++#RestrictAddressFamilies=AF_UNIX AF_NETLINK AF_INET AF_INET6
++#RestrictRealtime=yes
++#RestrictSUIDSGID=yes
++#SystemCallFilter=@system-service @module @raw-io bpf
++#SystemCallFilter=~@clock
++#SystemCallErrorNumber=EPERM
++#SystemCallArchitectures=native
++#LockPersonality=yes
++#IPAddressDeny=any
+ {{SERVICE_WATCHDOG}}
+-- 
+2.39.5
+

--- a/patches/systemd/0003-add-fallback-parse_printf_format-implementation.patch
+++ b/patches/systemd/0003-add-fallback-parse_printf_format-implementation.patch
@@ -1,0 +1,381 @@
+From d998fd66ec2ac7e5d29a08e366ce0b0d5553d801 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Sat, 22 May 2021 20:26:24 +0200
+Subject: [PATCH 3/3] add fallback parse_printf_format implementation
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Emil Renner Berthing <systemd@esmil.dk>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+[adapted for Managarm]
+Signed-off-by: Dennis Bonke <dennis@managarm.org>
+---
+ src/basic/meson.build           |   1 +
+ src/basic/parse-printf-format.c | 273 ++++++++++++++++++++++++++++++++
+ src/basic/parse-printf-format.h |  59 +++++++
+ 3 files changed, 333 insertions(+)
+ create mode 100644 src/basic/parse-printf-format.c
+ create mode 100644 src/basic/parse-printf-format.h
+
+diff --git a/src/basic/meson.build b/src/basic/meson.build
+index b538775..a4d9f53 100644
+--- a/src/basic/meson.build
++++ b/src/basic/meson.build
+@@ -111,6 +111,7 @@ basic_sources = files(
+         'utf8.c',
+         'virt.c',
+         'xattr-util.c',
++        'parse-printf-format.c',
+ )
+ 
+ missing_audit_h = files('missing_audit.h')
+diff --git a/src/basic/parse-printf-format.c b/src/basic/parse-printf-format.c
+new file mode 100644
+index 0000000..49437e5
+--- /dev/null
++++ b/src/basic/parse-printf-format.c
+@@ -0,0 +1,273 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the musl C library
++  Copyright 2005-2014 Rich Felker, et al.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#include <stddef.h>
++#include <string.h>
++
++#include "parse-printf-format.h"
++
++static const char *consume_nonarg(const char *fmt)
++{
++        do {
++                if (*fmt == '\0')
++                        return fmt;
++        } while (*fmt++ != '%');
++        return fmt;
++}
++
++static const char *consume_num(const char *fmt)
++{
++        for (;*fmt >= '0' && *fmt <= '9'; fmt++)
++                /* do nothing */;
++        return fmt;
++}
++
++static const char *consume_argn(const char *fmt, size_t *arg)
++{
++        const char *p = fmt;
++        size_t val = 0;
++
++        if (*p < '1' || *p > '9')
++                return fmt;
++        do {
++                val = 10*val + (*p++ - '0');
++        } while (*p >= '0' && *p <= '9');
++
++        if (*p != '$')
++                return fmt;
++        *arg = val;
++        return p+1;
++}
++
++static const char *consume_flags(const char *fmt)
++{
++        while (1) {
++                switch (*fmt) {
++                case '#':
++                case '0':
++                case '-':
++                case ' ':
++                case '+':
++                case '\'':
++                case 'I':
++                        fmt++;
++                        continue;
++                }
++                return fmt;
++        }
++}
++
++enum state {
++        BARE,
++        LPRE,
++        LLPRE,
++        HPRE,
++        HHPRE,
++        BIGLPRE,
++        ZTPRE,
++        JPRE,
++        STOP
++};
++
++enum type {
++        NONE,
++        PTR,
++        INT,
++        UINT,
++        ULLONG,
++        LONG,
++        ULONG,
++        SHORT,
++        USHORT,
++        CHAR,
++        UCHAR,
++        LLONG,
++        SIZET,
++        IMAX,
++        UMAX,
++        PDIFF,
++        UIPTR,
++        DBL,
++        LDBL,
++        MAXTYPE
++};
++
++static const short pa_types[MAXTYPE] = {
++        [NONE]   = PA_INT,
++        [PTR]    = PA_POINTER,
++        [INT]    = PA_INT,
++        [UINT]   = PA_INT,
++        [ULLONG] = PA_INT | PA_FLAG_LONG_LONG,
++        [LONG]   = PA_INT | PA_FLAG_LONG,
++        [ULONG]  = PA_INT | PA_FLAG_LONG,
++        [SHORT]  = PA_INT | PA_FLAG_SHORT,
++        [USHORT] = PA_INT | PA_FLAG_SHORT,
++        [CHAR]   = PA_CHAR,
++        [UCHAR]  = PA_CHAR,
++        [LLONG]  = PA_INT | PA_FLAG_LONG_LONG,
++        [SIZET]  = PA_INT | PA_FLAG_LONG,
++        [IMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [UMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [PDIFF]  = PA_INT | PA_FLAG_LONG_LONG,
++        [UIPTR]  = PA_INT | PA_FLAG_LONG,
++        [DBL]    = PA_DOUBLE,
++        [LDBL]   = PA_DOUBLE | PA_FLAG_LONG_DOUBLE
++};
++
++#define S(x) [(x)-'A']
++#define E(x) (STOP + (x))
++
++static const unsigned char states[]['z'-'A'+1] = {
++        { /* 0: bare types */
++                S('d') = E(INT), S('i') = E(INT),
++                S('o') = E(UINT),S('u') = E(UINT),S('x') = E(UINT), S('X') = E(UINT),
++                S('e') = E(DBL), S('f') = E(DBL), S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL), S('F') = E(DBL), S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(CHAR),S('C') = E(INT),
++                S('s') = E(PTR), S('S') = E(PTR), S('p') = E(UIPTR),S('n') = E(PTR),
++                S('m') = E(NONE),
++                S('l') = LPRE,   S('h') = HPRE, S('L') = BIGLPRE,
++                S('z') = ZTPRE,  S('j') = JPRE, S('t') = ZTPRE
++        }, { /* 1: l-prefixed */
++                S('d') = E(LONG), S('i') = E(LONG),
++                S('o') = E(ULONG),S('u') = E(ULONG),S('x') = E(ULONG),S('X') = E(ULONG),
++                S('e') = E(DBL),  S('f') = E(DBL),  S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL),  S('F') = E(DBL),  S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(INT),  S('s') = E(PTR),  S('n') = E(PTR),
++                S('l') = LLPRE
++        }, { /* 2: ll-prefixed */
++                S('d') = E(LLONG), S('i') = E(LLONG),
++                S('o') = E(ULLONG),S('u') = E(ULLONG),
++                S('x') = E(ULLONG),S('X') = E(ULLONG),
++                S('n') = E(PTR)
++        }, { /* 3: h-prefixed */
++                S('d') = E(SHORT), S('i') = E(SHORT),
++                S('o') = E(USHORT),S('u') = E(USHORT),
++                S('x') = E(USHORT),S('X') = E(USHORT),
++                S('n') = E(PTR),
++                S('h') = HHPRE
++        }, { /* 4: hh-prefixed */
++                S('d') = E(CHAR), S('i') = E(CHAR),
++                S('o') = E(UCHAR),S('u') = E(UCHAR),
++                S('x') = E(UCHAR),S('X') = E(UCHAR),
++                S('n') = E(PTR)
++        }, { /* 5: L-prefixed */
++                S('e') = E(LDBL),S('f') = E(LDBL),S('g') = E(LDBL), S('a') = E(LDBL),
++                S('E') = E(LDBL),S('F') = E(LDBL),S('G') = E(LDBL), S('A') = E(LDBL),
++                S('n') = E(PTR)
++        }, { /* 6: z- or t-prefixed (assumed to be same size) */
++                S('d') = E(PDIFF),S('i') = E(PDIFF),
++                S('o') = E(SIZET),S('u') = E(SIZET),
++                S('x') = E(SIZET),S('X') = E(SIZET),
++                S('n') = E(PTR)
++        }, { /* 7: j-prefixed */
++                S('d') = E(IMAX), S('i') = E(IMAX),
++                S('o') = E(UMAX), S('u') = E(UMAX),
++                S('x') = E(UMAX), S('X') = E(UMAX),
++                S('n') = E(PTR)
++        }
++};
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types)
++{
++        size_t i = 0;
++        size_t last = 0;
++
++        memset(types, 0, n);
++
++        while (1) {
++                size_t arg;
++                unsigned int state;
++
++                fmt = consume_nonarg(fmt);
++                if (*fmt == '\0')
++                        break;
++                if (*fmt == '%') {
++                        fmt++;
++                        continue;
++                }
++                arg = 0;
++                fmt = consume_argn(fmt, &arg);
++                /* flags */
++                fmt = consume_flags(fmt);
++                /* width */
++                if (*fmt == '*') {
++                        size_t warg = 0;
++                        fmt = consume_argn(fmt+1, &warg);
++                        if (warg == 0)
++                                warg = ++i;
++                        if (warg > last)
++                                last = warg;
++                        if (warg <= n && types[warg-1] == NONE)
++                                types[warg-1] = INT;
++                } else
++                        fmt = consume_num(fmt);
++                /* precision */
++                if (*fmt == '.') {
++                        fmt++;
++                        if (*fmt == '*') {
++                                size_t parg = 0;
++                                fmt = consume_argn(fmt+1, &parg);
++                                if (parg == 0)
++                                        parg = ++i;
++                                if (parg > last)
++                                        last = parg;
++                                if (parg <= n && types[parg-1] == NONE)
++                                        types[parg-1] = INT;
++                        } else {
++                                if (*fmt == '-')
++                                        fmt++;
++                                fmt = consume_num(fmt);
++                        }
++                }
++                /* length modifier and conversion specifier */
++                state = BARE;
++                do {
++                        unsigned char c = *fmt++;
++
++                        if (c < 'A' || c > 'z')
++                                continue;
++                        state = states[state]S(c);
++                        if (state == 0)
++                                continue;
++                } while (state < STOP);
++
++                if (state == E(NONE))
++                        continue;
++
++                if (arg == 0)
++                        arg = ++i;
++                if (arg > last)
++                        last = arg;
++                if (arg <= n)
++                        types[arg-1] = state - STOP;
++        }
++
++        if (last > n)
++                last = n;
++        for (i = 0; i < last; i++)
++                types[i] = pa_types[types[i]];
++
++        return last;
++}
+diff --git a/src/basic/parse-printf-format.h b/src/basic/parse-printf-format.h
+new file mode 100644
+index 0000000..9d10e53
+--- /dev/null
++++ b/src/basic/parse-printf-format.h
+@@ -0,0 +1,59 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the GNU C Library
++  Copyright 1991-2014 Free Software Foundation, Inc.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#pragma once
++
++#include "config.h"
++
++#if !defined(__managarm__)
++#include <printf.h>
++#elif defined _PRINTF_H
++
++#else
++
++#include <stddef.h>
++
++enum {				/* C type: */
++  PA_INT,			/* int */
++  PA_CHAR,			/* int, cast to char */
++  PA_WCHAR,			/* wide char */
++  PA_STRING,			/* const char *, a '\0'-terminated string */
++  PA_WSTRING,			/* const wchar_t *, wide character string */
++  PA_POINTER,			/* void * */
++  PA_FLOAT,			/* float */
++  PA_DOUBLE,			/* double */
++  PA_LAST
++};
++
++/* Flag bits that can be set in a type returned by `parse_printf_format'.  */
++#define	PA_FLAG_MASK		0xff00
++#define	PA_FLAG_LONG_LONG	(1 << 8)
++#define	PA_FLAG_LONG_DOUBLE	PA_FLAG_LONG_LONG
++#define	PA_FLAG_LONG		(1 << 9)
++#define	PA_FLAG_SHORT		(1 << 10)
++#define	PA_FLAG_PTR		(1 << 11)
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types);
++
++#endif
+-- 
+2.39.5
+

--- a/scripts/limine.conf
+++ b/scripts/limine.conf
@@ -3,12 +3,12 @@ timeout: 3
 /managarm (Weston, plainfb)
 	kernel_path: boot():/managarm/eir-limine
 	protocol: limine
-	cmdline: bochs init.launch=weston plainfb.force=1
+	cmdline: bochs init.launch=weston plainfb.force=1 systemd.log_level=debug
 	module_path: boot():/managarm/initrd.cpio
 /managarm (Sway, plainfb)
 	kernel_path: boot():/managarm/eir-limine
 	protocol: limine
-	cmdline: bochs init.launch=sway plainfb.force=1
+	cmdline: bochs init.launch=sway plainfb.force=1 systemd.log_level=debug
 	module_path: boot():/managarm/initrd.cpio
 /managarm (kmscon, plainfb)
 	kernel_path: boot():/managarm/eir-limine

--- a/scripts/limine.conf
+++ b/scripts/limine.conf
@@ -13,7 +13,7 @@ timeout: 3
 /managarm (kmscon, plainfb)
 	kernel_path: boot():/managarm/eir-limine
 	protocol: limine
-	cmdline: bochs init.launch=kmscon plainfb.force=1
+	cmdline: bochs init.launch=kmscon plainfb.force=1 systemd.log_level=debug
 	module_path: boot():/managarm/initrd.cpio
 
 /Advanced


### PR DESCRIPTION
This PR adds the necessary patchwork to allow systemd to boot a Managarm system into Weston.
Additional patches enabling weston and kmscon will follow later.
For now, if one has it locally, one can specify `systemd` on the kernel commandline to force stage1 to exec into systemd, otherwise the stage2 fallback will be used.

Part of the systemd on Managarm project.