### PR TITLE
rsync: don't use mktemp()

### DIFF
--- a/bootstrap.d/net-misc.y4.yml
+++ b/bootstrap.d/net-misc.y4.yml
@@ -285,7 +285,7 @@ packages:
       - xxhash
       - zlib
       - zstd
-    revision: 11
+    revision: 12
     configure:
       - args:
         - '@THIS_SOURCE_DIR@/configure'
@@ -308,6 +308,7 @@ packages:
         - '--with-rsyncd-conf=/etc/rscynd.conf'
         environ:
           rsync_cv_HAVE_GETTIMEOFDAY_TZ: 'yes'
+          rsync_cv_HAVE_SECURE_MKSTEMP: 'yes'
     build:
       - args: ['make', '-j@PARALLELISM@']
       - args: ['make', 'install']


### PR DESCRIPTION
rsync runs a configure test to see if mkstemp() is secure. It can't run the test when cross-compiling and them defaults to assuming it is insecure. This makes rsync use mktemp() which mlibc doesn't implement.