### PR TITLE
scripts: Custom `xbstrap` command prefix

### DIFF
--- a/scripts/managarm-lsp-launcher.sh
+++ b/scripts/managarm-lsp-launcher.sh
@@ -1,7 +1,28 @@
 #!/bin/sh
+
+# parse options
+XBSTRAP="xbstrap"
+BUILD_DIR=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --xbstrap-bin=*)
+            XBSTRAP="${1#*=}"
+            shift 1
+            ;;
+        *)
+            if [ -z "$BUILD_DIR" ]; then
+                BUILD_DIR="$1"
+            fi
+            shift 1
+            ;;
+    esac
+done
+BUILD_DIR="${BUILD_DIR:-/dev/null}"
+
 set -ue
-# check if $1 is a valid build directory
-[ -L "${1:-/dev/null}"/bootstrap.link ] || exit 1
+
+# check if the build directory is valid
+[ -L "$BUILD_DIR"/bootstrap.link ] || exit 1
 
 # find compile_commands.json
 sourcedir="$(pwd)"
@@ -18,7 +39,7 @@ x="${x%/*}"
 x="${x##*/}"
 
 # run the lsp server
-exec xbstrap -C "$1" \
+exec $XBSTRAP -C "$BUILD_DIR" \
     lsp "$x" --extra-tools host-llvm-toolchain -- \
     env HOME=@BUILD_ROOT@/clangd_home \
         XDG_CACHE_HOME=@BUILD_ROOT@/clangd_home/cache \


### PR DESCRIPTION
So my clangd was failing because `xbstrap` wasn't found. Initially i just added `uvx` before running `xbstrap`, but i thought i would create this PR because it would be easier to add the fix to the [Troubleshooting the LSP setup](https://docs.managarm.org/handbook/contributing/lsp.html#troubleshooting) section of the handbook.

Also someone should probably check that this works completely, and that my device doesn't do some quirky thing that makes it work, even tho it should work on all devices (i think).