### PR TITLE
Toolchain work

### DIFF
--- a/bootstrap.d/app-accessibility.y4.yml
+++ b/bootstrap.d/app-accessibility.y4.yml
@@ -40,7 +40,7 @@ packages:
       - libxml
       - libxtst
       - libxi
-    revision: 1
+    revision: 2
     configure:
       - args:
           - 'meson'

--- a/bootstrap.d/app-admin.y4.yml
+++ b/bootstrap.d/app-admin.y4.yml
@@ -56,7 +56,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-    revision: 6
+    revision: 7
     configure:
       # Sysstat really wants to be configured in the same tree.
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']

--- a/bootstrap.d/app-arch.y4.yml
+++ b/bootstrap.d/app-arch.y4.yml
@@ -13,7 +13,7 @@ packages:
       git: 'https://github.com/google/brotli.git'
       tag: 'v1.1.0'
       version: '1.1.0'
-    revision: 6
+    revision: 7
     tools_required:
       - system-gcc
       - host-cmake
@@ -54,7 +54,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 10
+    revision: 11
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       # Remove the test directory from the Makefile, as it tries to run (and fail on) the tests
@@ -92,7 +92,7 @@ packages:
       - mlibc
       - libiconv
       - libintl
-    revision: 1
+    revision: 2
     configure:
       # Fix a build issue when building with gcc 10 and higher
       - args: ['sed', '-i', '/The name/,+2 d', '@THIS_SOURCE_DIR@/src/global.c']
@@ -137,7 +137,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -178,7 +178,7 @@ packages:
       - libxml
       - zstd
       - lz4
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -214,7 +214,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -255,7 +255,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -294,7 +294,7 @@ packages:
       - mlibc
       - bzip2
       - libiconv
-    revision: 10
+    revision: 11
     configure:
       # Fixup their makefile, thanks gentoo!
       - args: |
@@ -347,7 +347,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -382,7 +382,7 @@ packages:
     pkgs_required:
       - mlibc
       - bzip2
-    revision: 10
+    revision: 11
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -419,7 +419,7 @@ packages:
       - mlibc
       - zlib
       - xz-utils
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/app-crypt.y4.yml
+++ b/bootstrap.d/app-crypt.y4.yml
@@ -70,7 +70,7 @@ packages:
         arch: [x86_64]
         item: gobject-introspection
       - libxslt
-    revision: 1
+    revision: 2
     configure:
       - args:
           - 'meson'
@@ -159,7 +159,7 @@ packages:
       - mlibc
       - libffi
       - libtasn
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -203,7 +203,7 @@ packages:
       - libgcrypt
       - nss
       - openssl
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/app-editors.y4.yml
+++ b/bootstrap.d/app-editors.y4.yml
@@ -40,7 +40,7 @@ packages:
       - ncurses
       - libintl
       - zlib
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -84,7 +84,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -123,7 +123,7 @@ packages:
       - mlibc
       - ncurses
       - libiconv
-    revision: 1
+    revision: 2
     configure:
       # vim does not seem to support out-of-tree builds, so we just copy
       # the source tree into the build directory instead

--- a/bootstrap.d/app-emulation.y4.yml
+++ b/bootstrap.d/app-emulation.y4.yml
@@ -64,7 +64,7 @@ packages:
       - libgcrypt
       - libusb
       - curl
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-misc.y4.yml
+++ b/bootstrap.d/app-misc.y4.yml
@@ -20,7 +20,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
         isolate_network: false
@@ -108,7 +108,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 8
+    revision: 9
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -151,7 +151,7 @@ packages:
       - libxcb
       - libxrandr
       - freetype
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'
@@ -216,7 +216,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -249,7 +249,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 12
+    revision: 13
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -314,7 +314,7 @@ packages:
       - mlibc
       - libevent
       - ncurses
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-shells.y4.yml
+++ b/bootstrap.d/app-shells.y4.yml
@@ -77,7 +77,7 @@ packages:
       - ncurses
       - readline
       - libiconv
-    revision: 14
+    revision: 15
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -126,7 +126,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -174,7 +174,7 @@ packages:
       - gdbm
       - pcre
       - ncurses
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/app-text.y4.yml
+++ b/bootstrap.d/app-text.y4.yml
@@ -27,7 +27,7 @@ packages:
       - libiconv
       - ncurses
       - readline
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -63,7 +63,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-db.y4.yml
+++ b/bootstrap.d/dev-db.y4.yml
@@ -22,7 +22,7 @@ packages:
       - mlibc
       - readline
       - zlib
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-lang.y4.yml
+++ b/bootstrap.d/dev-lang.y4.yml
@@ -236,7 +236,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 6
+    revision: 7
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -281,7 +281,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -379,7 +379,7 @@ packages:
       - util-linux-libs
       - xz-utils
       - zlib
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -426,7 +426,7 @@ packages:
       - mlibc
       - sqlite
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -492,7 +492,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/dev-libs.y4.yml
+++ b/bootstrap.d/dev-libs.y4.yml
@@ -233,7 +233,7 @@ packages:
       - libxml
       - libxmlb
       - libyaml
-    revision: 1
+    revision: 2
     configure:
       - args: ['mkdir', '-pv', '@THIS_BUILD_DIR@/data']
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/data/org.freedesktop.appstream.cli.metainfo.xml', '@THIS_BUILD_DIR@/data/nol10n_withrelinfo_org.freedesktop.appstream.cli.metainfo.xml']
@@ -286,7 +286,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
-    revision: 8
+    revision: 9
     configure:
       - args:
         - 'meson'
@@ -332,7 +332,7 @@ packages:
           isolate_network: false
         - args: ['./bootstrap.sh']
         - args: ['./b2', 'headers']
-    revision: 8
+    revision: 9
     configure: []
     build:
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/include']
@@ -364,7 +364,7 @@ packages:
     pkgs_required:
       - mlibc
       - gmp
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -400,7 +400,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'
@@ -456,7 +456,7 @@ packages:
       - obstack-standalone
       - libintl
       - libiconv
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -510,7 +510,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -546,7 +546,7 @@ packages:
       - zlib
       - libiconv
       - libintl
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -604,7 +604,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -646,7 +646,7 @@ packages:
       - cairo
       - pcre2
       - python
-    revision: 3
+    revision: 4
     configure:
       - args:
         - 'meson'
@@ -695,7 +695,7 @@ packages:
       - host-icu
     pkgs_required:
       - mlibc
-    revision: 3
+    revision: 4
     configure:
       - args: ['cp',
           '@THIS_SOURCE_DIR@/icu4c/source/config/mh-linux',
@@ -737,7 +737,7 @@ packages:
       - host-cmake
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'
@@ -780,7 +780,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -821,7 +821,7 @@ packages:
       - mlibc
       - openssl
       - zlib
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -863,7 +863,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/expat/configure'
@@ -894,7 +894,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -934,7 +934,7 @@ packages:
     pkgs_required:
       - mlibc
       - libgpg-error
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -985,7 +985,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1029,7 +1029,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       # libgpg-error does not know about managarm, teach it
       - args: ['cp', '-v', '@THIS_SOURCE_DIR@/src/syscfg/lock-obj-pub.x86_64-unknown-linux-gnu.h',
@@ -1076,7 +1076,7 @@ packages:
       - glib
       - systemd
       - gobject-introspection
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'
@@ -1177,7 +1177,7 @@ packages:
       - host-libtool
     pkgs_required:
       - mlibc
-    revision: 8
+    revision: 9
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1219,7 +1219,7 @@ packages:
       - systemd
       - libevdev
       - mtdev
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -1269,7 +1269,7 @@ packages:
     pkgs_required:
       - mlibc
       - libiconv
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1314,7 +1314,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1355,7 +1355,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1394,7 +1394,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1478,7 +1478,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1514,7 +1514,7 @@ packages:
       - glib
       - qtbase6
       - qtsvg6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1560,7 +1560,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 7
+    revision: 8 
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1594,7 +1594,7 @@ packages:
     pkgs_required:
       - mlibc
       - libxkbcommon
-    revision: 7
+    revision: 8
     configure:
       - args:
         - 'cmake'
@@ -1637,7 +1637,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1686,7 +1686,7 @@ packages:
     pkgs_required:
       - mlibc
       - systemd
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1726,7 +1726,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1768,7 +1768,7 @@ packages:
       - mlibc
       - zlib
       - libiconv
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1807,7 +1807,7 @@ packages:
       - glib
       - xz-utils
       - zstd
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -1852,7 +1852,7 @@ packages:
     pkgs_required:
       - mlibc
       - libxml
-    revision: 1
+    revision: 2
     configure:
       # BLFS increases the recursion limit, apparently some packages need that to build their documentation.
       - args: ['sed', '-i', 's/3000/5000/', '@THIS_SOURCE_DIR@/libxslt/transform.c']
@@ -1905,7 +1905,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1946,7 +1946,7 @@ packages:
       - mlibc
       - gmp
       - mpfr
-    revision: 5
+    revision: 6
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1990,7 +1990,7 @@ packages:
     pkgs_required:
       - mlibc
       - gmp
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2042,7 +2042,7 @@ packages:
     pkgs_required:
       - mlibc
       - gmp
-    revision: 1
+    revision: 2 
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2084,7 +2084,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       # Disable installing two unneeded scripts.
       - args: ['sed', '-ri', '/^RELEASE/s/^/#/', '@THIS_SOURCE_DIR@/pr/src/misc/Makefile.in']
@@ -2131,7 +2131,7 @@ packages:
       - nspr
       - sqlite
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -2244,7 +2244,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 2
+    revision: 3 
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/Configure'
@@ -2302,7 +2302,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
-    revision: 12
+    revision: 13
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2351,7 +2351,7 @@ packages:
       - ncurses
       - readline
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2395,7 +2395,7 @@ packages:
     pkgs_required:
       - mlibc
       - wayland
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -2436,7 +2436,7 @@ packages:
     pkgs_required:
       - mlibc
       - libiconv
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2474,7 +2474,7 @@ packages:
       - mlibc
       - libexpat
       - libffi
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -2521,7 +2521,7 @@ packages:
         triple: "@OPTION:arch-triple@"
       - virtual: pkgconfig-for-host
         program_name: host-pkg-config
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -2581,7 +2581,7 @@ packages:
       - xcb-util-cursor
       - libdisplay-info
       - systemd
-    revision: 5
+    revision: 6
     configure:
       - args:
         - 'meson'
@@ -2640,7 +2640,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -2678,7 +2678,7 @@ packages:
       - host-cmake
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-qt.y4.yml
+++ b/bootstrap.d/dev-qt.y4.yml
@@ -68,7 +68,7 @@ packages:
       - qtdeclarative6
       - qtshadertools6
       - icu
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -145,7 +145,7 @@ packages:
       - brotli
       - dbus
       - at-spi2-core
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -242,7 +242,7 @@ packages:
       - qtsvg6
       - libxkbcommon
       - mesa
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -284,7 +284,7 @@ packages:
       - libwebp
       - libtiff
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -323,7 +323,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -365,7 +365,7 @@ packages:
       - libglvnd
       - gstreamer
       - gst-plugins-bad
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -406,7 +406,7 @@ packages:
       - mlibc
       - qtbase6
       - qtdeclarative6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -445,7 +445,7 @@ packages:
       - qtbase6
       - mesa
       - libxkbcommon
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -485,7 +485,7 @@ packages:
       - qtbase6
       - qtdeclarative6
       - qtmultimedia6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -523,7 +523,7 @@ packages:
       - mlibc
       - qtbase6
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -564,7 +564,7 @@ packages:
       - mesa
       - wayland
       - libxkbcommon
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/dev-util.y4.yml
+++ b/bootstrap.d/dev-util.y4.yml
@@ -161,7 +161,7 @@ packages:
       - xz-utils
       - zlib
       - zstd
-    revision: 1
+    revision: 2
     configure:
       - args: ['sed', '-i', '/"lib64"/s/64//', '@THIS_SOURCE_DIR@/Modules/GNUInstallDirs.cmake']
       - args: ['cp', '-f', '@SOURCE_ROOT@/scripts/managarm.cmake', '@THIS_SOURCE_DIR@/Modules/Platform/']
@@ -214,7 +214,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -247,7 +247,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
         isolate_network: false
@@ -301,7 +301,7 @@ packages:
       - mlibc
       - libxml
       - python
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -354,7 +354,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -387,7 +387,7 @@ packages:
     pkgs_required:
       # This is only a build-time dependency.
       - mlibc
-    revision: 6
+    revision: 7
     configure:
       - args:
         - 'cmake'
@@ -421,7 +421,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     build:
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/bin']
       - args: ['@OPTION:arch-triple@-gcc', '-Os', '-s', '@THIS_SOURCE_DIR@/pc.c', '-o', '@THIS_COLLECT_DIR@/usr/bin/pc']

--- a/bootstrap.d/dev-vcs.y4.yml
+++ b/bootstrap.d/dev-vcs.y4.yml
@@ -33,7 +33,7 @@ packages:
       - curl
       - libiconv
       - pcre2
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:

--- a/bootstrap.d/games-board.y4.yml
+++ b/bootstrap.d/games-board.y4.yml
@@ -28,7 +28,7 @@ packages:
       - libx11
       - libxpm
       - zlib
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -64,7 +64,7 @@ packages:
       - qtbase6
       - qtsvg6
       - qtmultimedia6
-    revision: 13
+    revision: 14
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/games-emulation.y4.yml
+++ b/bootstrap.d/games-emulation.y4.yml
@@ -26,7 +26,7 @@ packages:
       - libintl
       - libiconv
       - zlib
-    revision: 12
+    revision: 13
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/games-misc.y4.yml
+++ b/bootstrap.d/games-misc.y4.yml
@@ -82,7 +82,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 10
+    revision: 11
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/games-simulation.y4.yml
+++ b/bootstrap.d/games-simulation.y4.yml
@@ -58,7 +58,7 @@ packages:
       - openttd-opengfx
       - openttd-openmsx
       - openttd-opensfx
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/gnome-base.y4.yml
+++ b/bootstrap.d/gnome-base.y4.yml
@@ -32,7 +32,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
-    revision: 1
+    revision: 2
     configure:
       - args: |
               sed -i -r 's:"(/system):"/org/gnome\1:g' @THIS_SOURCE_DIR@/schemas/*.in

--- a/bootstrap.d/gui-apps.y4.yml
+++ b/bootstrap.d/gui-apps.y4.yml
@@ -24,7 +24,7 @@ packages:
       - wayland
       - wayland-protocols
       - libxkbcommon
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -78,7 +78,7 @@ packages:
       - wayland
       - wayland-protocols
       - gdk-pixbuf
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -125,10 +125,11 @@ packages:
       - wayland-protocols
       - mesa
       - libepoxy
-    revision: 8
+    revision: 9
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--native-file'
@@ -169,7 +170,7 @@ packages:
       - mlibc
       - wayland
       - gtk+-3
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/gui-libs.y4.yml
+++ b/bootstrap.d/gui-libs.y4.yml
@@ -333,7 +333,7 @@ packages:
       - mlibc
       - mesa
       - libxkbcommon
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -394,7 +394,7 @@ packages:
       - xwayland
       - hwdata
       - mesa
-    revision: 1
+    revision: 2
     configure:
       - args: 'sed -i s#{XBSTRAP_SYSTEM_ROOT}#@SYSROOT_DIR@# @THIS_SOURCE_DIR@/xwayland/meson.build'
       - args:
@@ -443,7 +443,7 @@ packages:
       - wayland
       - libepoxy
       - glib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/gui-wm.y4.yml
+++ b/bootstrap.d/gui-wm.y4.yml
@@ -34,7 +34,7 @@ packages:
       - wayland-protocols
       - wlroots
       - xwayland
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/kde-apps.y4.yml
+++ b/bootstrap.d/kde-apps.y4.yml
@@ -35,7 +35,7 @@ packages:
       - knotifications
       - kwidgetsaddons
       - kxmlgui
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/kde-frameworks.y4.yml
+++ b/bootstrap.d/kde-frameworks.y4.yml
@@ -320,7 +320,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -366,7 +366,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -412,7 +412,7 @@ packages:
       - bzip2
       - zstd
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -454,7 +454,7 @@ packages:
       - mlibc
       - qtbase6
       - kcoreaddons
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -503,7 +503,7 @@ packages:
       - kcoreaddons
       - kiconthemes
       - kwidgetsaddons
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -547,7 +547,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -592,7 +592,7 @@ packages:
       - kconfig
       - kguiaddons
       - ki18n
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -637,7 +637,7 @@ packages:
       - kconfig
       - kcoreaddons
       - kwidgetsaddons
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -682,7 +682,7 @@ packages:
       - mlibc
       - qtbase6
       - qtdeclarative6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -734,7 +734,7 @@ packages:
       - kguiaddons
       - ki18n
       - kwidgetsaddons
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -777,7 +777,7 @@ packages:
       - qtbase6
       - qtdeclarative6
       - systemd
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'
@@ -823,7 +823,7 @@ packages:
       - libice
       - libx11
       - xorg-proto
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -868,7 +868,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -918,7 +918,7 @@ packages:
       - kcrash
       - kdbusaddons
       - kservice
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -962,7 +962,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1014,7 +1014,7 @@ packages:
       - libxcb
       - xorg-proto
       - libice
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1064,7 +1064,7 @@ packages:
       - qtdeclarative6
       - libintl
       - iso-codes
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1117,7 +1117,7 @@ packages:
       - ki18n
       - kwidgetsaddons
       - breeze-icons
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1170,7 +1170,7 @@ packages:
       - libxscrnsaver
       - plasma-wayland-protocols
       - wayland-protocols
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1240,7 +1240,7 @@ packages:
       - kwindowsystem
       - kxmlgui
       - solid
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1288,7 +1288,7 @@ packages:
       - qtdeclarative6
       - qtsvg6
       - qt5compat
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1333,7 +1333,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1383,7 +1383,7 @@ packages:
       - libx11
       - libice
       - xorg-proto
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1436,7 +1436,7 @@ packages:
       - kpackage
       - kirigami
       - kwidgetsaddons
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1483,7 +1483,7 @@ packages:
       - qtdeclarative6
       - kconfig
       - libcanberra
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1532,7 +1532,7 @@ packages:
       - ki18n
       - kio
       - libcanberra
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1579,7 +1579,7 @@ packages:
       - karchive
       - kcoreaddons
       - ki18n
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1632,7 +1632,7 @@ packages:
       - kservice
       - kwidgetsaddons
       - kxmlgui
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1684,7 +1684,7 @@ packages:
       - kservice
       - kwidgetsaddons
       - sonnet
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1733,7 +1733,7 @@ packages:
       - kcoreaddons
       - kdbusaddons
       - ki18n
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1778,7 +1778,7 @@ packages:
       - mlibc
       - qtbase6
       - kwindowsystem
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1839,7 +1839,7 @@ packages:
       - kservice
       - kwidgetsaddons
       - kwindowsystem
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1883,7 +1883,7 @@ packages:
     pkgs_required:
       - mlibc
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1936,7 +1936,7 @@ packages:
       - xorg-proto
       - xcb-util-keysyms
       - libice
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -1990,7 +1990,7 @@ packages:
       - kiconthemes
       - kitemviews
       - kwidgetsaddons
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -2036,7 +2036,7 @@ packages:
       - qtdeclarative6
       - util-linux-libs
       - systemd
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'
@@ -2079,7 +2079,7 @@ packages:
       - qtbase6
       - qtdeclarative6
       - hunspell
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/kde-plasma.y4.yml
+++ b/bootstrap.d/kde-plasma.y4.yml
@@ -27,7 +27,7 @@ packages:
       - wayland
       - wayland-protocols
       - libxkbcommon
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/lxqt-base.y4.yml
+++ b/bootstrap.d/lxqt-base.y4.yml
@@ -25,7 +25,7 @@ packages:
       - kwindowsystem
       - libx11
       - libxscrnsaver
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -68,7 +68,7 @@ packages:
       - layer-shell-qt
       - kwindowsystem
       - qtbase6
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/managarm-base.y4.yml
+++ b/bootstrap.d/managarm-base.y4.yml
@@ -13,7 +13,7 @@ packages:
     source:
       subdir: meta-sources
       version: '1.0'
-    revision: 12
+    revision: 13
     configure: []
     build:
       # Create initial directories
@@ -55,5 +55,3 @@ packages:
       - args: ['ln', '-svf', 'usr/bin', '@THIS_COLLECT_DIR@/bin']
       - args: ['ln', '-svf', 'usr/lib', '@THIS_COLLECT_DIR@/lib']
       - args: ['ln', '-svf', 'usr/sbin', '@THIS_COLLECT_DIR@/sbin']
-      # Create a compatibility symlink for ld.so
-      - args: ['ln', '-svf', '/usr/lib/ld.so', '@THIS_COLLECT_DIR@/lib/ld-init.so']

--- a/bootstrap.d/managarm-build.y4.yml
+++ b/bootstrap.d/managarm-build.y4.yml
@@ -197,7 +197,7 @@ tools:
       - binutils
     tools_required:
       - host-cmake
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/managarm-build.y4.yml
+++ b/bootstrap.d/managarm-build.y4.yml
@@ -265,6 +265,7 @@ tools:
     tools_required:
       - tool: cross-binutils
         recursive: true
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -387,7 +388,7 @@ tools:
     tools_required:
       - tool: cross-binutils
         recursive: true
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/managarm-build.y4.yml
+++ b/bootstrap.d/managarm-build.y4.yml
@@ -327,7 +327,7 @@ tools:
     tools_required:
       - tool: cross-binutils
         recursive: true
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -339,6 +339,8 @@ tools:
         - '--enable-languages=c,c++,lto'
         - '--enable-initfini-array'
         - '--enable-libstdcxx-filesystem-ts'
+        - '--enable-linker-build-id'
+        - '--enable-default-pie'
         # -g blows up GCC's binary size.
         - 'CFLAGS=-O2'
         - 'CXXFLAGS=-O2'

--- a/bootstrap.d/managarm-libc.y4.yml
+++ b/bootstrap.d/managarm-libc.y4.yml
@@ -2,7 +2,7 @@ sources:
   - name: mlibc
     git: 'https://github.com/managarm/mlibc.git'
     branch: 'master'
-    commit: '0e66eb754c6b744b3fe3d8eb5fbe8e23dcf05ec2'
+    commit: 'bf177a219302e6055cc5722789356a4350fc4a15'
     rolling_version: true
     version: '0.0pl@ROLLING_ID@'
     sources_required:
@@ -234,6 +234,7 @@ packages:
         - '--buildtype=debugoptimized'
         - '--wrap-mode=nofallback'
         - '-Dno_headers=true'
+        - '-Dld_library_name=@OPTION:arch@-managarm-mlibc-ld'
         - '-Dlinux_kernel_headers=@SYSROOT_DIR@/usr/src/linux-headers'
         - '@THIS_SOURCE_DIR@'
     build:

--- a/bootstrap.d/managarm-libs.y4.yml
+++ b/bootstrap.d/managarm-libs.y4.yml
@@ -80,10 +80,11 @@ packages:
       branch: 'master'
     tools_required:
       - system-gcc
-    revision: 9
+    revision: 10
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -121,7 +122,7 @@ packages:
         triple: '@OPTION:arch-triple@'
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -178,10 +179,11 @@ packages:
       subdir: 'ports'
       git: 'https://github.com/managarm/frigg.git'
       branch: 'master'
-    revision: 7
+    revision: 8
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--prefix=/usr'
         - '--libdir=lib'
         # Install to /usr/share to avoid conflicts with standard C++ headers.
@@ -204,10 +206,11 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc-headers
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -234,10 +237,11 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 10
+    revision: 11
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -265,10 +269,11 @@ packages:
       - system-gcc
     pkgs_required:
       - boost
-    revision: 9
+    revision: 11
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -300,11 +305,12 @@ packages:
       branch: 'master'
     tools_required:
       - system-gcc
-    revision: 11
+    revision: 12
     configure:
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/include']
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -334,7 +340,7 @@ packages:
       - system-gcc
       - virtual: pkgconfig-for-target
         triple: '@OPTION:arch-triple@'
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/managarm-system.y4.yml
+++ b/bootstrap.d/managarm-system.y4.yml
@@ -50,10 +50,11 @@ tools:
       - host-bragi
       - virtual: pkgconfig-for-host
         program_name: host-pkg-config
-    revision: 3
+    revision: 1
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--native-file'
         - '@SOURCE_ROOT@/scripts/meson.native-file'
         - '--prefix=@PREFIX@'

--- a/bootstrap.d/media-fonts.y4.yml
+++ b/bootstrap.d/media-fonts.y4.yml
@@ -78,7 +78,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/media-gfx.y4.yml
+++ b/bootstrap.d/media-gfx.y4.yml
@@ -14,7 +14,7 @@ packages:
     pkgs_required:
       - mlibc
       - gcc # Actually requires libstdc++.so in the system root, otherwise it links against the host libstdc++.so.6
-    revision: 10
+    revision: 11
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/media-libs.y4.yml
+++ b/bootstrap.d/media-libs.y4.yml
@@ -28,7 +28,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -62,7 +62,7 @@ packages:
       - nasm
       - libogg
       - libiconv
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -119,7 +119,7 @@ packages:
       - freetype
       - libxml
       - libiconv
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -159,7 +159,7 @@ packages:
       - libxi
       - mesa
       - glu
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -218,7 +218,7 @@ packages:
       - bzip2
       - libpng
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -251,7 +251,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 10
+    revision: 11
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -277,7 +277,7 @@ packages:
       - mlibc
       - glu
       - mesa
-    revision: 10
+    revision: 11
     configure:
       # These two seds lets the build system respect the GCC variable
       - args: ['sed', '-i', 's/CC = cc/CC = $(GCC)/g', '@THIS_SOURCE_DIR@/config/Makefile.linux']
@@ -311,7 +311,7 @@ packages:
       - mlibc
       - gcc # Actually requires libstdc++.so in the system root, otherwise it links against the host libstdc++.so.6
       - mesa
-    revision: 6
+    revision: 7
     configure:
       - args:
         - 'meson'
@@ -360,7 +360,7 @@ packages:
       - !managarm::arch_dep
         arch: [x86_64]
         item: gobject-introspection
-    revision: 3
+    revision: 4
     configure:
       - args:
         - 'meson'
@@ -445,7 +445,7 @@ packages:
       - libmodplug
       - vulkan-headers
       - libusb
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -508,7 +508,7 @@ packages:
       - wayland
       - pango
       - libxext
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -573,7 +573,7 @@ packages:
       - libpng
       - nettle
       - libxml
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -617,7 +617,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -687,7 +687,7 @@ packages:
       - !managarm::arch_dep
         item: gobject-introspection
         arch: [x86_64]
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -769,7 +769,7 @@ packages:
       - gtk+-3
       - gstreamer
       - libtool
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -810,7 +810,7 @@ packages:
         program_name: host-pkg-config
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
           - 'meson'
@@ -853,7 +853,7 @@ packages:
       - mesa
       - xorg-proto
       - libx11
-    revision: 9
+    revision: 10
     configure:
       - args:
           - 'meson'
@@ -893,7 +893,7 @@ packages:
       - mlibc
       - libx11
       - libxext
-    revision: 7
+    revision: 8
     configure:
       - args:
         - 'meson'
@@ -940,7 +940,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -987,7 +987,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1026,7 +1026,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1069,7 +1069,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 3
+    revision: 4
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1118,7 +1118,7 @@ packages:
       - zlib
       - zstd
       - xz-utils
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1172,7 +1172,7 @@ packages:
       - libvorbis
       - sqlite
       - alsa-lib
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1214,7 +1214,7 @@ packages:
       - mlibc
       - libogg
       - libvorbis
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1263,7 +1263,7 @@ packages:
     pkgs_required:
       - mlibc
       - libogg
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1295,7 +1295,7 @@ packages:
     pkgs_required:
       - mlibc
       - nasm
-    revision: 1
+    revision: 2
     configure:
       # Fix ownership and permission of installed files.
       - args: ['sed', '-i', 's/cp -p/cp/', '@THIS_SOURCE_DIR@/build/make/Makefile']
@@ -1351,7 +1351,7 @@ packages:
       - sdl2
       - libtiff
       - giflib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1403,7 +1403,7 @@ packages:
       - libglvnd
       - libexpat
       - zstd
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file', 'meson.cross-file']
       - args:
@@ -1473,7 +1473,7 @@ packages:
       - wayland-protocols
       # This is only required for building.
       - vulkan-headers
-    revision: 6
+    revision: 7
     configure:
       - args:
         - 'cmake'
@@ -1520,7 +1520,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1573,7 +1573,7 @@ packages:
       - libxrender
       - libxxf86vm
       - libxkbcommon
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/net-dns.y4.yml
+++ b/bootstrap.d/net-dns.y4.yml
@@ -18,7 +18,7 @@ packages:
       - host-cmake
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'
@@ -65,7 +65,7 @@ packages:
       - mlibc
       - libunistring
       - libiconv
-    revision: 11
+    revision: 12
     configure:
       # Remove some files from the source directory if they exist.
       - args: |

--- a/bootstrap.d/net-irc.y4.yml
+++ b/bootstrap.d/net-irc.y4.yml
@@ -111,7 +111,7 @@ packages:
       - kwidgetsaddons
       - kwindowsystem
       - kxmlgui
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/net-libs.y4.yml
+++ b/bootstrap.d/net-libs.y4.yml
@@ -27,10 +27,11 @@ packages:
       - glib
       - gnutls
       - gsettings-desktop-schemas
-    revision: 8
+    revision: 9
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -87,7 +88,7 @@ packages:
       - libiconv
       - libintl
       - openssl
-    revision: 9
+    revision: 10
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -133,7 +134,7 @@ packages:
     pkgs_required:
       - mlibc
       - glib
-    revision: 5
+    revision: 6
     configure:
       - args:
         - 'meson'
@@ -185,7 +186,7 @@ packages:
       - libidn2
       - libunistring
       - libiconv
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -232,7 +233,7 @@ packages:
       - libxml
       - sqlite
       - libpsl
-    revision: 6
+    revision: 7
     configure:
       - args:
         - 'meson'
@@ -390,7 +391,7 @@ packages:
       - zlib
       - c-ares
       - boost
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/net-misc.y4.yml
+++ b/bootstrap.d/net-misc.y4.yml
@@ -25,7 +25,7 @@ packages:
       - openssl
       - zlib
       - zstd
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -64,7 +64,7 @@ packages:
     pkgs_required:
       - mlibc
       - systemd
-    revision: 5
+    revision: 6
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -144,7 +144,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -175,7 +175,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
           - 'meson'
@@ -230,7 +230,7 @@ packages:
       - xxhash
       - zstd
       - popt
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -282,7 +282,7 @@ packages:
       - ncurses
       - readline
       - openssl
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -325,7 +325,7 @@ packages:
       - mlibc
       - pcre
       - openssl
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/net-print.y4.yml
+++ b/bootstrap.d/net-print.y4.yml
@@ -29,7 +29,7 @@ packages:
       - gnutls
       - libiconv
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:

--- a/bootstrap.d/net-wireless.y4.yml
+++ b/bootstrap.d/net-wireless.y4.yml
@@ -18,7 +18,7 @@ packages:
     pkgs_required:
       - mlibc
       - libnl
-    revision: 2
+    revision: 3
     configure:
       # libnl does not seem to support out-of-tree builds, so we just copy
       # the source tree into the build directory instead

--- a/bootstrap.d/sys-apps.y4.yml
+++ b/bootstrap.d/sys-apps.y4.yml
@@ -116,7 +116,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
         isolate_network: false
@@ -167,7 +167,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       # Huge hack: coreutils does not compile the build-machine binary make-prime-list
       # using the build-machine compiler. Hence, build and invoke the binary manually here.
@@ -230,7 +230,7 @@ packages:
       - glib
       - libexpat
       - systemd
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -296,7 +296,7 @@ packages:
       - host-automake-v1.15
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -330,7 +330,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -361,7 +361,7 @@ packages:
       - mlibc
       - libdrm
       - json-c
-    revision: 8
+    revision: 9
     configure:
       - args:
         - 'meson'
@@ -400,7 +400,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
         isolate_network: false
@@ -441,7 +441,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -486,7 +486,7 @@ packages:
       - host-python
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -532,7 +532,7 @@ packages:
       - host-automake-v1.16
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -575,7 +575,7 @@ packages:
     pkgs_required:
       - mlibc
       - pcre
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -619,7 +619,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 12
+    revision: 13
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -688,7 +688,7 @@ packages:
     pkgs_required:
       - mlibc
       - libmnl
-    revision: 1
+    revision: 2
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -734,7 +734,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -773,7 +773,7 @@ packages:
       - groff
       - less
       - libiconv
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -835,10 +835,11 @@ packages:
     pkgs_required:
       - mlibc
       - pciids
-    revision: 7
+    revision: 8
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--cross-file'
         - '@SOURCE_ROOT@/scripts/meson-@OPTION:arch-triple@.cross-file'
         - '--prefix=/usr'
@@ -890,7 +891,7 @@ packages:
       - libnvme
       - json-c
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -938,7 +939,7 @@ packages:
       - systemd
       - hwdata
       - zlib
-    revision: 5
+    revision: 6
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:
@@ -993,7 +994,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1038,7 +1039,7 @@ packages:
       - libiconv
       - libintl
       - pam
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1113,7 +1114,7 @@ packages:
       - rust-patched-libs
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args: ['@SOURCE_ROOT@/scripts/cargo-inject-patches.py', '@THIS_SOURCE_DIR@/Cargo.toml']
         isolate_network: false
@@ -1163,7 +1164,7 @@ packages:
       - systemd
       - hwdata
       - libiconv
-    revision: 3
+    revision: 4
     configure:
       - args:
         - 'meson'
@@ -1196,7 +1197,7 @@ packages:
       - libiconv
       - file
       - libxcrypt
-    revision: 13
+    revision: 14
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1346,7 +1347,7 @@ packages:
       - file
       - libxcrypt
       - pcre2
-    revision: 18
+    revision: 19
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1446,7 +1447,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1483,7 +1484,7 @@ packages:
       - openssl
       - zlib
       - lz4
-    revision: 3
+    revision: 4
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args:
@@ -1526,7 +1527,7 @@ packages:
       - libdrm
       - libtsm
       - systemd
-    revision: 13
+    revision: 14
     configure:
       - args:
         - 'meson'
@@ -1629,7 +1630,7 @@ packages:
       - util-linux-libs
       - mlibc
       - pam
-    revision: 9
+    revision: 10
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/sys-auth.y4.yml
+++ b/bootstrap.d/sys-auth.y4.yml
@@ -22,7 +22,7 @@ packages:
     pkgs_required:
       - mlibc
       - systemd
-    revision: 9
+    revision: 10
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/sys-devel.y4.yml
+++ b/bootstrap.d/sys-devel.y4.yml
@@ -127,7 +127,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 10
+    revision: 11
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
       - args: ['./configure.sh', '-G', '-O3']
@@ -264,7 +264,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -303,7 +303,7 @@ packages:
         triple: "@OPTION:arch-triple@"
     pkgs_required:
       - mlibc
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -344,7 +344,7 @@ packages:
     pkgs_required:
       - mlibc
       - diffutils
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -452,7 +452,7 @@ packages:
       - tool: system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/sys-devel.y4.yml
+++ b/bootstrap.d/sys-devel.y4.yml
@@ -409,7 +409,7 @@ packages:
       - mpfr
       - mpc
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -425,6 +425,8 @@ packages:
         - '--disable-nls'
         - '--enable-lto'
         - '--with-system-zlib'
+        - '--enable-linker-build-id'
+        - '--enable-default-pie'
         # -g blows up GCC's binary size.
         - 'CFLAGS=-O2'
         - 'CXXFLAGS=-O2'

--- a/bootstrap.d/sys-devel.y4.yml
+++ b/bootstrap.d/sys-devel.y4.yml
@@ -367,7 +367,7 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'cmake'

--- a/bootstrap.d/sys-firmware.y4.yml
+++ b/bootstrap.d/sys-firmware.y4.yml
@@ -20,7 +20,7 @@ packages:
           - 'chmod'
           - '+x'
           - '@THIS_SOURCE_DIR@/NVIDIA-Linux-x86_64-575.51.02.run'
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/NVIDIA-Linux-x86_64-575.51.02.run'
@@ -50,7 +50,7 @@ packages:
       format: tar.gz
       extract_path: 'raspi-firmware'
       version: '1.20250430'
-    revision: 1
+    revision: 2
     build:
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/lib/raspi-firmware']
       - args: ['mkdir', '-p', '@THIS_COLLECT_DIR@/usr/managarm/devicetree/overlays']

--- a/bootstrap.d/sys-libs.y4.yml
+++ b/bootstrap.d/sys-libs.y4.yml
@@ -302,7 +302,7 @@ packages:
     pkgs_required:
       - mlibc
       - libintl
-    revision: 2
+    revision: 3
     configure:
       - args:
           - 'meson'
@@ -345,7 +345,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -386,7 +386,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -427,7 +427,7 @@ packages:
       - dbus
       - openssl
       - util-linux-libs
-    revision: 1
+    revision: 2
     configure:
       - args:
           - 'meson'
@@ -476,7 +476,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -514,7 +514,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -540,7 +540,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -597,7 +597,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -635,7 +635,7 @@ packages:
       - mlibc
       - libxcrypt
       - gdbm
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'
@@ -673,7 +673,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -690,7 +690,7 @@ packages:
       - args: ['patchelf', '--set-soname', 'libreadline.so.8', '@THIS_COLLECT_DIR@/usr/lib/libreadline.so.8']
       - args: ['patchelf', '--set-soname', 'libhistory.so.8', '@THIS_COLLECT_DIR@/usr/lib/libhistory.so.8']
 
-  - name : tzdata
+  - name: tzdata
     labels: [aarch64, riscv64]
     architecture: noarch
     default: true
@@ -773,7 +773,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 8
+    revision: 9
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -821,7 +821,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 2
+    revision: 3
     configure:
       - args: ['cp', '-r', '@THIS_SOURCE_DIR@/.', '@THIS_BUILD_DIR@']
     build:

--- a/bootstrap.d/sys-power.y4.yml
+++ b/bootstrap.d/sys-power.y4.yml
@@ -22,7 +22,7 @@ packages:
       - mlibc
       - libgudev
       - glib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/sys-process.y4.yml
+++ b/bootstrap.d/sys-process.y4.yml
@@ -28,7 +28,7 @@ packages:
     pkgs_required:
       - mlibc
       - ncurses
-    revision: 9
+    revision: 10
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -79,7 +79,7 @@ packages:
       - mlibc
       - ncurses
       - systemd
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/www-client.y4.yml
+++ b/bootstrap.d/www-client.y4.yml
@@ -25,7 +25,7 @@ packages:
       - fontconfig
       - libjpeg-turbo
       - xz-utils
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-apps.y4.yml
+++ b/bootstrap.d/x11-apps.y4.yml
@@ -32,7 +32,7 @@ packages:
       - libxkbcommon
       - dbus
       - gtk+-3
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -89,7 +89,7 @@ packages:
       - libxi
       - mlibc
       - mtdev
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -132,7 +132,7 @@ packages:
       - libxt
       - libxkbfile
       - libiconv
-    revision: 13
+    revision: 14
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -179,7 +179,7 @@ packages:
       - libxi
       - libxrender
       - libxtst
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -218,7 +218,7 @@ packages:
       - mesa
       - xorg-util-macros
       - libx11
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -268,7 +268,7 @@ packages:
       - libxmu
       - libxrender
       - libxt
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -307,7 +307,7 @@ packages:
       - xorg-util-macros
       - libx11
       - libxkbfile
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -346,7 +346,7 @@ packages:
       - xorg-util-macros
       - libx11
       - libxmu
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -385,7 +385,7 @@ packages:
       - mlibc
       - xorg-util-macros
       - libxcb
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -422,7 +422,7 @@ packages:
       - mlibc
       - xorg-util-macros
       - libx11
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -461,7 +461,7 @@ packages:
       - libxmu
       - libx11
       - libxext
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -502,7 +502,7 @@ packages:
       - xorg-util-macros
       - libx11
       - xcb-util
-    revision: 6
+    revision: 7
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -584,7 +584,7 @@ packages:
     pkgs_required:
       - mlibc
       - mesa
-    revision: 10
+    revision: 11
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-base.y4.yml
+++ b/bootstrap.d/x11-base.y4.yml
@@ -32,7 +32,7 @@ packages:
       - xorg-proto
       - libxau
       - libxdmcp
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -72,7 +72,7 @@ packages:
     pkgs_required:
       - mlibc
       - xorg-util-macros
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -125,10 +125,11 @@ packages:
       - nettle
       - xkbcomp
       - pixman
-    revision: 10
+    revision: 11
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--native-file'
         - '@SOURCE_ROOT@/scripts/meson.native-file'
         - '--cross-file'
@@ -200,10 +201,11 @@ packages:
       - nettle
       - xkbcomp
       - pixman
-    revision: 6
+    revision: 7
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--native-file'
         - '@SOURCE_ROOT@/scripts/meson.native-file'
         - '--cross-file'

--- a/bootstrap.d/x11-libs.y4.yml
+++ b/bootstrap.d/x11-libs.y4.yml
@@ -73,7 +73,7 @@ packages:
       - mesa
       - libxrender
       - glib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -129,7 +129,7 @@ packages:
       - !managarm::arch_dep
         arch: [x86_64]
         item: gobject-introspection
-    revision: 8
+    revision: 9
     configure:
       - args:
         - 'meson'
@@ -198,7 +198,7 @@ packages:
       - mlibc
       - gdk-pixbuf
       - libx11
-    revision: 7
+    revision: 8
     configure:
       - args:
         - 'meson'
@@ -339,7 +339,7 @@ packages:
       - !managarm::arch_dep
         arch: [x86_64]
         item: gobject-introspection
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'
@@ -435,7 +435,7 @@ packages:
       - xorg-proto
       - libx11
       - libxext
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -466,7 +466,7 @@ packages:
       - system-gcc
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -532,7 +532,7 @@ packages:
       - libxtrans
       - xorg-font-util
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -578,7 +578,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -611,10 +611,11 @@ packages:
     pkgs_required:
       - mlibc
       - zlib
-    revision: 2
+    revision: 3
     configure:
       - args:
         - 'meson'
+        - 'setup'
         - '--native-file'
         - '@SOURCE_ROOT@/scripts/meson.native-file'
         - '--cross-file'
@@ -662,7 +663,7 @@ packages:
       - libx11
       - libxtrans
       - libice
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -714,7 +715,7 @@ packages:
       - xorg-proto
       - libxcb
       - libxtrans
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -759,7 +760,7 @@ packages:
       - mlibc
       - xorg-util-macros
       - xorg-proto
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -806,7 +807,7 @@ packages:
       - libxt
       - libxmu
       - libxpm
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -858,7 +859,7 @@ packages:
       - libxau
       - libxdmcp
       - xcb-proto
-    revision: 1
+    revision: 2
     configure:
       - args: ['sed', '-i', "s/pthread-stubs//", '@THIS_SOURCE_DIR@/configure']
       - args:
@@ -911,7 +912,7 @@ packages:
       - xorg-proto
       - libx11
       - libxfixes
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -956,7 +957,7 @@ packages:
       - libx11
       - libxfixes
       - libxrender
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1002,7 +1003,7 @@ packages:
       - libx11
       - libxtrans
       - libxfixes
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1045,7 +1046,7 @@ packages:
       - xorg-util-macros
       - xorg-proto
       - libxau
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1090,7 +1091,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1136,7 +1137,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1190,7 +1191,7 @@ packages:
       - bzip2
       - libfontenc
       - zlib
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1240,7 +1241,7 @@ packages:
       - libxrender
       - freetype
       - fontconfig
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1288,7 +1289,7 @@ packages:
       - libxtrans
       - libxext
       - libxfixes
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1338,7 +1339,7 @@ packages:
       - xorg-proto
       - libx11
       - libxext
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1377,7 +1378,7 @@ packages:
       - libxcb
       - libxml
       - xkeyboard-config
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -1427,7 +1428,7 @@ packages:
       - xorg-util-macros
       - xorg-proto
       - libx11
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1475,7 +1476,7 @@ packages:
       - libxext
       - libxtrans
       - libxt
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1520,7 +1521,7 @@ packages:
       - libx11
       - libxext
       - libxt
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1567,7 +1568,7 @@ packages:
       - libxtrans
       - libxrender
       - libxext
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1613,7 +1614,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1663,7 +1664,7 @@ packages:
       - xorg-proto
       - libx11
       - libxext
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1713,7 +1714,7 @@ packages:
       - xorg-proto
       - libx11
       - libxext
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1759,7 +1760,7 @@ packages:
       - xorg-proto
       - libx11
       - libxtrans
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1807,7 +1808,7 @@ packages:
       - libxtrans
       - libsm
       - libice
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1837,7 +1838,7 @@ packages:
       - xorg-util-macros
       - xorg-proto
       - libxcb
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1884,7 +1885,7 @@ packages:
       - libxtrans
       - libxext
       - libxi
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1930,7 +1931,7 @@ packages:
       - libx11
       - libxtrans
       - libxext
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -1977,7 +1978,7 @@ packages:
       - libx11
       - libxtrans
       - libxext
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2038,7 +2039,7 @@ packages:
       - !managarm::arch_dep
         arch: [x86_64]
         item: gobject-introspection
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -2098,7 +2099,7 @@ packages:
     pkgs_required:
       - mlibc
       - libpng
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -2149,7 +2150,7 @@ packages:
       - libx11
       - libxtrans
       - libxcb
-    revision: 8
+    revision: 9
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2198,7 +2199,7 @@ packages:
       - xcb-util-render-util
       - xorg-proto
       - xcb-util
-    revision: 8
+    revision: 9
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2244,7 +2245,7 @@ packages:
       - xorg-util-macros
       - xorg-proto
       - xcb-util
-    revision: 8
+    revision: 9
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2290,7 +2291,7 @@ packages:
       - libxcb
       - xorg-util-macros
       - xorg-proto
-    revision: 8
+    revision: 9
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2336,7 +2337,7 @@ packages:
       - libxcb
       - xorg-util-macros
       - xorg-proto
-    revision: 8
+    revision: 9
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2381,7 +2382,7 @@ packages:
       - libxcb
       - xorg-util-macros
       - xorg-proto
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -2417,7 +2418,7 @@ packages:
       - host-pkg-config
     pkgs_required:
       - mlibc
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/x11-misc.y4.yml
+++ b/bootstrap.d/x11-misc.y4.yml
@@ -55,7 +55,7 @@ packages:
       - glib
       - libxml
       - itstool
-    revision: 12
+    revision: 13
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -96,7 +96,7 @@ packages:
     pkgs_required:
       - mlibc
       - xorg-util-macros
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -125,7 +125,7 @@ packages:
       - mlibc
       - libx11
       - xorg-proto
-    revision: 1
+    revision: 2
     configure:
       - args:
         - 'meson'
@@ -148,7 +148,7 @@ packages:
     tools_required:
       - system-gcc
       - host-xorg-macros
-    revision: 1
+    revision: 2
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/bootstrap.d/x11-themes.y4.yml
+++ b/bootstrap.d/x11-themes.y4.yml
@@ -20,7 +20,7 @@ packages:
         - args: ['./autogen.sh', '--no-configure']
     tools_required:
       - system-gcc
-    revision: 9
+    revision: 10
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -62,7 +62,7 @@ packages:
       - mlibc
       - xorg-util-macros
       - libxcursor
-    revision: 7
+    revision: 8
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update \
 		gengetopt \
 		# Used by host-gettext
 		gettext \
+		# Used by mesa if vulkan is enabled
+		glslang-tools \
 		# Git is used extensively in the build process
 		git \
 		# Used by eudev

--- a/patches/gcc/0001-Fix-dynamic-linker-paths-and-add-support-for-backtra.patch
+++ b/patches/gcc/0001-Fix-dynamic-linker-paths-and-add-support-for-backtra.patch
@@ -1,0 +1,117 @@
+From 59650138ac89368d1de499e79ee46c37ec7d0058 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sat, 9 Aug 2025 00:06:54 +0200
+Subject: [PATCH] Fix dynamic linker paths and add support for backtracing into
+ libgcc
+
+---
+ gcc/config/aarch64/aarch64-managarm.h | 2 +-
+ gcc/config/i386/i386-managarm.h       | 6 +++---
+ gcc/config/managarm.h                 | 1 +
+ gcc/config/riscv/managarm.h           | 2 +-
+ libgcc/config.host                    | 6 ++++--
+ libgcc/unwind-dw2-fde-dip.c           | 5 +++++
+ 6 files changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/gcc/config/aarch64/aarch64-managarm.h b/gcc/config/aarch64/aarch64-managarm.h
+index 9143fa673..7b84bd395 100644
+--- a/gcc/config/aarch64/aarch64-managarm.h
++++ b/gcc/config/aarch64/aarch64-managarm.h
+@@ -2,7 +2,7 @@
+ #undef GCC_AARCH64_MANAGARM
+ #define GCC_AARCH64_MANAGARM 1
+ 
+-#define GNU_USER_DYNAMIC_LINKER "/lib/x86_64-managarm/ld.so"
++#define GNU_USER_DYNAMIC_LINKER "/lib/aarch64-managarm-mlibc-ld.so"
+ 
+ #define MANAGARM_TARGET_LINK_SPEC  "%{h*}		\
+    %{static:-Bstatic}				\
+diff --git a/gcc/config/i386/i386-managarm.h b/gcc/config/i386/i386-managarm.h
+index eeba4ba00..f86cf6391 100644
+--- a/gcc/config/i386/i386-managarm.h
++++ b/gcc/config/i386/i386-managarm.h
+@@ -6,6 +6,6 @@
+ #define GNU_USER_LINK_EMULATION64 "elf_x86_64"
+ #define GNU_USER_LINK_EMULATIONX32 "elf32_x86_64"
+ 
+-#define GNU_USER_DYNAMIC_LINKER32 "/lib/i386-managarm/ld.so"
+-#define GNU_USER_DYNAMIC_LINKER64 "/lib/x86_64-managarm/ld.so"
+-#define GNU_USER_DYNAMIC_LINKERX32 "/lib/x86_64-managarm-x32/ld.so"
++#define GNU_USER_DYNAMIC_LINKER32 "/lib/i386-managarm-mlibc-ld.so"
++#define GNU_USER_DYNAMIC_LINKER64 "/lib/x86_64-managarm-mlibc-ld.so"
++#define GNU_USER_DYNAMIC_LINKERX32 "/lib/x86_64-managarm-x32-mlibc-ld.so"
+diff --git a/gcc/config/managarm.h b/gcc/config/managarm.h
+index 517e68c38..a5fdf77fe 100644
+--- a/gcc/config/managarm.h
++++ b/gcc/config/managarm.h
+@@ -6,6 +6,7 @@
+ #define TARGET_OS_CPP_BUILTINS()		\
+   do {						\
+     builtin_define ("__managarm__");		\
++    builtin_define ("__mlibc__");		\
+     builtin_define ("__unix__");		\
+     builtin_assert ("system=managarm");		\
+     builtin_assert ("system=unix");		\
+diff --git a/gcc/config/riscv/managarm.h b/gcc/config/riscv/managarm.h
+index 2c5db5521..64cbdd4aa 100644
+--- a/gcc/config/riscv/managarm.h
++++ b/gcc/config/riscv/managarm.h
+@@ -41,7 +41,7 @@ along with GCC; see the file COPYING3.  If not see
+   "%{mabi=ilp32f:_ilp32f}" \
+   "%{mabi=ilp32:_ilp32}"
+ 
+-#define GNU_USER_DYNAMIC_LINKER "/lib/riscv-managarm/ld" XLEN_SPEC "-" ABI_SPEC ".so"
++#define GNU_USER_DYNAMIC_LINKER "/lib/riscv64-managarm-mlibc-ld.so"
+ 
+ #define LINK_SPEC "\
+ -melf" XLEN_SPEC DEFAULT_ENDIAN_SPEC "riscv" LD_EMUL_SUFFIX " \
+diff --git a/libgcc/config.host b/libgcc/config.host
+index 6317343ea..4289f7a4f 100644
+--- a/libgcc/config.host
++++ b/libgcc/config.host
+@@ -321,7 +321,7 @@ case ${host} in
+       ;;
+   esac
+   tmake_file="$tmake_file t-crtstuff-pic"
+-  tmake_file="$tmake_file t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver t-libgcc-pic"
++  tmake_file="$tmake_file t-slibgcc t-slibgcc-gld t-slibgcc-elf-ver t-libgcc-pic t-eh-dw2-dip"
+   ;;
+ *-*-lynxos*)
+   tmake_file="$tmake_file t-lynx $cpu_type/t-crtstuff t-crtstuff-pic t-libgcc-pic"
+@@ -808,7 +808,8 @@ i[34567]86-*-linux*)
+ x86_64-*-managarm*)
+ 	extra_parts="$extra_parts crtprec32.o crtprec64.o crtprec80.o crtfastmath.o"
+ 	tmake_file="$tmake_file i386/t-crtpc t-crtfm i386/t-crtstuff t-dfprules"
+-	tmake_file="$tmake_file i386/t-linux"
++	tm_file="${tm_file} i386/elf-lib.h"
++	md_unwind_header=i386/linux-unwind.h
+ 	;;
+ i[34567]86-*-kfreebsd*-gnu | i[34567]86-*-kopensolaris*-gnu)
+ 	extra_parts="$extra_parts crtprec32.o crtprec64.o crtprec80.o crtfastmath.o"
+@@ -1619,6 +1620,7 @@ esac
+ 
+ case ${host} in
+ i[34567]86-*-linux* | x86_64-*-linux* | \
++  i[34567]86-*-managarm* | x86_64-*-managarm* | \
+   i[34567]86-*-kfreebsd*-gnu | x86_64-*-kfreebsd*-gnu | \
+   i[34567]86-*-gnu* | x86_64-*-gnu*)
+ 	tmake_file="${tmake_file} t-tls i386/t-linux i386/t-msabi t-slibgcc-libgcc"
+diff --git a/libgcc/unwind-dw2-fde-dip.c b/libgcc/unwind-dw2-fde-dip.c
+index 57d0c8812..38913e490 100644
+--- a/libgcc/unwind-dw2-fde-dip.c
++++ b/libgcc/unwind-dw2-fde-dip.c
+@@ -83,6 +83,11 @@
+ # define USE_PT_GNU_EH_FRAME
+ #endif
+ 
++#if !defined(inhibit_libc) && defined(HAVE_LD_EH_FRAME_HDR) \
++    && defined(__managarm__)
++# define USE_PT_GNU_EH_FRAME
++#endif
++
+ #if defined(USE_PT_GNU_EH_FRAME)
+ 
+ #include <link.h>
+-- 
+2.50.1
+

--- a/patches/llvm/0001-Add-managarm-OS-target.patch
+++ b/patches/llvm/0001-Add-managarm-OS-target.patch
@@ -1,7 +1,7 @@
-From 0263ee83e7924f0947ad1d718465eddf60743592 Mon Sep 17 00:00:00 2001
+From 218a5b2f00b5d2133ef7e319ee96e5cf7e14e7d2 Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Fri, 6 Sep 2024 21:17:53 +0200
-Subject: [PATCH 1/4] Add managarm OS target
+Subject: [PATCH 1/5] Add managarm OS target
 
 ---
  llvm/include/llvm/ADT/bit.h                |  2 +-
@@ -173,5 +173,5 @@ index ae5df4621..232b1f3b6 100644
    EXPECT_EQ(Triple::wasm32, T.getArch());
    EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
 -- 
-2.48.1
+2.50.1
 

--- a/patches/llvm/0002-Add-managarm-OS-target.patch
+++ b/patches/llvm/0002-Add-managarm-OS-target.patch
@@ -1,7 +1,7 @@
-From 2c0688fc0596678a864edca46b7815bd1998df0f Mon Sep 17 00:00:00 2001
+From 758cbec811f474d7fe36c43955d39664991a5ffb Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Fri, 6 Sep 2024 21:18:39 +0200
-Subject: [PATCH 2/4] Add managarm OS target
+Subject: [PATCH 2/5] Add managarm OS target
 
 ---
  clang/lib/Basic/Targets.cpp              |   9 +
@@ -432,5 +432,5 @@ index 000000000..2082e2c61
 +
 +#endif // LLVM_CLANG_LIB_DRIVER_TOOLCHAINS_MANAGARM_H
 -- 
-2.48.1
+2.50.1
 

--- a/patches/llvm/0003-Add-managarm-tests.patch
+++ b/patches/llvm/0003-Add-managarm-tests.patch
@@ -1,7 +1,7 @@
-From db237ac6244e08929620f3765549f0b1e733a0b3 Mon Sep 17 00:00:00 2001
+From e40601f1efeee6349ea2785cb04aa5154158c6e0 Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Tue, 5 Nov 2024 01:43:57 +0100
-Subject: [PATCH 3/4] Add managarm tests
+Subject: [PATCH 3/5] Add managarm tests
 
 ---
  .../lib/aarch64-managarm-mlibc/.keep          |   0
@@ -325,5 +325,5 @@ index 000000000..86f1e2710
 +// CHECK-RISCV64-SHARED-SAME: {{^}} "-L[[SYSROOT]]/lib"
 +// CHECK-RISCV64-SHARED-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 -- 
-2.48.1
+2.50.1
 

--- a/patches/llvm/0004-WIP-kernel-environment.patch
+++ b/patches/llvm/0004-WIP-kernel-environment.patch
@@ -1,7 +1,7 @@
-From 9914d66168396b435cc89121fa29ac3f78ebaf93 Mon Sep 17 00:00:00 2001
+From ca6beef488fd8a2d67f7ad3dacfaeb7563663dcd Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Tue, 5 Nov 2024 01:44:16 +0100
-Subject: [PATCH 4/4] WIP: kernel environment
+Subject: [PATCH 4/5] WIP: kernel environment
 
 ---
  llvm/include/llvm/TargetParser/Triple.h | 1 +
@@ -42,5 +42,5 @@ index 32b924729..58036baee 100644
  }
  
 -- 
-2.48.1
+2.50.1
 

--- a/patches/llvm/0005-Managarm-Define-__mlibc__-and-fix-ld.so-paths.patch
+++ b/patches/llvm/0005-Managarm-Define-__mlibc__-and-fix-ld.so-paths.patch
@@ -1,0 +1,70 @@
+From fd010ca74eacde2759e1350b4284212781bac7f7 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 10 Aug 2025 15:03:10 +0200
+Subject: [PATCH 5/5] Managarm: Define __mlibc__ and fix ld.so paths
+
+---
+ clang/lib/Basic/Targets/OSTargets.h      |  1 +
+ clang/lib/Driver/ToolChains/Managarm.cpp | 10 ++++------
+ clang/test/Driver/managarm.cpp           |  4 ++--
+ 3 files changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/clang/lib/Basic/Targets/OSTargets.h b/clang/lib/Basic/Targets/OSTargets.h
+index 257d399b2..88adf8575 100644
+--- a/clang/lib/Basic/Targets/OSTargets.h
++++ b/clang/lib/Basic/Targets/OSTargets.h
+@@ -381,6 +381,7 @@ protected:
+                     MacroBuilder &Builder) const override {
+     DefineStd(Builder, "unix", Opts);
+     Builder.defineMacro("__managarm__");
++    Builder.defineMacro("__mlibc__");
+     if (Opts.POSIXThreads)
+       Builder.defineMacro("_REENTRANT");
+     if (Opts.CPlusPlus)
+diff --git a/clang/lib/Driver/ToolChains/Managarm.cpp b/clang/lib/Driver/ToolChains/Managarm.cpp
+index 51abd8459..0764503dc 100644
+--- a/clang/lib/Driver/ToolChains/Managarm.cpp
++++ b/clang/lib/Driver/ToolChains/Managarm.cpp
+@@ -126,13 +126,11 @@ std::string Managarm::computeSysRoot() const {
+ std::string Managarm::getDynamicLinker(const ArgList &Args) const {
+   switch (getTriple().getArch()) {
+   case llvm::Triple::aarch64:
+-    return "/lib/aarch64-managarm/ld.so";
+-  case llvm::Triple::riscv64: {
+-    StringRef ABIName = tools::riscv::getRISCVABI(Args, getTriple());
+-    return ("/lib/riscv64-managarm/ld-riscv64-" + ABIName + ".so").str();
+-  }
++    return "/lib/aarch64-managarm-mlibc-ld.so";
++  case llvm::Triple::riscv64:
++    return "/lib/riscv64-managarm-mlibc-ld.so";
+   case llvm::Triple::x86_64:
+-    return "/lib/x86_64-managarm/ld.so";
++    return "/lib/x86_64-managarm-mlibc-ld.so";
+   default:
+     llvm_unreachable("unsupported architecture");
+   }
+diff --git a/clang/test/Driver/managarm.cpp b/clang/test/Driver/managarm.cpp
+index 86f1e2710..3cbeba312 100644
+--- a/clang/test/Driver/managarm.cpp
++++ b/clang/test/Driver/managarm.cpp
+@@ -13,7 +13,7 @@
+ // CHECK-X86-64-SAME: {{^}} "-internal-externc-isystem" "[[SYSROOT]]/include"
+ // CHECK-X86-64-SAME: {{^}} "-internal-externc-isystem" "[[SYSROOT]]/usr/include"
+ // CHECK-X86-64:      "{{.*}}ld" "--sysroot=[[SYSROOT:[^"]+]]"
+-// CHECK-X86-64-SAME: "-dynamic-linker" "/lib/x86_64-managarm/ld.so"
++// CHECK-X86-64-SAME: "-dynamic-linker" "/lib/x86_64-managarm-mlibc-ld.so"
+ // CHECK-X86-64-SAME: "{{.*}}/usr/lib/gcc/x86_64-managarm-mlibc/10/crtbegin.o"
+ // CHECK-X86-64-SAME: "-L
+ // CHECK-X86-64-SAME: {{^}}[[SYSROOT]]/usr/lib/gcc/x86_64-managarm-mlibc/10"
+@@ -78,7 +78,7 @@
+ // CHECK-AARCH64-SAME: {{^}} "-internal-externc-isystem" "[[SYSROOT]]/include"
+ // CHECK-AARCH64-SAME: {{^}} "-internal-externc-isystem" "[[SYSROOT]]/usr/include"
+ // CHECK-AARCH64:      "{{.*}}ld" "--sysroot=[[SYSROOT:[^"]+]]"
+-// CHECK-AARCH64-SAME: "-dynamic-linker" "/lib/aarch64-managarm/ld.so"
++// CHECK-AARCH64-SAME: "-dynamic-linker" "/lib/aarch64-managarm-mlibc-ld.so"
+ // CHECK-AARCH64-SAME: "{{.*}}/usr/lib/gcc/aarch64-managarm-mlibc/10/crtbegin.o"
+ // CHECK-AARCH64-SAME: "-L
+ // CHECK-AARCH64-SAME: {{^}}[[SYSROOT]]/usr/lib/gcc/aarch64-managarm-mlibc/10"
+-- 
+2.50.1
+

--- a/patches/systemd/0001-Add-managarm-support.patch
+++ b/patches/systemd/0001-Add-managarm-support.patch
@@ -1,7 +1,7 @@
-From 65955365fa9d860138af62f8b35ab91fa7de2eab Mon Sep 17 00:00:00 2001
+From 95e913dc38c0944ac5089775656e7f5609b2559f Mon Sep 17 00:00:00 2001
 From: no92 <no92.mail@gmail.com>
 Date: Tue, 18 Feb 2025 23:40:13 +0100
-Subject: [PATCH 1/4] Add managarm support
+Subject: [PATCH 1/5] Add managarm support
 
 ---
  meson.build                        |  8 ++--

--- a/patches/systemd/0002-Add-support-for-systemd-boot-for-Managarm.patch
+++ b/patches/systemd/0002-Add-support-for-systemd-boot-for-Managarm.patch
@@ -1,7 +1,7 @@
-From f96a9c549f8c1be8b4efaa85d6a098d9b53d014a Mon Sep 17 00:00:00 2001
+From 26ad1866c83173941c0aef6a1343b934b4decd7e Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Fri, 10 Jan 2025 00:55:19 +0100
-Subject: [PATCH 2/4] Add support for systemd boot for Managarm
+Subject: [PATCH 2/5] Add support for systemd boot for Managarm
 
 ---
  src/basic/capability-util.c              |  2 ++

--- a/patches/systemd/0003-add-fallback-parse_printf_format-implementation.patch
+++ b/patches/systemd/0003-add-fallback-parse_printf_format-implementation.patch
@@ -1,7 +1,7 @@
-From 507376e53eb99475e5515366788a78091c1c7eed Mon Sep 17 00:00:00 2001
+From 9debe945155dd1db9c6e6a384d2455bcc077476f Mon Sep 17 00:00:00 2001
 From: Alexander Kanavin <alex.kanavin@gmail.com>
 Date: Sat, 22 May 2021 20:26:24 +0200
-Subject: [PATCH 3/4] add fallback parse_printf_format implementation
+Subject: [PATCH 3/5] add fallback parse_printf_format implementation
 
 Upstream-Status: Inappropriate [musl specific]
 

--- a/patches/systemd/0004-Additional-patches-for-systemd-logind.patch
+++ b/patches/systemd/0004-Additional-patches-for-systemd-logind.patch
@@ -1,7 +1,7 @@
-From 4ea3a70e5b2735ee3ddaa1c1e48b9f972d1eb66d Mon Sep 17 00:00:00 2001
+From 8396013e72274db975be1f4f8fd2445f1f6dd7ad Mon Sep 17 00:00:00 2001
 From: Dennis Bonke <admin@dennisbonke.com>
 Date: Mon, 4 Aug 2025 14:49:35 +0200
-Subject: [PATCH 4/4] Additional patches for systemd-logind
+Subject: [PATCH 4/5] Additional patches for systemd-logind
 
 ---
  src/core/exec-invoke.c        | 4 ++++

--- a/patches/systemd/0005-Fix-get_runpath_from_dynamic-on-mlibc.patch
+++ b/patches/systemd/0005-Fix-get_runpath_from_dynamic-on-mlibc.patch
@@ -1,0 +1,28 @@
+From 691483c1ffdac0a7ea4472618e4cf512ebc0eee9 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 10 Aug 2025 16:57:58 +0200
+Subject: [PATCH 5/5] Fix get_runpath_from_dynamic on mlibc
+
+---
+ src/basic/build-path.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/basic/build-path.c b/src/basic/build-path.c
+index b597265..866f5b8 100644
+--- a/src/basic/build-path.c
++++ b/src/basic/build-path.c
+@@ -35,9 +35,10 @@ static int get_runpath_from_dynamic(const ElfW(Dyn) *d, ElfW(Addr) bias, const c
+                 case DT_STRTAB:
+                         /* On MIPS and RISC-V DT_STRTAB records an offset, not a valid address, so it has to be adjusted
+                          * using the bias calculated earlier. */
++                        // Mlibc always works with an offset, so add bias if we're mlibc.
+                         if (d->d_un.d_val != 0)
+                                 strtab = (const char *) ((uintptr_t) d->d_un.d_val
+-#if defined(__mips__) || defined(__riscv)
++#if defined(__mips__) || defined(__riscv) || defined(__mlibc__)
+                                          + bias
+ #endif
+                                 );
+-- 
+2.50.1
+

--- a/patches/wlroots/0001-Add-support-for-vulkan-for-mlibc-users.patch
+++ b/patches/wlroots/0001-Add-support-for-vulkan-for-mlibc-users.patch
@@ -1,0 +1,25 @@
+From 01602123f1dcfc82437cc273e628ff2dd45e5603 Mon Sep 17 00:00:00 2001
+From: Dennis Bonke <admin@dennisbonke.com>
+Date: Sun, 10 Aug 2025 17:18:51 +0200
+Subject: [PATCH] Add support for vulkan for mlibc users
+
+---
+ render/vulkan/vulkan.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/render/vulkan/vulkan.c b/render/vulkan/vulkan.c
+index 7cdc44a..c5268e4 100644
+--- a/render/vulkan/vulkan.c
++++ b/render/vulkan/vulkan.c
+@@ -17,7 +17,7 @@
+ #include "render/dmabuf.h"
+ #include "render/vulkan.h"
+ 
+-#if defined(__linux__)
++#if defined(__linux__) || defined(__mlibc__)
+ #include <sys/sysmacros.h>
+ #endif
+ 
+-- 
+2.50.1
+


### PR DESCRIPTION
This PR updates the `gcc` and `llvm` toolchains to enable build id by default. It also fixes the location of `ld.so` in both of them. `gcc` also got PIE enabled by default and some changes to libgcc to allow using the unwind functions in there for backtracing.
The patches for `gcc` will need to be moved to the `gcc` repo that we use, but that can be done later.

This PR also rebuilds the world, updates mlibc and fixes some `meson setup` related warnings. After this is merged, _all_ packages must be rebuild or pulled from ci by developers, else stuff will break.

Blocked on managarm/mlibc#1408 and must be merged together with managarm/managarm#1000