### PR TITLE
host-rust: Fix rustc not being built

### DIFF
--- a/bootstrap.d/dev-lang.y4.yml
+++ b/bootstrap.d/dev-lang.y4.yml
@@ -64,7 +64,7 @@ tools:
       - host-llvm-toolchain
       - host-python
       - host-libffi
-    revision: 2
+    revision: 3
     compile:
       - args: |
             cat << EOF > config.toml
@@ -93,14 +93,14 @@ tools:
             [target.x86_64-unknown-managarm-mlibc]
             llvm-config = "@BUILD_ROOT@/tools/host-llvm-toolchain/bin/llvm-config"
             EOF
-      - args: ['python3', '@THIS_SOURCE_DIR@/x.py', 'build', 'clippy', '--stage', '2', '-j', '@PARALLELISM@']
+      - args: ['python3', '@THIS_SOURCE_DIR@/x.py', 'build', 'rustc', 'clippy', 'std', '--stage', '2', '-j', '@PARALLELISM@']
         cargo_home: false
         environ:
           CARGO_HOME: '@THIS_BUILD_DIR@/cargo-home'
           BOOTSTRAP_SKIP_TARGET_SANITY: '1'
         isolate_network: false
     install:
-      - args: ['python3', '@THIS_SOURCE_DIR@/x.py', 'install', 'clippy', '-j', '@PARALLELISM@']
+      - args: ['python3', '@THIS_SOURCE_DIR@/x.py', 'install', 'rustc', 'clippy', 'std', '-j', '@PARALLELISM@']
         cargo_home: false
         environ:
           CARGO_HOME: '@THIS_BUILD_DIR@/cargo-home'


### PR DESCRIPTION
Changes made in #489 mistakenly made xbstrap build only clippy as part of host-rust, this PR fixes that.