### PR TITLE
scripts: make python shebangs non-FHS compatible

### DIFF
--- a/scripts/build-image.py
+++ b/scripts/build-image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/scripts/gen-limine-conf.py
+++ b/scripts/gen-limine-conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import contextlib

--- a/scripts/many-boots.py
+++ b/scripts/many-boots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os


### PR DESCRIPTION
This allows building on non-FHS distros such as NixOS.