### PR TITLE
.github: Upload images to hades

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -131,6 +131,10 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install -y dosfstools e2fsprogs mtools util-linux zstd
+            - name: Install rsync-ssl
+              run: |
+                  wget https://raw.githubusercontent.com/WayneD/rsync/c3f7414c450faaf6a8281cc4a4403529aeb7d859/rsync-ssl
+                  sudo install -D rsync-ssl /usr/local/bin/rsync-ssl
             - name: Download empty image artifact
               uses: actions/download-artifact@v4
               with:
@@ -159,6 +163,14 @@ jobs:
               with:
                 name: ${{ matrix.image-type }}-image-${{ matrix.arch }}
                 path: image.zst
+            - name: Upload image to repos.managarm.org
+              if: github.repository_owner == 'managarm' && github.ref == 'refs/heads/master'
+              env:
+                  RSYNC_PASSWORD: ${{ secrets.RSYNC_IMAGEREPO_PASSWD }}
+              run: |
+                  mv image.zst image-${{ matrix.image-type }}-${{ matrix.arch }}.zst
+                  sha256sum image-${{ matrix.image-type }}-${{ matrix.arch }}.zst > image-${{ matrix.image-type }}-${{ matrix.arch }}.sha256sum
+                  rsync-ssl -a image-${{ matrix.image-type }}-${{ matrix.arch }}.{sha256sum,zst} imagerepo@rsync.managarm.org::imagerepo/
             - name: Notify about failures
               if: ${{ failure() }}
               run: |


### PR DESCRIPTION
GitHub unfortunately only allows artifact access to logged in users, so upload the artifacts to make them more openly available.