### PR TITLE
More systemd fixes and enablement for kmscon

### DIFF
--- a/bootstrap.d/app-misc.y4.yml
+++ b/bootstrap.d/app-misc.y4.yml
@@ -106,7 +106,7 @@ packages:
       - libxcb
       - libxrandr
       - freetype
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-libs.y4.yml
+++ b/bootstrap.d/dev-libs.y4.yml
@@ -2516,7 +2516,7 @@ packages:
       - xcb-util-cursor
       - libdisplay-info
       - systemd
-    revision: 3
+    revision: 4
     configure:
       - args:
         - 'meson'
@@ -2550,11 +2550,11 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
         quiet: true
-      - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/socket.target.wants']
+      - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sockets.target.wants']
       - args: ['mkdir', '-pv', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/graphical.target.wants']
       - args: ['cp', '-v', '@THIS_SOURCE_DIR@/weston.socket', '@THIS_COLLECT_DIR@/usr/lib/systemd/system']
       - args: ['cp', '-v', '@THIS_SOURCE_DIR@/weston.service', '@THIS_COLLECT_DIR@/usr/lib/systemd/system']
-      - args: ['ln', '-svn', '../weston.socket', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/socket.target.wants/']
+      - args: ['ln', '-svn', '../weston.socket', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sockets.target.wants/']
       - args: ['ln', '-svn', '../weston.service', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/graphical.target.wants/']
 
   - name: xxhash

--- a/bootstrap.d/managarm-base.y4.yml
+++ b/bootstrap.d/managarm-base.y4.yml
@@ -13,7 +13,7 @@ packages:
     source:
       subdir: meta-sources
       version: '1.0'
-    revision: 10
+    revision: 11
     configure: []
     build:
       # Create initial directories
@@ -55,7 +55,5 @@ packages:
       - args: ['ln', '-svf', 'usr/bin', '@THIS_COLLECT_DIR@/bin']
       - args: ['ln', '-svf', 'usr/lib', '@THIS_COLLECT_DIR@/lib']
       - args: ['ln', '-svf', 'usr/sbin', '@THIS_COLLECT_DIR@/sbin']
-      # Link /var/run to /run
-      - args: ['ln', '-svf', 'var/run', '@THIS_COLLECT_DIR@/run']
       # Create a compatibility symlink for ld.so
       - args: ['ln', '-svf', '/usr/lib/ld.so', '@THIS_COLLECT_DIR@/lib/ld-init.so']

--- a/bootstrap.d/meta-pkgs.y4.yml
+++ b/bootstrap.d/meta-pkgs.y4.yml
@@ -57,7 +57,9 @@ packages:
       - procps
       - htop
       - shadow
-    revision: 8
+      - dbus
+      - systemd
+    revision: 9
     configure: []
     build: []
 

--- a/bootstrap.d/net-misc.y4.yml
+++ b/bootstrap.d/net-misc.y4.yml
@@ -64,7 +64,7 @@ packages:
     pkgs_required:
       - mlibc
       - systemd
-    revision: 4
+    revision: 5
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -84,6 +84,9 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/multi-user.target.wants']
+      - args: ['cp', '@THIS_SOURCE_DIR@/dhcpcd.service', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/']
+      - args: ['ln', '-svn', '../dhcpcd.service', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/multi-user.target.wants/']
 
   - name: iana-etc
     labels: [aarch64, riscv64]

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -1467,7 +1467,7 @@ packages:
       - openssl
       - util-linux-libs
       - mlibc
-    revision: 5
+    revision: 6
     configure:
       - args:
         - 'meson'
@@ -1539,7 +1539,7 @@ packages:
         - '-Dqrencode=false'
         - '-Dquotacheck=false'
         - '-Duserdb=false'
-        - '-Dutmp=false'
+        - '-Dutmp=true'
         - '-Dvconsole=false'
         - '-Dwheel-group=false'
         - '-Dxdg-autostart=false'
@@ -1560,6 +1560,13 @@ packages:
       - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-ask-password-console.path']
       - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sysinit.target.wants/systemd-ask-password-console.path']
       - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-ask-password-console.service']
+      # These are part of utmp, but don't work yet, investigate later
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-update-utmp.service']
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-update-utmp-runlevel.service']
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/graphical.target.wants/systemd-update-utmp-runlevel.service']
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/multi-user.target.wants/systemd-update-utmp-runlevel.service']
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/rescue.target.wants/systemd-update-utmp-runlevel.service']
+      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sysinit.target.wants/systemd-update-utmp.service']
       # Touch up empty directories
       - args: ['touch',
           '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel1.target.wants/.keep',
@@ -1567,6 +1574,8 @@ packages:
           '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel3.target.wants/.keep',
           '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel4.target.wants/.keep',
           '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel5.target.wants/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system/rescue.target.wants/.keep',
+          '@THIS_COLLECT_DIR@/usr/lib/systemd/system/graphical.target.wants/.keep',
           '@THIS_COLLECT_DIR@/usr/lib/systemd/user-generators/.keep',
           '@THIS_COLLECT_DIR@/usr/lib/systemd/system-shutdown/.keep',
           '@THIS_COLLECT_DIR@/usr/lib/systemd/system-sleep/.keep',

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -1365,7 +1365,7 @@ packages:
       - libdrm
       - libtsm
       - systemd
-    revision: 11
+    revision: 12
     configure:
       - args:
         - 'meson'
@@ -1388,6 +1388,9 @@ packages:
         quiet: true
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/kmscon']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/kmscon.conf', '@THIS_COLLECT_DIR@/etc/kmscon/']
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/kmscon.target.wants']
+      - args: ['ln', '-svn', '../kmscon.service', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/kmscon.target.wants/']
+      - args: ['cp', '@THIS_SOURCE_DIR@/kmscon.target', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/kmscon.target']
 
   - name: eudev
     labels: [aarch64, riscv64]

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -905,7 +905,7 @@ packages:
       - libxcrypt
       - libiconv
       - libintl
-    revision: 5
+    revision: 6
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -157,7 +157,7 @@ packages:
       - glib
       - libexpat
       - systemd
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -189,9 +189,9 @@ packages:
       # Touch up empty directories
       - args: ['touch',
           '@THIS_COLLECT_DIR@/usr/share/dbus-1/session.d/.keep',
-          '@THIS_COLLECT_DIR@/var/lib/dbus/.keep',
-          '@THIS_COLLECT_DIR@/var/run/dbus/.keep'
+          '@THIS_COLLECT_DIR@/var/lib/dbus/.keep'
         ]
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/var/run/']
 
   - name: diffutils
     labels: [aarch64, riscv64]

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -1463,7 +1463,7 @@ packages:
       - openssl
       - util-linux-libs
       - mlibc
-    revision: 4
+    revision: 5
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -121,7 +121,15 @@ packages:
         quiet: true
 
   - name: dbus
+    labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'
+    metadata:
+      summary: A message bus system, a simple way for applications to talk to each other
+      description: D-Bus is a message bus system, a simple way for applications to talk to one another. D-Bus supplies both a system daemon (for events such as "new hardware device added" or "printer queue changed") and a per-user-login-session daemon (for general IPC needs among user applications). Also, the message bus is built on top of a general one-to-one message passing framework, which can be used by any two applications to communicate directly (without going through the message bus daemon).
+      spdx: 'GPL-2.0-only'
+      website: 'https://www.freedesktop.org/wiki/Software/dbus/'
+      maintainer: "Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-apps']
     source:
       subdir: ports
       git: 'https://gitlab.freedesktop.org/dbus/dbus.git'
@@ -149,7 +157,7 @@ packages:
       - glib
       - libexpat
       - systemd
-    revision: 9
+    revision: 10
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -178,6 +186,12 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+      # Touch up empty directories
+      - args: ['touch',
+          '@THIS_COLLECT_DIR@/usr/share/dbus-1/session.d/.keep',
+          '@THIS_COLLECT_DIR@/var/lib/dbus/.keep',
+          '@THIS_COLLECT_DIR@/var/run/dbus/.keep'
+        ]
 
   - name: diffutils
     labels: [aarch64, riscv64]

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -1365,7 +1365,7 @@ packages:
       - libdrm
       - libtsm
       - systemd
-    revision: 10
+    revision: 11
     configure:
       - args:
         - 'meson'
@@ -1378,6 +1378,7 @@ packages:
         - '--buildtype=debugoptimized'
         - '-Dsession_dummy=enabled'
         - '-Dsession_terminal=enabled'
+        - '-Dmulti_seat=disabled'
         - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']

--- a/patches/dbus/0001-Disable-the-use-of-getresuid-as-we-don-t-implement-t.patch
+++ b/patches/dbus/0001-Disable-the-use-of-getresuid-as-we-don-t-implement-t.patch
@@ -1,7 +1,8 @@
-From 4e718c51b3f75b740d12bc8d4ffe04d81929e008 Mon Sep 17 00:00:00 2001
+From 9d69ab48a8d596ab0c20d1c02ab51ff2c8dc9670 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Mon, 10 Oct 2022 16:24:57 +0200
-Subject: [PATCH] Disable the use of getresuid as we don't implement that yet
+Subject: [PATCH 1/2] Disable the use of getresuid as we don't implement that
+ yet
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
@@ -23,5 +24,5 @@ index e511afc..30c5fd8 100644
            getresgid (&rgid, &egid, &sgid) != 0)
  #endif /* HAVE_GETRESUID */
 -- 
-2.38.1
+2.47.2
 

--- a/patches/dbus/0002-Add-Managarm-support-and-remove-unimplemented-items-.patch
+++ b/patches/dbus/0002-Add-Managarm-support-and-remove-unimplemented-items-.patch
@@ -1,0 +1,131 @@
+From 1495c02fca99bc73538d24321633e831d5bc9f6c Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Fri, 14 Mar 2025 11:48:48 +0100
+Subject: [PATCH 2/2] Add Managarm support and remove unimplemented items in
+ systemd unit file
+
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
+---
+ bus/dbus.service.in           |  2 +-
+ configure.ac                  |  4 ++--
+ dbus/dbus-socket-set-epoll.c  |  2 +-
+ dbus/dbus-sysdeps-unix.c      |  4 ++--
+ dbus/dbus-sysdeps-util-unix.c | 14 ++++++++++++++
+ 5 files changed, 20 insertions(+), 6 deletions(-)
+
+diff --git a/bus/dbus.service.in b/bus/dbus.service.in
+index ca0b7e9..445ab0e 100644
+--- a/bus/dbus.service.in
++++ b/bus/dbus.service.in
+@@ -6,4 +6,4 @@ Requires=dbus.socket
+ [Service]
+ ExecStart=@EXPANDED_BINDIR@/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
+ ExecReload=@EXPANDED_BINDIR@/dbus-send --print-reply --system --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
+-OOMScoreAdjust=-900
++#OOMScoreAdjust=-900
+diff --git a/configure.ac b/configure.ac
+index 3bb9cce..0ad0621 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -992,8 +992,8 @@ else
+     AC_MSG_CHECKING([for Linux epoll(4)])
+     AC_LINK_IFELSE([AC_LANG_PROGRAM(
+         [
+-        #ifndef __linux__
+-        #error This is not Linux
++        #if !defined(__linux__) && !defined(__managarm__)
++        #error This is not Linux or Managarm
+         #endif
+         #include <sys/epoll.h>
+         ],
+diff --git a/dbus/dbus-socket-set-epoll.c b/dbus/dbus-socket-set-epoll.c
+index 4692cbe..b50e22d 100644
+--- a/dbus/dbus-socket-set-epoll.c
++++ b/dbus/dbus-socket-set-epoll.c
+@@ -28,7 +28,7 @@
+ #include <dbus/dbus-internals.h>
+ #include <dbus/dbus-sysdeps.h>
+ 
+-#ifndef __linux__
++#if !defined(__linux__) && !defined(__managarm__)
+ # error This file is for Linux epoll(4)
+ #endif
+ 
+diff --git a/dbus/dbus-sysdeps-unix.c b/dbus/dbus-sysdeps-unix.c
+index 30c5fd8..bde9228 100644
+--- a/dbus/dbus-sysdeps-unix.c
++++ b/dbus/dbus-sysdeps-unix.c
+@@ -961,7 +961,7 @@ _dbus_connect_unix_socket (const char     *path,
+ 
+   if (abstract)
+     {
+-#ifdef __linux__
++#if defined(__linux__) || defined(__managarm__)
+       addr.sun_path[0] = '\0'; /* this is what says "use abstract" */
+       path_len++; /* Account for the extra nul byte added to the start of sun_path */
+ 
+@@ -1163,7 +1163,7 @@ _dbus_listen_unix_socket (const char     *path,
+ 
+   if (abstract)
+     {
+-#ifdef __linux__
++#if defined(__linux__) || defined(__managarm__)
+       /* remember that abstract names aren't nul-terminated so we rely
+        * on sun_path being filled in with zeroes above.
+        */
+diff --git a/dbus/dbus-sysdeps-util-unix.c b/dbus/dbus-sysdeps-util-unix.c
+index 26fcb5b..0306a95 100644
+--- a/dbus/dbus-sysdeps-util-unix.c
++++ b/dbus/dbus-sysdeps-util-unix.c
+@@ -397,10 +397,12 @@ _dbus_rlimit_save_fd_limit (DBusError *error)
+ 
+   if (getrlimit (RLIMIT_NOFILE, &self->lim) < 0)
+     {
++#ifndef __managarm__
+       dbus_set_error (error, _dbus_error_from_errno (errno),
+                       "Failed to get fd limit: %s", _dbus_strerror (errno));
+       dbus_free (self);
+       return NULL;
++#endif
+     }
+ 
+   return self;
+@@ -420,7 +422,11 @@ _dbus_rlimit_raise_fd_limit (DBusError *error)
+     {
+       dbus_set_error (error, _dbus_error_from_errno (errno),
+                       "Failed to get fd limit: %s", _dbus_strerror (errno));
++#ifdef __managarm__
++      return TRUE;
++#else
+       return FALSE;
++#endif
+     }
+ 
+   old = lim;
+@@ -460,7 +466,11 @@ _dbus_rlimit_raise_fd_limit (DBusError *error)
+                       "Failed to set fd limit to %lu: %s",
+                       (unsigned long) lim.rlim_cur,
+                       _dbus_strerror (errno));
++#ifdef __managarm__
++      return TRUE;
++#else
+       return FALSE;
++#endif
+     }
+ 
+   return TRUE;
+@@ -475,7 +485,11 @@ _dbus_rlimit_restore_fd_limit (DBusRLimit *saved,
+       dbus_set_error (error, _dbus_error_from_errno (errno),
+                       "Failed to restore old fd limit: %s",
+                       _dbus_strerror (errno));
++#ifdef __managarm__
++      return TRUE;
++#else
+       return FALSE;
++#endif
+     }
+ 
+   return TRUE;
+-- 
+2.47.2
+

--- a/patches/dhcpcd/0001-Add-managarm-support.patch
+++ b/patches/dhcpcd/0001-Add-managarm-support.patch
@@ -1,7 +1,7 @@
-From 9995559d20b1e91b54b8f9a6c896be97f13b7a4b Mon Sep 17 00:00:00 2001
+From 3934f02e42c7a25ca4545c2ca7b628e2de051bfd Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Sun, 19 May 2024 22:35:30 +0200
-Subject: [PATCH] Add managarm support
+Subject: [PATCH 1/2] Add managarm support
 
 ---
  configure           | 14 +++++++-------
@@ -271,5 +271,5 @@ index 45f0e1a..fd4bc74 100644
  # endif
  #endif
 -- 
-2.44.0
+2.47.2
 

--- a/patches/dhcpcd/0002-Add-systemd-unit-file.patch
+++ b/patches/dhcpcd/0002-Add-systemd-unit-file.patch
@@ -1,0 +1,36 @@
+From cb0f0831b08d35d265fd4378ecfb6aba05e367cf Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Fri, 14 Mar 2025 15:27:37 +0100
+Subject: [PATCH 2/2] Add systemd unit file
+
+---
+ dhcpcd.service | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+ create mode 100644 dhcpcd.service
+
+diff --git a/dhcpcd.service b/dhcpcd.service
+new file mode 100644
+index 0000000..1a88202
+--- /dev/null
++++ b/dhcpcd.service
+@@ -0,0 +1,17 @@
++# This service file is graciously taken from gentoo
++
++[Unit]
++Description=Lightweight DHCP client daemon
++Wants=network.target
++Before=network.target network-online.target
++
++[Service]
++Type=forking
++ExecStart=/sbin/dhcpcd -q
++PIDFile=/run/dhcpcd/pid
++# Avoid duplicate output on stderr/syslog
++StandardOutput=null
++StandardError=null
++
++[Install]
++WantedBy=multi-user.target
+-- 
+2.47.2
+

--- a/patches/fastfetch/0001-Add-Managarm-support.patch
+++ b/patches/fastfetch/0001-Add-Managarm-support.patch
@@ -1,20 +1,21 @@
-From b50977b2cb6b3f9c2c7f9762373085918c9447cb Mon Sep 17 00:00:00 2001
+From 4807cfac0b52b2f242eaa8091108c6f131c6353c Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Sun, 5 Jan 2025 22:21:51 +0100
 Subject: [PATCH] Add Managarm support
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
- CMakeLists.txt                           | 112 ++++++++++++++++++++---
- src/common/processing_linux.c            |   4 +-
- src/detection/displayserver/linux/wmde.c |   2 +-
- src/detection/libc/libc_linux.c          |   3 +
- src/options/general.h                    |   2 +-
- src/util/FFstrbuf.h                      |   1 +
- src/util/platform/FFPlatform_unix.c      |   2 +-
- src/util/smbiosHelper.c                  |   6 +-
- src/util/smbiosHelper.h                  |   2 +-
- 9 files changed, 113 insertions(+), 21 deletions(-)
+ CMakeLists.txt                              | 112 +++++++++++++++++---
+ src/common/processing_linux.c               |   4 +-
+ src/detection/displayserver/linux/wmde.c    |   2 +-
+ src/detection/initsystem/initsystem_linux.c |   2 +-
+ src/detection/libc/libc_linux.c             |   3 +
+ src/options/general.h                       |   2 +-
+ src/util/FFstrbuf.h                         |   1 +
+ src/util/platform/FFPlatform_unix.c         |   2 +-
+ src/util/smbiosHelper.c                     |   6 +-
+ src/util/smbiosHelper.h                     |   2 +-
+ 10 files changed, 114 insertions(+), 22 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 71c0e88..e1d0bfb 100644
@@ -207,6 +208,19 @@ index 557be31..473e834 100644
      FF_AUTO_CLOSE_DIR DIR* procdir = opendir("/proc");
      if(procdir == NULL)
          return "opendir(\"/proc\") failed";
+diff --git a/src/detection/initsystem/initsystem_linux.c b/src/detection/initsystem/initsystem_linux.c
+index 6776ef7..e2e4142 100644
+--- a/src/detection/initsystem/initsystem_linux.c
++++ b/src/detection/initsystem/initsystem_linux.c
+@@ -48,7 +48,7 @@ const char* ffDetectInitSystem(FFInitSystemResult* result)
+ 
+     if (instance.config.general.detectVersion)
+     {
+-        #if __linux__ && !__ANDROID__
++        #if (__linux__ && !__ANDROID__) || defined(__managarm__)
+         if (ffStrbufEqualS(&result->name, "systemd"))
+         {
+             ffBinaryExtractStrings(result->exe.chars, extractSystemdVersion, &result->version, (uint32_t) strlen("systemd 0.0 running in x"));
 diff --git a/src/detection/libc/libc_linux.c b/src/detection/libc/libc_linux.c
 index 19e8e83..1ade513 100644
 --- a/src/detection/libc/libc_linux.c
@@ -301,5 +315,5 @@ index 1bce70b..98b01a0 100644
  bool ffGetSmbiosValue(const char* devicesPath, const char* classPath, FFstrbuf* buffer);
  #endif
 -- 
-2.45.2
+2.47.2
 

--- a/patches/kmscon/0001-Fix-a-few-things-to-make-kmscon-compile-for-managarm.patch
+++ b/patches/kmscon/0001-Fix-a-few-things-to-make-kmscon-compile-for-managarm.patch
@@ -1,15 +1,58 @@
-From f2db8b60b5c51787ae26e52b434b3f608aff537b Mon Sep 17 00:00:00 2001
+From 5827826d39bc9553802ea4e8e417599bb280bffd Mon Sep 17 00:00:00 2001
 From: qookie <kacper.slominski72@gmail.com>
 Date: Sun, 23 Jun 2019 19:02:21 +0200
 Subject: [PATCH 1/2] Fix a few things to make kmscon compile for managarm
 
+Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
+ docs/kmscon.service.in |  1 +
+ kmscon.target          |  8 ++++++++
+ src/conf.c             |  1 +
  src/pty.c              |  1 +
  src/uterm_drm_shared.c |  3 ++-
  src/uterm_monitor.c    | 24 +++++++++++++++++-------
  src/uterm_vt.c         |  1 +
- 4 files changed, 21 insertions(+), 8 deletions(-)
+ 7 files changed, 31 insertions(+), 8 deletions(-)
+ create mode 100644 kmscon.target
 
+diff --git a/docs/kmscon.service.in b/docs/kmscon.service.in
+index c29fe92..398469e 100644
+--- a/docs/kmscon.service.in
++++ b/docs/kmscon.service.in
+@@ -3,6 +3,7 @@ Description=KMS System Console
+ Documentation=man:kmscon(1)
+ 
+ [Service]
++ExecStartPre=@bindir@/wait-for-devices --want-graphics --want-keyboard
+ ExecStart=@bindir@/kmscon -l /bin/login
+ 
+ [Install]
+diff --git a/kmscon.target b/kmscon.target
+new file mode 100644
+index 0000000..92c9b6e
+--- /dev/null
++++ b/kmscon.target
+@@ -0,0 +1,8 @@
++[Unit]
++Description=Graphical Interface (KMSCON)
++Documentation=man:systemd.special(7)
++Requires=multi-user.target
++Wants=kmscon.service
++Conflicts=rescue.service rescue.target
++After=multi-user.target rescue.service rescue.target kmscon.service
++AllowIsolate=yes
+diff --git a/src/conf.c b/src/conf.c
+index 890e599..4f245e0 100644
+--- a/src/conf.c
++++ b/src/conf.c
+@@ -36,6 +36,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <strings.h>
+ #include <unistd.h>
+ #include <xkbcommon/xkbcommon.h>
+ #include "conf.h"
 diff --git a/src/pty.c b/src/pty.c
 index 1443f4a..e9c817a 100644
 --- a/src/pty.c
@@ -108,5 +151,5 @@ index fbe9e76..203350b 100644
  #include <sys/stat.h>
  #include <sys/sysmacros.h>
 -- 
-2.40.1
+2.47.2
 

--- a/patches/kmscon/0002-Disable-system-locale-querying-via-dbus.patch
+++ b/patches/kmscon/0002-Disable-system-locale-querying-via-dbus.patch
@@ -1,4 +1,4 @@
-From cfa28f86984a600fdcb7587295e778ea8fe6839b Mon Sep 17 00:00:00 2001
+From 8f8f2b9397ad95b2f171662ebcec4492a308de0a Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Mon, 24 Jul 2023 18:06:22 +0200
 Subject: [PATCH 2/2] Disable system locale querying via dbus
@@ -19,5 +19,5 @@ index 61594bf..c7f74b1 100755
 +# setupLocale
  exec ${helperdir}/kmscon "$@"
 -- 
-2.40.1
+2.47.2
 

--- a/patches/shadow/0001-Add-Managarm-support.patch
+++ b/patches/shadow/0001-Add-Managarm-support.patch
@@ -1,4 +1,4 @@
-From 2f202a15824086eda8f5e006ec64e6e7ee87bd8a Mon Sep 17 00:00:00 2001
+From a0a3c21b74484544e07683bed59e089707e47781 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Thu, 5 Sep 2024 00:27:05 +0200
 Subject: [PATCH] Add Managarm support
@@ -12,8 +12,9 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  libmisc/user_busy.c |  1 +
  libmisc/utmp.c      |  3 +++
  src/Makefile.am     | 10 ++++------
+ src/lastlog.c       |  4 +++-
  src/login.c         |  6 ++++++
- 8 files changed, 23 insertions(+), 12 deletions(-)
+ 9 files changed, 26 insertions(+), 13 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
 index 8851f5d..5a58c54 100644
@@ -160,6 +161,21 @@ index f175928..fda013b 100644
  endif
  if !WITH_TCB
  suidubins += passwd
+diff --git a/src/lastlog.c b/src/lastlog.c
+index c1caedb..8984075 100644
+--- a/src/lastlog.c
++++ b/src/lastlog.c
+@@ -160,7 +160,9 @@ static void print_one (/*@null@*/const struct passwd *pw)
+ 	ll_time = ll.ll_time;
+ 	tm = localtime (&ll_time);
+ #ifdef HAVE_STRFTIME
+-	strftime (ptime, sizeof (ptime), "%a %b %e %H:%M:%S %z %Y", tm);
++	// TODO: Managarm does not implement %z yet
++	// strftime (ptime, sizeof (ptime), "%a %b %e %H:%M:%S %z %Y", tm);
++	strftime (ptime, sizeof (ptime), "%a %b %e %H:%M:%S %Y", tm);
+ 	cp = ptime;
+ #else
+ 	cp = asctime (tm);
 diff --git a/src/login.c b/src/login.c
 index 00508cd..af876c9 100644
 --- a/src/login.c
@@ -193,5 +209,5 @@ index 00508cd..af876c9 100644
  #ifndef USE_PAM			/* PAM does this */
  	/*
 -- 
-2.45.2
+2.47.2
 

--- a/patches/systemd/0001-Add-managarm-support.patch
+++ b/patches/systemd/0001-Add-managarm-support.patch
@@ -509,5 +509,5 @@ index c236a70..8314e2c 100644
          if (getuid() == 0) {
                  _cleanup_(udev_ctrl_unrefp) UdevCtrl *uctrl = NULL;
 -- 
-2.39.5
+2.47.2
 

--- a/patches/systemd/0002-Add-support-for-systemd-boot-for-Managarm.patch
+++ b/patches/systemd/0002-Add-support-for-systemd-boot-for-Managarm.patch
@@ -1,4 +1,4 @@
-From c02304e2d1f9a5e95832104eb5c533afee403964 Mon Sep 17 00:00:00 2001
+From fcc16df2c48e35ad13083e46f3c67b3bacb1f80b Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Fri, 10 Jan 2025 00:55:19 +0100
 Subject: [PATCH 2/3] Add support for systemd boot for Managarm
@@ -12,9 +12,7 @@ Subject: [PATCH 2/3] Add support for systemd boot for Managarm
  src/core/exec-invoke.c                   | 11 ++++++++++
  src/core/main.c                          |  3 +++
  src/core/mount.c                         | 11 ++++++++++
- src/journal/journald-native.c            |  3 +++
  src/journal/journald-server.c            |  9 ++++++++
- src/journal/journald-syslog.c            |  3 +++
  src/journal/journald.conf                |  6 +++---
  src/libsystemd/sd-journal/journal-send.c |  1 +
  src/shared/async.c                       |  4 ++++
@@ -23,7 +21,7 @@ Subject: [PATCH 2/3] Add support for systemd boot for Managarm
  src/udev/udev.conf                       |  2 +-
  units/systemd-journald.service.in        | 10 ++++-----
  units/systemd-udevd.service.in           | 26 ++++++++++++------------
- 19 files changed, 99 insertions(+), 28 deletions(-)
+ 17 files changed, 93 insertions(+), 28 deletions(-)
 
 diff --git a/src/basic/capability-util.c b/src/basic/capability-util.c
 index e9b41fe..ed8472c 100644
@@ -257,23 +255,6 @@ index 66917df..405dd2b 100644
  }
  
  static int mount_dispatch_io(sd_event_source *source, int fd, uint32_t revents, void *userdata) {
-diff --git a/src/journal/journald-native.c b/src/journal/journald-native.c
-index 0600102..817bc7c 100644
---- a/src/journal/journald-native.c
-+++ b/src/journal/journald-native.c
-@@ -493,9 +493,12 @@ int server_open_native_socket(Server *s, const char *native_socket) {
-                         log_warning_errno(r, "SO_PASSSEC failed: %m");
-         }
- 
-+// TODO: Remove this hack once SO_TIMESTAMP is merged
-+#ifndef __managarm__
-         r = setsockopt_int(s->native_fd, SOL_SOCKET, SO_TIMESTAMP, true);
-         if (r < 0)
-                 return log_error_errno(r, "SO_TIMESTAMP failed: %m");
-+#endif
- 
-         r = sd_event_add_io(s->event, &s->native_event_source, s->native_fd, EPOLLIN, server_process_datagram, s);
-         if (r < 0)
 diff --git a/src/journal/journald-server.c b/src/journal/journald-server.c
 index 07748f0..3f05328 100644
 --- a/src/journal/journald-server.c
@@ -306,23 +287,6 @@ index 07748f0..3f05328 100644
 +#endif
  
          r = server_setup_signals(s);
-         if (r < 0)
-diff --git a/src/journal/journald-syslog.c b/src/journal/journald-syslog.c
-index 4ad73ed..d2436c5 100644
---- a/src/journal/journald-syslog.c
-+++ b/src/journal/journald-syslog.c
-@@ -495,9 +495,12 @@ int server_open_syslog_socket(Server *s, const char *syslog_socket) {
-                         log_warning_errno(r, "SO_PASSSEC failed: %m");
-         }
- 
-+// TODO: Remove this hack once SO_TIMESTAMP is merged
-+#ifndef __managarm__
-         r = setsockopt_int(s->syslog_fd, SOL_SOCKET, SO_TIMESTAMP, true);
-         if (r < 0)
-                 return log_error_errno(r, "SO_TIMESTAMP failed: %m");
-+#endif
- 
-         r = sd_event_add_io(s->event, &s->syslog_event_source, s->syslog_fd, EPOLLIN, server_process_datagram, s);
          if (r < 0)
 diff --git a/src/journal/journald.conf b/src/journal/journald.conf
 index 9a12ca7..828dee0 100644
@@ -563,5 +527,5 @@ index f4a4482..29a22b5 100644
 +#IPAddressDeny=any
  {{SERVICE_WATCHDOG}}
 -- 
-2.39.5
+2.47.2
 

--- a/patches/systemd/0003-add-fallback-parse_printf_format-implementation.patch
+++ b/patches/systemd/0003-add-fallback-parse_printf_format-implementation.patch
@@ -1,4 +1,4 @@
-From d998fd66ec2ac7e5d29a08e366ce0b0d5553d801 Mon Sep 17 00:00:00 2001
+From 72556c6577df790193a14403969ad61ca0978caa Mon Sep 17 00:00:00 2001
 From: Alexander Kanavin <alex.kanavin@gmail.com>
 Date: Sat, 22 May 2021 20:26:24 +0200
 Subject: [PATCH 3/3] add fallback parse_printf_format implementation
@@ -377,5 +377,5 @@ index 0000000..9d10e53
 +
 +#endif
 -- 
-2.39.5
+2.47.2
 

--- a/patches/weston/0002-Add-systemd-unit-files.patch
+++ b/patches/weston/0002-Add-systemd-unit-files.patch
@@ -4,18 +4,18 @@ Date: Thu, 13 Mar 2025 02:14:28 +0100
 Subject: [PATCH 2/3] Add systemd unit files
 
 ---
- weston.service | 27 +++++++++++++++++++++++++++
+ weston.service | 28 ++++++++++++++++++++++++++++
  weston.socket  |  7 +++++++
- 2 files changed, 34 insertions(+)
+ 2 files changed, 35 insertions(+)
  create mode 100644 weston.service
  create mode 100644 weston.socket
 
 diff --git a/weston.service b/weston.service
 new file mode 100644
-index 0000000..b126d9a
+index 0000000..a5d3989
 --- /dev/null
 +++ b/weston.service
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,28 @@
 +[Unit]
 +Description=Weston, a Wayland compositor, as a user service
 +Documentation=man:weston(1) man:weston.ini(5)
@@ -35,6 +35,7 @@ index 0000000..b126d9a
 +StandardError=journal
 +
 +# add a ~/.config/weston.ini and weston will pick-it up
++ExecStartPre=/usr/bin/wait-for-devices --want-graphics --want-keyboard --want-mouse
 +ExecStart=/usr/bin/weston --xwayland
 +# HACK: All of these should be set by a proper DM, but for now hardcode them in
 +Environment="XDG_RUNTIME_DIR=/run"

--- a/scripts/limine.conf
+++ b/scripts/limine.conf
@@ -13,7 +13,7 @@ timeout: 3
 /managarm (kmscon, plainfb)
 	kernel_path: boot():/managarm/eir-limine
 	protocol: limine
-	cmdline: bochs init.launch=kmscon plainfb.force=1 systemd.log_level=debug
+	cmdline: bochs init.launch=kmscon plainfb.force=1 systemd.log_level=debug systemd.unit=kmscon.target
 	module_path: boot():/managarm/initrd.cpio
 
 /Advanced


### PR DESCRIPTION
This PR fixes `dbus` to not be broken when launched over `systemd`, fixes a broken installation path for `weston`, removes now unneeded patches for `systemd` and enables utmp and logind, removes an unneeded symlink made by `core-files`, enables `systemd` support in `kmscon` and updates the limine.conf to reflect that. It also updates `fastfetch` to enable checking for which systemd version we run and adds a systemd unit to `dhcpcd`. Finally, the `base` metapackage was updated to include `dbus` by default.

Blocked on managarm/managarm#888