### PR TITLE
Logind enablement

### DIFF
--- a/bootstrap.d/managarm-libc.y4.yml
+++ b/bootstrap.d/managarm-libc.y4.yml
@@ -2,7 +2,7 @@ sources:
   - name: mlibc
     git: 'https://github.com/managarm/mlibc.git'
     branch: 'master'
-    commit: '02347f657f094b3883f8f1efcf072bf468d9da0a'
+    commit: '0e66eb754c6b744b3fe3d8eb5fbe8e23dcf05ec2'
     rolling_version: true
     version: '0.0pl@ROLLING_ID@'
     sources_required:

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -1037,7 +1037,8 @@ packages:
       - libxcrypt
       - libiconv
       - libintl
-    revision: 6
+      - pam
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1049,7 +1050,7 @@ packages:
         - '--enable-shared'
         - '--disable-nls'
         - '--without-audit'
-        - '--without-libpam'
+        - '--with-libpam'
         - '--without-btrfs'
         - '--without-selinux'
         - '--without-acl'
@@ -1069,9 +1070,28 @@ packages:
           ac_cv_header_sys_capability_h: 'no'
     build:
       - args: ['make', '-j@PARALLELISM@']
+      # We don't set pamdir as we install our own pam config files
       - args: ['make', 'pamddir=', 'exec_prefix=/usr', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+      # Install PAM files
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/pam.d']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/login', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/chage', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/chfn', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/chgpasswd', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/chpasswd', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/chsh', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/groupadd', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/groupdel', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/groupmems', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/groupmod', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/newusers', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/passwd', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/su', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/useradd', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/userdel', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/usermod', '@THIS_COLLECT_DIR@/etc/pam.d/']
 
   - name: ripgrep
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -1526,7 +1526,7 @@ packages:
       - libdrm
       - libtsm
       - systemd
-    revision: 12
+    revision: 13
     configure:
       - args:
         - 'meson'
@@ -1539,7 +1539,7 @@ packages:
         - '--buildtype=debugoptimized'
         - '-Dsession_dummy=enabled'
         - '-Dsession_terminal=enabled'
-        - '-Dmulti_seat=disabled'
+        - '-Dmulti_seat=enabled'
         - '@THIS_SOURCE_DIR@'
     build:
       - args: ['ninja']

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -1346,7 +1346,7 @@ packages:
       - file
       - libxcrypt
       - pcre2
-    revision: 17
+    revision: 18
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1360,8 +1360,8 @@ packages:
         - '--disable-nls'
         - '--disable-static'
         - '--without-python'
-        - '--without-systemd'
-        - '--without-systemdsystemunitdir'
+        - '--with-systemd'
+        - '--with-systemdsystemunitdir=/usr/lib/systemd/system'
         - '--disable-partx'
         - '--disable-fallocate'
         - '--disable-unshare'
@@ -1423,8 +1423,12 @@ packages:
       - args: ['make', 'install']
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
+      # Remove items installed by util-linux-libs
       - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/include']
-      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib']
+      - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/lib/pkgconfig']
+      - args: |
+          rm @THIS_COLLECT_DIR@/usr/lib/*.so*
+          rm @THIS_COLLECT_DIR@/usr/lib/*.la*
       - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/share/man/man3']
       - args: ['rm', '-r', '@THIS_COLLECT_DIR@/usr/share/man/man5/terminal-colors.d.5']
 

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -1604,7 +1604,8 @@ packages:
       - openssl
       - util-linux-libs
       - mlibc
-    revision: 8
+      - pam
+    revision: 9
     configure:
       - args:
         - 'meson'
@@ -1617,21 +1618,23 @@ packages:
         - '--buildtype=debugoptimized'
         - '-Dadm-group=false'
         - '-Danalyze=false'
-        - '-Dapparmor=false'
-        - '-Daudit=false'
+        - '-Dapparmor=disabled'
+        - '-Daudit=disabled'
         - '-Dbacklight=false'
+        - '-Dbootloader=disabled'
         - '-Dbinfmt=false'
-        - '-Dbpf-framework=false'
-        - '-Dbzip2=false'
+        - '-Dbpf-framework=disabled'
+        - '-Dbzip2=disabled'
         - '-Dcoredump=false'
-        - '-Ddbus=false'
-        - '-Delfutils=false'
+        - '-Ddbus=disabled'
+        - '-Defi=false'
+        - '-Delfutils=disabled'
         - '-Denvironment-d=false'
-        - '-Dfdisk=false'
-        - '-Dgcrypt=false'
-        - '-Dglib=false'
+        - '-Dfdisk=disabled'
+        - '-Dgcrypt=disabled'
+        - '-Dglib=disabled'
         - '-Dgshadow=false'
-        - '-Dgnutls=false'
+        - '-Dgnutls=disabled'
         - '-Dhibernate=false'
         - '-Dhostnamed=false'
         - '-Didn=false'
@@ -1639,51 +1642,51 @@ packages:
         - '-Dinitrd=false'
         - '-Dfirstboot=false'
         - '-Dldconfig=false'
-        - '-Dlibcryptsetup=false'
-        - '-Dlibcurl=false'
-        - '-Dlibfido2=false'
-        - '-Dlibidn=false'
-        - '-Dlibidn2=false'
-        - '-Dlibiptc=false'
+        - '-Dlibcryptsetup=disabled'
+        - '-Dlibcurl=disabled'
+        - '-Dlibfido2=disabled'
+        - '-Dlibidn=disabled'
+        - '-Dlibidn2=disabled'
+        - '-Dlibiptc=disabled'
         - '-Dlocaled=false'
-        - '-Dlogind=false'
-        - '-Dlz4=false'
+        - '-Dlogind=true'
+        - '-Dlz4=disabled'
         - '-Dmachined=false'
-        - '-Dmicrohttpd=false'
+        - '-Dmicrohttpd=disabled'
         - '-Dnetworkd=false'
         - '-Dnscd=false'
         - '-Dnss-myhostname=false'
-        - '-Dnss-resolve=false'
+        - '-Dnss-resolve=disabled'
         - '-Dnss-systemd=false'
         - '-Doomd=false'
-        - '-Dopenssl=false'
-        - '-Dp11kit=false'
-        - '-Dpam=false'
-        - '-Dpcre2=false'
-        - '-Dpolkit=false'
+        - '-Dopenssl=disabled'
+        - '-Dp11kit=disabled'
+        - '-Dpam=enabled'
+        - '-Dpcre2=disabled'
+        - '-Dpolkit=disabled'
         - '-Dportabled=false'
         - '-Dpstore=false'
-        - '-Dpwquality=false'
+        - '-Dpwquality=disabled'
         - '-Drandomseed=false'
         - '-Dresolve=false'
         - '-Drfkill=false'
-        - '-Dseccomp=false'
+        - '-Dseccomp=disabled'
         - '-Dsmack=false'
         - '-Dsysext=false'
         - '-Dtimedated=false'
         - '-Dtimesyncd=false'
         - '-Dtpm=false'
-        - '-Dqrencode=false'
+        - '-Dqrencode=disabled'
         - '-Dquotacheck=false'
         - '-Duserdb=false'
         - '-Dutmp=true'
         - '-Dvconsole=false'
         - '-Dwheel-group=false'
         - '-Dxdg-autostart=false'
-        - '-Dxkbcommon=false'
-        - '-Dxz=false'
-        - '-Dzlib=false'
-        - '-Dzstd=false'
+        - '-Dxkbcommon=disabled'
+        - '-Dxz=disabled'
+        - '-Dzlib=disabled'
+        - '-Dzstd=disabled'
         - '-Dtests=true'
         - '-Dinstall-tests=true'
         - '@THIS_SOURCE_DIR@'
@@ -1697,13 +1700,9 @@ packages:
       - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-ask-password-console.path']
       - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sysinit.target.wants/systemd-ask-password-console.path']
       - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-ask-password-console.service']
-      # These are part of utmp, but don't work yet, investigate later
-      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-update-utmp.service']
-      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/systemd-update-utmp-runlevel.service']
-      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/graphical.target.wants/systemd-update-utmp-runlevel.service']
-      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/multi-user.target.wants/systemd-update-utmp-runlevel.service']
-      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/rescue.target.wants/systemd-update-utmp-runlevel.service']
-      - args: ['rm', '@THIS_COLLECT_DIR@/usr/lib/systemd/system/sysinit.target.wants/systemd-update-utmp.service']
+      # Install PAM files
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/pam.d']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/systemd-user', '@THIS_COLLECT_DIR@/etc/pam.d/']
       # Touch up empty directories
       - args: ['touch',
           '@THIS_COLLECT_DIR@/usr/lib/systemd/system/runlevel1.target.wants/.keep',

--- a/bootstrap.d/sys-auth.y4.yml
+++ b/bootstrap.d/sys-auth.y4.yml
@@ -21,15 +21,17 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-    revision: 8
+      - systemd
+    revision: 9
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
         - '--buildtype=debugoptimized'
-        - '-Dlibseat-logind=disabled'
+        - '-Dlibseat-logind=systemd'
         - '@THIS_SOURCE_DIR@'
         environ:
           PKG_CONFIG_SYSROOT_DIR: '@BUILD_ROOT@/system-root'

--- a/bootstrap.d/sys-libs.y4.yml
+++ b/bootstrap.d/sys-libs.y4.yml
@@ -611,6 +611,55 @@ packages:
         environ:
           DESTDIR: '@THIS_COLLECT_DIR@'
 
+  - name: pam
+    labels: [aarch64, riscv64]
+    architecture: '@OPTION:arch@'
+    metadata:
+      summary: Standard PAM library
+      description: This package provides the Pluggable Authentication Modules (PAM) library.
+      spdx: 'LGPL-2.1-or-later'
+      website: 'https://github.com/linux-pam/linux-pam'
+      maintainer: "no92 <leo@managarm.org> && Dennis Bonke <dennis@managarm.org>"
+      categories: ['sys-libs']
+    source:
+      subdir: ports
+      git: 'https://github.com/linux-pam/linux-pam.git'
+      tag: 'v1.7.1'
+      version: '1.7.1'
+    tools_required:
+      - system-gcc
+      - host-pkg-config
+      - virtual: pkgconfig-for-target
+        triple: "@OPTION:arch-triple@"
+    pkgs_required:
+      - mlibc
+      - libxcrypt
+      - gdbm
+    revision: 1
+    configure:
+      - args:
+        - 'meson'
+        - 'setup'
+        - '--cross-file'
+        - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
+        - '--prefix=/usr'
+        - '-Ddocs=disabled'
+        - '@THIS_SOURCE_DIR@'
+    build:
+      - args: ['ninja']
+      - args: ['ninja', 'install']
+        environ:
+          DESTDIR: '@THIS_COLLECT_DIR@'
+      - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/etc/pam.d']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/other', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/system-auth', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/system-session', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/system-account', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      - args: ['cp', '@SOURCE_ROOT@/extrafiles/pam.d/system-password', '@THIS_COLLECT_DIR@/etc/pam.d/']
+      # Touch empty directories to ensure they are packaged
+      - args: ['touch', '@THIS_COLLECT_DIR@/etc/security/namespace.d/.keep']
+      - args: ['touch', '@THIS_COLLECT_DIR@/etc/security/limits.d/.keep']
+
   - name: readline
     labels: [aarch64, riscv64]
     architecture: '@OPTION:arch@'

--- a/bootstrap.d/sys-libs.y4.yml
+++ b/bootstrap.d/sys-libs.y4.yml
@@ -635,7 +635,7 @@ packages:
       - mlibc
       - libxcrypt
       - gdbm
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/extrafiles/pam.d/chage
+++ b/extrafiles/pam.d/chage
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/chage
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/chage

--- a/extrafiles/pam.d/chfn
+++ b/extrafiles/pam.d/chfn
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/chfn
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/chfn

--- a/extrafiles/pam.d/chgpasswd
+++ b/extrafiles/pam.d/chgpasswd
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/chgpasswd
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/chgpasswd

--- a/extrafiles/pam.d/chpasswd
+++ b/extrafiles/pam.d/chpasswd
@@ -1,0 +1,11 @@
+# Begin /etc/pam.d/chpasswd
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+password  include     system-password
+
+# End /etc/pam.d/chpasswd

--- a/extrafiles/pam.d/chsh
+++ b/extrafiles/pam.d/chsh
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/chsh
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/chsh

--- a/extrafiles/pam.d/groupadd
+++ b/extrafiles/pam.d/groupadd
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/groupadd
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/groupadd

--- a/extrafiles/pam.d/groupdel
+++ b/extrafiles/pam.d/groupdel
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/groupdel
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/groupdel

--- a/extrafiles/pam.d/groupmems
+++ b/extrafiles/pam.d/groupmems
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/groupmems
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/groupmems

--- a/extrafiles/pam.d/groupmod
+++ b/extrafiles/pam.d/groupmod
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/groupmod
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/groupmod

--- a/extrafiles/pam.d/login
+++ b/extrafiles/pam.d/login
@@ -1,0 +1,42 @@
+# Begin /etc/pam.d/login
+
+# Set failure delay before next prompt to 3 seconds
+auth      optional    pam_faildelay.so  delay=3000000
+
+# Check to make sure that the user is allowed to login
+auth      requisite   pam_nologin.so
+
+# Check to make sure that root is allowed to login
+# Disabled by default. You will need to create /etc/securetty
+# file for this module to function. See man 5 securetty.
+#auth      required    pam_securetty.so
+
+# Additional group memberships - disabled by default
+#auth      optional    pam_group.so
+
+# include system auth settings
+auth      include     system-auth
+
+# check access for the user
+account   required    pam_access.so
+
+# include system account settings
+account   include     system-account
+
+# Set default environment variables for the user
+session   required    pam_env.so
+
+# Set resource limits for the user
+session   required    pam_limits.so
+
+# Display the message of the day - Disabled by default
+#session   optional    pam_motd.so
+
+# Check user's mail - Disabled by default
+#session   optional    pam_mail.so      standard quiet
+
+# include system session and password settings
+session   include     system-session
+password  include     system-password
+
+# End /etc/pam.d/login

--- a/extrafiles/pam.d/newusers
+++ b/extrafiles/pam.d/newusers
@@ -1,0 +1,11 @@
+# Begin /etc/pam.d/newusers
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+password  include     system-password
+
+# End /etc/pam.d/newusers

--- a/extrafiles/pam.d/other
+++ b/extrafiles/pam.d/other
@@ -1,0 +1,12 @@
+# Begin /etc/pam.d/other
+
+auth        required        pam_warn.so
+auth        required        pam_deny.so
+account     required        pam_warn.so
+account     required        pam_deny.so
+password    required        pam_warn.so
+password    required        pam_deny.so
+session     required        pam_warn.so
+session     required        pam_deny.so
+
+# End /etc/pam.d/other

--- a/extrafiles/pam.d/passwd
+++ b/extrafiles/pam.d/passwd
@@ -1,0 +1,5 @@
+# Begin /etc/pam.d/passwd
+
+password  include     system-password
+
+# End /etc/pam.d/passwd

--- a/extrafiles/pam.d/su
+++ b/extrafiles/pam.d/su
@@ -1,0 +1,26 @@
+# Begin /etc/pam.d/su
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# Allow users in the wheel group to execute su without a password
+# disabled by default
+#auth      sufficient  pam_wheel.so trust use_uid
+
+# include system auth settings
+auth      include     system-auth
+
+# limit su to users in the wheel group
+# disabled by default
+#auth      required    pam_wheel.so use_uid
+
+# include system account settings
+account   include     system-account
+
+# Set default environment variables for the service user
+session   required    pam_env.so
+
+# include system session settings
+session   include     system-session
+
+# End /etc/pam.d/su

--- a/extrafiles/pam.d/system-account
+++ b/extrafiles/pam.d/system-account
@@ -1,0 +1,5 @@
+# Begin /etc/pam.d/system-account
+
+account   required    pam_unix.so
+
+# End /etc/pam.d/system-account

--- a/extrafiles/pam.d/system-auth
+++ b/extrafiles/pam.d/system-auth
@@ -1,0 +1,5 @@
+# Begin /etc/pam.d/system-auth
+
+auth      required    pam_unix.so
+
+# End /etc/pam.d/system-auth

--- a/extrafiles/pam.d/system-password
+++ b/extrafiles/pam.d/system-password
@@ -1,0 +1,8 @@
+# Begin /etc/pam.d/system-password
+
+# use yescrypt hash for encryption, use shadow, and try to use any
+# previously defined authentication token (chosen password) set by any
+# prior module.
+password  required    pam_unix.so       yescrypt shadow try_first_pass
+
+# End /etc/pam.d/system-password

--- a/extrafiles/pam.d/system-session
+++ b/extrafiles/pam.d/system-session
@@ -1,0 +1,5 @@
+# Begin /etc/pam.d/system-session
+
+session   required    pam_unix.so
+
+# End /etc/pam.d/system-session

--- a/extrafiles/pam.d/system-session
+++ b/extrafiles/pam.d/system-session
@@ -2,4 +2,11 @@
 
 session   required    pam_unix.so
 
+# Begin Systemd addition
+
+session  required    pam_loginuid.so
+session  optional    pam_systemd.so
+
+# End Systemd addition
+
 # End /etc/pam.d/system-session

--- a/extrafiles/pam.d/systemd-user
+++ b/extrafiles/pam.d/systemd-user
@@ -1,0 +1,16 @@
+# Begin /etc/pam.d/systemd-user
+
+# This file is adapted from BLFS, changes for Managarm are the removal of the keyinit module
+
+account  required    pam_access.so
+account  include     system-account
+
+session  required    pam_env.so
+session  required    pam_limits.so
+session  required    pam_loginuid.so
+session  optional    pam_systemd.so
+
+auth     required    pam_deny.so
+password required    pam_deny.so
+
+# End /etc/pam.d/systemd-user

--- a/extrafiles/pam.d/useradd
+++ b/extrafiles/pam.d/useradd
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/useradd
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/useradd

--- a/extrafiles/pam.d/userdel
+++ b/extrafiles/pam.d/userdel
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/userdel
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/userdel

--- a/extrafiles/pam.d/usermod
+++ b/extrafiles/pam.d/usermod
@@ -1,0 +1,10 @@
+# Begin /etc/pam.d/usermod
+
+# always allow root
+auth      sufficient  pam_rootok.so
+
+# include system auth and account settings
+auth      include     system-auth
+account   include     system-account
+
+# End /etc/pam.d/usermod

--- a/patches/kmscon/0001-Fix-a-few-things-to-make-kmscon-compile-for-managarm.patch
+++ b/patches/kmscon/0001-Fix-a-few-things-to-make-kmscon-compile-for-managarm.patch
@@ -1,7 +1,7 @@
-From 5827826d39bc9553802ea4e8e417599bb280bffd Mon Sep 17 00:00:00 2001
+From 51c279a06599fc80e7e964e98d6482b48c6a0f5e Mon Sep 17 00:00:00 2001
 From: qookie <kacper.slominski72@gmail.com>
 Date: Sun, 23 Jun 2019 19:02:21 +0200
-Subject: [PATCH 1/2] Fix a few things to make kmscon compile for managarm
+Subject: [PATCH 1/3] Fix a few things to make kmscon compile for managarm
 
 Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
 ---
@@ -151,5 +151,5 @@ index fbe9e76..203350b 100644
  #include <sys/stat.h>
  #include <sys/sysmacros.h>
 -- 
-2.47.2
+2.50.1
 

--- a/patches/kmscon/0002-Disable-system-locale-querying-via-dbus.patch
+++ b/patches/kmscon/0002-Disable-system-locale-querying-via-dbus.patch
@@ -1,7 +1,7 @@
-From 8f8f2b9397ad95b2f171662ebcec4492a308de0a Mon Sep 17 00:00:00 2001
+From 1601690bcd60acfbff7a80ca79afb25485f41dba Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Mon, 24 Jul 2023 18:06:22 +0200
-Subject: [PATCH 2/2] Disable system locale querying via dbus
+Subject: [PATCH 2/3] Disable system locale querying via dbus
 
 ---
  scripts/kmscon.in | 2 +-
@@ -19,5 +19,5 @@ index 61594bf..c7f74b1 100755
 +# setupLocale
  exec ${helperdir}/kmscon "$@"
 -- 
-2.47.2
+2.50.1
 

--- a/patches/kmscon/0003-Update-systemd-unit-file-to-work-with-logind.patch
+++ b/patches/kmscon/0003-Update-systemd-unit-file-to-work-with-logind.patch
@@ -1,0 +1,25 @@
+From 1ca6b0320850941c2c06e28917bfd101b496155d Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 4 Aug 2025 15:23:37 +0200
+Subject: [PATCH 3/3] Update systemd unit file to work with logind
+
+---
+ docs/kmscon.service.in | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/docs/kmscon.service.in b/docs/kmscon.service.in
+index 398469e..7b0fb4b 100644
+--- a/docs/kmscon.service.in
++++ b/docs/kmscon.service.in
+@@ -1,6 +1,8 @@
+ [Unit]
+ Description=KMS System Console
+ Documentation=man:kmscon(1)
++After=plymouth-quit-wait.service
++After=systemd-user-sessions.service
+ 
+ [Service]
+ ExecStartPre=@bindir@/wait-for-devices --want-graphics --want-keyboard
+-- 
+2.50.1
+

--- a/patches/pam/0001-Add-managarm-support.patch
+++ b/patches/pam/0001-Add-managarm-support.patch
@@ -1,0 +1,82 @@
+From 0b34bd509b14fa7bcc45ae750bdb56705bb6b4ee Mon Sep 17 00:00:00 2001
+From: no92 <no92.mail@gmail.com>
+Date: Fri, 11 Jul 2025 17:00:18 +0200
+Subject: [PATCH] Add managarm support
+
+---
+ meson.build                           | 2 +-
+ modules/pam_limits/pam_limits.c       | 4 ++--
+ modules/pam_namespace/pam_namespace.c | 2 ++
+ modules/pam_namespace/pam_namespace.h | 2 +-
+ modules/pam_unix/pam_unix_acct.c      | 1 +
+ 5 files changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 0827a53..0f09425 100644
+--- a/meson.build
++++ b/meson.build
+@@ -199,7 +199,7 @@ foreach ident: check_functions
+   endif
+ endforeach
+ 
+-enable_pam_keyinit = cc.get_define('__NR_keyctl', prefix: '#include <sys/syscall.h>') != ''
++enable_pam_keyinit = cc.has_header('<sys/syscall.h>') and (cc.get_define('__NR_keyctl', prefix: '#include <sys/syscall.h>') != '')
+ 
+ if get_option('mailspool') != ''
+   cdata.set_quoted('PAM_PATH_MAILDIR', get_option('mailspool'))
+diff --git a/modules/pam_limits/pam_limits.c b/modules/pam_limits/pam_limits.c
+index ff0f424..24eb106 100644
+--- a/modules/pam_limits/pam_limits.c
++++ b/modules/pam_limits/pam_limits.c
+@@ -13,8 +13,8 @@
+  * See end for Copyright information
+  */
+ 
+-#ifndef __linux__
+-#warning THIS CODE IS KNOWN TO WORK ONLY ON LINUX !!!
++#if !defined(__linux__) && !defined(__managarm__)
++#warning THIS CODE IS KNOWN TO WORK ONLY ON LINUX OR MANAGARM !!!
+ #endif
+ 
+ #include "config.h"
+diff --git a/modules/pam_namespace/pam_namespace.c b/modules/pam_namespace/pam_namespace.c
+index e7ff5b3..84e2a38 100644
+--- a/modules/pam_namespace/pam_namespace.c
++++ b/modules/pam_namespace/pam_namespace.c
+@@ -41,6 +41,8 @@
+ #include "pam_namespace.h"
+ #include "argv_parse.h"
+ 
++#include <signal.h>
++
+ #define MAGIC_LNK_FD_SIZE 64
+ 
+ /* --- evaluating all files in VENDORDIR/security/namespace.d and /etc/security/namespace.d --- */
+diff --git a/modules/pam_namespace/pam_namespace.h b/modules/pam_namespace/pam_namespace.h
+index 8a7a66b..4edca26 100644
+--- a/modules/pam_namespace/pam_namespace.h
++++ b/modules/pam_namespace/pam_namespace.h
+@@ -30,7 +30,7 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+ 
+-#ifndef __linux__
++#if !defined(__linux__) && !defined(__managarm__)
+ #error THIS CODE IS KNOWN TO WORK ONLY ON LINUX !!!
+ #endif
+ 
+diff --git a/modules/pam_unix/pam_unix_acct.c b/modules/pam_unix/pam_unix_acct.c
+index 961b766..7814159 100644
+--- a/modules/pam_unix/pam_unix_acct.c
++++ b/modules/pam_unix/pam_unix_acct.c
+@@ -50,6 +50,7 @@
+ #include <time.h>		/* for time() */
+ #include <errno.h>
+ #include <sys/wait.h>
++#include <signal.h>
+ 
+ #include <security/_pam_macros.h>
+ 
+-- 
+2.50.1
+

--- a/patches/shadow/0001-Add-Managarm-support.patch
+++ b/patches/shadow/0001-Add-Managarm-support.patch
@@ -1,4 +1,4 @@
-From a0a3c21b74484544e07683bed59e089707e47781 Mon Sep 17 00:00:00 2001
+From da03beed7dbabf247ad2cfb9ff7abe0dfb6e89d8 Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Thu, 5 Sep 2024 00:27:05 +0200
 Subject: [PATCH] Add Managarm support
@@ -14,7 +14,8 @@ Signed-off-by: Dennis Bonke <admin@dennisbonke.com>
  src/Makefile.am     | 10 ++++------
  src/lastlog.c       |  4 +++-
  src/login.c         |  6 ++++++
- 9 files changed, 26 insertions(+), 13 deletions(-)
+ src/newgrp.c        |  1 +
+ 10 files changed, 27 insertions(+), 13 deletions(-)
 
 diff --git a/Makefile.am b/Makefile.am
 index 8851f5d..5a58c54 100644
@@ -208,6 +209,18 @@ index 00508cd..af876c9 100644
  
  #ifndef USE_PAM			/* PAM does this */
  	/*
+diff --git a/src/newgrp.c b/src/newgrp.c
+index e3c44e1..f079320 100644
+--- a/src/newgrp.c
++++ b/src/newgrp.c
+@@ -39,6 +39,7 @@
+ #include <pwd.h>
+ #include <stdio.h>
+ #include <assert.h>
++#include <signal.h>
+ #include "defines.h"
+ #include "getdef.h"
+ #include "prototypes.h"
 -- 
-2.47.2
+2.50.1
 

--- a/patches/systemd/0001-Add-managarm-support.patch
+++ b/patches/systemd/0001-Add-managarm-support.patch
@@ -1,14 +1,14 @@
-From 4bf206726a72edeb4eb9fe902271881186ebd32e Mon Sep 17 00:00:00 2001
+From 65955365fa9d860138af62f8b35ab91fa7de2eab Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Tue, 18 Feb 2025 23:40:13 +0100
-Subject: [PATCH 1/3] Add managarm support
+Subject: [PATCH 1/4] Add managarm support
 
 ---
  meson.build                        |  8 ++--
  src/basic/missing_syscall.h        | 68 ++++++++++++++++++++++++------
  src/basic/raw-clone.h              |  9 ++++
  src/basic/raw-reboot.h             | 11 +++++
- src/core/exec-invoke.c             |  1 +
+ src/core/exec-invoke.c             |  4 ++
  src/libsystemd/sd-event/sd-event.c |  5 +++
  src/mountfsd/mountwork.c           |  2 +
  src/nsresourced/userns-registry.c  |  2 +
@@ -18,7 +18,7 @@ Subject: [PATCH 1/3] Add managarm support
  src/shared/dev-setup.c             |  1 +
  src/test/test-path-util.c          |  3 ++
  src/udev/udevadm-settle.c          |  3 ++
- 14 files changed, 105 insertions(+), 18 deletions(-)
+ 14 files changed, 108 insertions(+), 18 deletions(-)
 
 diff --git a/meson.build b/meson.build
 index 5a5ac35..213d07d 100644
@@ -328,7 +328,7 @@ index e6bff30..3fa8df3 100644
 +#endif
  }
 diff --git a/src/core/exec-invoke.c b/src/core/exec-invoke.c
-index 56df5cf..f72eccf 100644
+index 56df5cf..98d6485 100644
 --- a/src/core/exec-invoke.c
 +++ b/src/core/exec-invoke.c
 @@ -3,6 +3,7 @@
@@ -339,6 +339,21 @@ index 56df5cf..f72eccf 100644
  #include <sys/mount.h>
  #include <sys/prctl.h>
  
+@@ -4646,11 +4647,14 @@ int exec_invoke(
+ 
+         (void) umask(context->umask);
+ 
++#ifndef __managarm__
++// TODO: We don't implement kernel keyring, remove if / when we do.
+         r = setup_keyring(context, params, uid, gid);
+         if (r < 0) {
+                 *exit_status = EXIT_KEYRING;
+                 return log_exec_error_errno(context, params, r, "Failed to set up kernel keyring: %m");
+         }
++#endif
+ 
+         /* We need sandboxing if the caller asked us to apply it and the command isn't explicitly excepted
+          * from it. */
 diff --git a/src/libsystemd/sd-event/sd-event.c b/src/libsystemd/sd-event/sd-event.c
 index 64825ca..ff84f60 100644
 --- a/src/libsystemd/sd-event/sd-event.c
@@ -472,5 +487,5 @@ index c236a70..8314e2c 100644
          if (getuid() == 0) {
                  _cleanup_(udev_ctrl_unrefp) UdevCtrl *uctrl = NULL;
 -- 
-2.47.2
+2.50.1
 

--- a/patches/systemd/0002-Add-support-for-systemd-boot-for-Managarm.patch
+++ b/patches/systemd/0002-Add-support-for-systemd-boot-for-Managarm.patch
@@ -1,7 +1,7 @@
-From 70d8db99bb7f7e319368a28c8e892cae5d65544f Mon Sep 17 00:00:00 2001
+From f96a9c549f8c1be8b4efaa85d6a098d9b53d014a Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Fri, 10 Jan 2025 00:55:19 +0100
-Subject: [PATCH 2/3] Add support for systemd boot for Managarm
+Subject: [PATCH 2/4] Add support for systemd boot for Managarm
 
 ---
  src/basic/capability-util.c              |  2 ++
@@ -138,7 +138,7 @@ index 6157ac4..d508df7 100644
                  r = setup_credentials_internal(
                                  context,
 diff --git a/src/core/exec-invoke.c b/src/core/exec-invoke.c
-index f72eccf..dd75336 100644
+index 98d6485..03760dd 100644
 --- a/src/core/exec-invoke.c
 +++ b/src/core/exec-invoke.c
 @@ -226,8 +226,13 @@ static int connect_logger_as(
@@ -155,7 +155,7 @@ index f72eccf..dd75336 100644
  
          (void) fd_inc_sndbuf(fd, SNDBUF_SIZE);
  
-@@ -4687,6 +4692,7 @@ int exec_invoke(
+@@ -4690,6 +4695,7 @@ int exec_invoke(
  #endif
          }
  
@@ -163,7 +163,7 @@ index f72eccf..dd75336 100644
          if (needs_sandboxing) {
                  int which_failed;
  
-@@ -4699,6 +4705,7 @@ int exec_invoke(
+@@ -4702,6 +4708,7 @@ int exec_invoke(
                          return log_exec_error_errno(context, params, r, "Failed to adjust resource limit RLIMIT_%s: %m", rlimit_to_string(which_failed));
                  }
          }
@@ -171,7 +171,7 @@ index f72eccf..dd75336 100644
  
          if (needs_setuid && context->pam_name && username) {
                  /* Let's call into PAM after we set up our own idea of resource limits so that pam_limits
-@@ -5005,6 +5012,7 @@ int exec_invoke(
+@@ -5008,6 +5015,7 @@ int exec_invoke(
                  }
  #endif
  
@@ -179,7 +179,7 @@ index f72eccf..dd75336 100644
                  if (!cap_test_all(bset)) {
                          r = capability_bounding_set_drop(bset, /* right_now= */ false);
                          if (r < 0) {
-@@ -5012,6 +5020,7 @@ int exec_invoke(
+@@ -5015,6 +5023,7 @@ int exec_invoke(
                                  return log_exec_error_errno(context, params, r, "Failed to drop capabilities: %m");
                          }
                  }
@@ -187,7 +187,7 @@ index f72eccf..dd75336 100644
  
                  /* Ambient capabilities are cleared during setresuid() (in enforce_user()) even with
                   * keep-caps set.
-@@ -5129,6 +5138,7 @@ int exec_invoke(
+@@ -5132,6 +5141,7 @@ int exec_invoke(
                  }
  #endif
  
@@ -195,7 +195,7 @@ index f72eccf..dd75336 100644
                  /* PR_GET_SECUREBITS is not privileged, while PR_SET_SECUREBITS is. So to suppress potential
                   * EPERMs we'll try not to call PR_SET_SECUREBITS unless necessary. Setting securebits
                   * requires CAP_SETPCAP. */
-@@ -5160,6 +5170,7 @@ int exec_invoke(
+@@ -5163,6 +5173,7 @@ int exec_invoke(
                                  *exit_status = EXIT_NO_NEW_PRIVILEGES;
                                  return log_exec_error_errno(context, params, errno, "Failed to disable new privileges: %m");
                          }
@@ -490,5 +490,5 @@ index f4a4482..29a22b5 100644
 +#IPAddressDeny=any
  {{SERVICE_WATCHDOG}}
 -- 
-2.47.2
+2.50.1
 

--- a/patches/systemd/0003-add-fallback-parse_printf_format-implementation.patch
+++ b/patches/systemd/0003-add-fallback-parse_printf_format-implementation.patch
@@ -1,7 +1,7 @@
-From 276440ac4830e57bddb23579b22eaae9affc30b2 Mon Sep 17 00:00:00 2001
+From 507376e53eb99475e5515366788a78091c1c7eed Mon Sep 17 00:00:00 2001
 From: Alexander Kanavin <alex.kanavin@gmail.com>
 Date: Sat, 22 May 2021 20:26:24 +0200
-Subject: [PATCH 3/3] add fallback parse_printf_format implementation
+Subject: [PATCH 3/4] add fallback parse_printf_format implementation
 
 Upstream-Status: Inappropriate [musl specific]
 
@@ -377,5 +377,5 @@ index 0000000..9d10e53
 +
 +#endif
 -- 
-2.47.2
+2.50.1
 

--- a/patches/systemd/0004-Additional-patches-for-systemd-logind.patch
+++ b/patches/systemd/0004-Additional-patches-for-systemd-logind.patch
@@ -1,0 +1,64 @@
+From 4ea3a70e5b2735ee3ddaa1c1e48b9f972d1eb66d Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Mon, 4 Aug 2025 14:49:35 +0200
+Subject: [PATCH 4/4] Additional patches for systemd-logind
+
+---
+ src/core/exec-invoke.c        | 4 ++++
+ src/update-utmp/update-utmp.c | 6 +++++-
+ units/user@.service.in        | 6 +++---
+ 3 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/src/core/exec-invoke.c b/src/core/exec-invoke.c
+index 03760dd..20f85bd 100644
+--- a/src/core/exec-invoke.c
++++ b/src/core/exec-invoke.c
+@@ -4736,6 +4736,10 @@ int exec_invoke(
+                 }
+ 
+                 ngids_after_pam = getgroups_alloc(&gids_after_pam);
++#ifdef __managarm__
++                // HACK: We don't support groups yet.
++                ngids_after_pam = 0;
++#endif
+                 if (ngids_after_pam < 0) {
+                         *exit_status = EXIT_GROUP;
+                         return log_exec_error_errno(context, params, ngids_after_pam, "Failed to obtain groups after setting up PAM: %m");
+diff --git a/src/update-utmp/update-utmp.c b/src/update-utmp/update-utmp.c
+index c376676..665c2da 100644
+--- a/src/update-utmp/update-utmp.c
++++ b/src/update-utmp/update-utmp.c
+@@ -148,7 +148,11 @@ static int on_reboot(int argc, char *argv[], void *userdata) {
+ 
+         /* If this call fails, then utmp_put_reboot() will fix to the current time. */
+         (void) get_startup_monotonic_time(c, &t);
+-        boottime = map_clock_usec(t, CLOCK_MONOTONIC, CLOCK_REALTIME);
++        t = 0;
++        // HACK: Managarm does not implement this correctly?
++        // TODO: Verify if needed, lifted from Leo's patchwork.
++        // boottime = map_clock_usec(t, CLOCK_MONOTONIC, CLOCK_REALTIME);
++        boottime = 0;
+         /* We query the recorded monotonic time here (instead of the system clock CLOCK_REALTIME), even
+          * though we actually want the system clock time. That's because there's a likely chance that the
+          * system clock wasn't set right during early boot. By manually converting the monotonic clock to the
+diff --git a/units/user@.service.in b/units/user@.service.in
+index 5695465..87b6d86 100644
+--- a/units/user@.service.in
++++ b/units/user@.service.in
+@@ -21,10 +21,10 @@ Type=notify-reload
+ ExecStart={{LIBEXECDIR}}/systemd --user
+ Slice=user-%i.slice
+ KillMode=mixed
+-Delegate=pids memory cpu
+-DelegateSubgroup=init.scope
++#Delegate=pids memory cpu
++#DelegateSubgroup=init.scope
+ TasksMax=infinity
+ TimeoutStopSec={{ DEFAULT_USER_TIMEOUT_SEC*4//3 }}s
+ KeyringMode=inherit
+-OOMScoreAdjust=100
++#OOMScoreAdjust=100
+ MemoryPressureWatch=skip
+-- 
+2.50.1
+


### PR DESCRIPTION
This PR adds a port of PAM and enables logind. It also does the necessary integration with shadow and systemd. Kmscon will now make logind sessions. Weston enablement will follow later.

Blocked on managarm/mlibc#1397