### PR TITLE
plasma-desktop: add xkeyboard-config dependency

### DIFF
--- a/bootstrap.d/kde-plasma.y4.yml
+++ b/bootstrap.d/kde-plasma.y4.yml
@@ -1003,6 +1003,7 @@ packages:
       - qtsvg6
       - solid
       - sonnet
+      - xkeyboard-config
     revision: 1
     configure:
       - args:


### PR DESCRIPTION
This is necessary as its pkg-config variables are used in the configure step.