### PR TITLE
core-files: add basic `config.site`

### DIFF
--- a/bootstrap.d/managarm-base.y4.yml
+++ b/bootstrap.d/managarm-base.y4.yml
@@ -13,7 +13,7 @@ packages:
     source:
       subdir: meta-sources
       version: '1.0'
-    revision: 16
+    revision: 17
     configure: []
     build:
       # Create initial directories
@@ -54,6 +54,8 @@ packages:
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/gshadow', '@THIS_COLLECT_DIR@/etc']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/resolv.conf', '@THIS_COLLECT_DIR@/etc']
       - args: ['cp', '@SOURCE_ROOT@/extrafiles/hosts', '@THIS_COLLECT_DIR@/etc']
+      # Install the default config.site
+      - args: ['cp', '@SOURCE_ROOT@/scripts/config.site', '@THIS_COLLECT_DIR@/usr/share']
       # Link /bin, /lib and /sbin to their /usr counterparts
       - args: ['ln', '-svf', 'usr/bin', '@THIS_COLLECT_DIR@/bin']
       - args: ['ln', '-svf', 'usr/lib', '@THIS_COLLECT_DIR@/lib']

--- a/bootstrap.d/net-misc.y4.yml
+++ b/bootstrap.d/net-misc.y4.yml
@@ -412,7 +412,7 @@ packages:
       - pam
       - zlib
       - openssl
-    revision: 2
+    revision: 3
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -426,9 +426,7 @@ packages:
         - '--with-pam'
         - '--disable-strip'
         environ:
-          ac_cv_iconv_omits_bom: 'yes'
-          ac_cv_fread_reads_directories: 'no'
-          ac_cv_snprintf_returns_bogus: 'no'
+          CONFIG_SITE: '@SOURCE_ROOT@/scripts/config.site'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']

--- a/scripts/config.site
+++ b/scripts/config.site
@@ -1,0 +1,4 @@
+# Default variables to prevent configure from assuming broken implementations.
+ac_cv_fread_reads_directories=${ac_cv_fread_reads_directories=no}
+ac_cv_iconv_omits_bom=${ac_cv_iconv_omits_bom=yes}
+ac_cv_snprintf_returns_bogus=${ac_cv_snprintf_returns_bogus=no}


### PR DESCRIPTION
This should be used to tell configure scripts about what stuff is _not_ broken on managarm, as often it is wrongly assumed that all unknown implementations are broken in specific ways.