### PR TITLE
update-image.py, vm-util.py: Some QoL improvements

### DIFF
--- a/bootstrap.d/tasks.y4.yml
+++ b/bootstrap.d/tasks.y4.yml
@@ -77,6 +77,28 @@ tasks:
     workdir: '@BUILD_ROOT@'
     containerless: true
 
+  # Like make-image but do not use root regardless of mount-using.
+  - name: make-image-rootless
+    pkgs_required:
+      - core-files
+      - limine
+      - managarm-kernel
+      - managarm-kernel-uefi
+      - managarm-system
+    tools_required:
+      - tool: host-limine
+        expose: false
+    tasks_required:
+      - update-initrd
+    args:
+      - '@SOURCE_ROOT@/scripts/update-image.py'
+      - '--triple'
+      - '@OPTION:arch-triple@'
+      - '--mount-using'
+      - 'guestfs'
+    workdir: '@BUILD_ROOT@'
+    containerless: true
+
   - name: remake-image
     pkgs_required:
       - core-files

--- a/scripts/update-image.py
+++ b/scripts/update-image.py
@@ -254,11 +254,17 @@ class MountAction:
                 pass
             run_elevated(["mount", f"{diskdev}{sep}{root_partition}", self.mountpoint])
         elif self.mount_using == "guestfs":
-            # guestfs requires us to specify all mountpoints at once
+            # guestfs requires us to specify all mountpoints at once.
+            # Remap UIDs/GIDs to the calling user so that root-owned files in the image
+            # (notably under /boot and on the FAT ESP) can be modified without elevation.
             args = [
                 "guestmount",
                 "--pid-file",
                 "guestfs.pid",
+                "-o",
+                f"uid={os.getuid()}",
+                "-o",
+                f"gid={os.getgid()}",
                 "-a",
                 self.image,
                 "-m",

--- a/scripts/vm-util.py
+++ b/scripts/vm-util.py
@@ -432,7 +432,10 @@ class QemuRunner:
         self.proc = await asyncio.create_subprocess_exec(
             qemu,
             *qemu_args,
-            stdout=subprocess.PIPE
+            # Qemu switches stdin to non-blocking.
+            # This is a problem since it may match stdout and we are writing to stdout.
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
         )
         self.launch_time = time.time()
         self.last_io_time = time.time()
@@ -473,10 +476,6 @@ class QemuRunner:
                 break
 
     async def process_stdout(self, *, expect_all, expect_none):
-        loop = asyncio.get_running_loop()
-        w_transport, w_protocol = await loop.connect_write_pipe(asyncio.streams.FlowControlMixin, sys.stdout)
-        writer = asyncio.StreamWriter(w_transport, w_protocol, None, loop)
-
         buf = bytes()
         while True:
             chunk = await self.proc.stdout.read(4096)
@@ -488,9 +487,12 @@ class QemuRunner:
             # Echo the chunk to stdout.
             if self.logfile:
                 self.logfile.write(chunk)
+                self.logfile.flush()
             else:
-                writer.write(chunk)
-                await writer.drain()
+                # Validate that Qemu did not switch to non-blocking mode.
+                assert os.get_blocking(sys.stdout.fileno())
+                sys.stdout.buffer.write(chunk)
+                sys.stdout.buffer.flush()
 
             # Split the chunk into lines, analyze each line.
             buf += chunk

--- a/scripts/vm-util.py
+++ b/scripts/vm-util.py
@@ -619,7 +619,9 @@ def do_qemu(args):
         qemu_args += ["-m", args.memory]
 
     qemu_args += ["-name", f"Managarm {args.arch}"]
-    if args.sdl:
+    if args.no_display:
+        qemu_args += ["-display", "none"]
+    elif args.sdl:
         qemu_args += ["-display", "sdl"]
     else:
         qemu_args += ["-display", "gtk,zoom-to-fit=off"]
@@ -925,7 +927,7 @@ def do_qemu(args):
 
     # Add graphics output.
     if args.gfx == "none":
-        qemu_args += ["-vga", "none", "-display", "none"]
+        qemu_args += ["-vga", "none"]
     elif args.gfx == "default":
         if args.arch == "x86_64":
             qemu_args += qemu_virtio_device("virtio-vga", [], args.iommu)
@@ -1113,7 +1115,9 @@ qemu_parser.add_argument(
 qemu_parser.add_argument("--gfx", choices=["bga", "virtio", "vmware", "ramfb", "none"], default="default")
 qemu_parser.add_argument("--ps2", action="store_true")
 qemu_parser.add_argument("--mouse", action="store_true")
-qemu_parser.add_argument("--sdl", action="store_true")
+display_group = qemu_parser.add_mutually_exclusive_group()
+display_group.add_argument("--sdl", action="store_true")
+display_group.add_argument("--no-display", action="store_true")
 qemu_parser.add_argument("--init-launch", type=str, default="weston")
 qemu_parser.add_argument("--device-spec", type=argparse.FileType('r'))
 qemu_parser.add_argument("--pci-passthrough", type=str)


### PR DESCRIPTION
- `make-image-rootless` is useful if you want to force rootless operation even though your `bootstrap-site.yml` specifies loopback. I use this to let Claude build images without modifying my `bootstrap-site.yml`. The guestfs change is a related fix.
- Emitting logs synchronously fixes redirects from `vm-util.py` into files.