### PR TITLE
kmscube: Switch to debian mirror

### DIFF
--- a/bootstrap.d/x11-apps.y4.yml
+++ b/bootstrap.d/x11-apps.y4.yml
@@ -567,8 +567,8 @@ packages:
       rolling_version: true
       version: '0.0pl@ROLLING_ID@'
       subdir: 'ports'
-      git: 'https://gitlab.freedesktop.org/mesa/kmscube.git'
-      branch: 'master'
+      git: 'https://salsa.debian.org/agx/kmscube.git' # Use debian mirror as freedesktop is currently down
+      branch: 'debian/sid'
       commit: b235bae4c674b6ef4ac15a40b46000876bee9425
       tools_required:
         - host-autoconf-v2.69


### PR DESCRIPTION
With gitlab.freedesktop.org down, and the fact that `kmscube` checks out a commit and is therefore not catched by the mirroring task, let's switch to the debian mirror, at least for now.