### PR TITLE
Small fixes for ci and local development

### DIFF
--- a/bootstrap.d/dev-libs.y4.yml
+++ b/bootstrap.d/dev-libs.y4.yml
@@ -3413,7 +3413,7 @@ packages:
       - xcb-proto
       - xcb-util-cursor
       - xwayland
-    revision: 10
+    revision: 11
     configure:
       - args:
         - 'meson'

--- a/bootstrap.d/meta-pkgs.y4.yml
+++ b/bootstrap.d/meta-pkgs.y4.yml
@@ -63,7 +63,7 @@ packages:
       - xbps
       - xkeyboard-config
       - xz-utils
-    revision: 14
+    revision: 15
     configure: []
     build: []
 

--- a/scripts/update-image.py
+++ b/scripts/update-image.py
@@ -621,6 +621,10 @@ class UpdateFsAction:
         def plan_rsync(dir, exclude_files=[]):
             source = os.path.join(self.sysroot, dir)
             target = os.path.join(target_mntpoint, dir)
+            if os.path.islink(source):
+                # rsync 3.5 cannot use an existing symlink as its destination
+                # directory. Sync the link through its parent instead.
+                target = os.path.dirname(target)
             command = ["rsync", "--checksum", "-a", "--delete"]
             command += rsync_id_args
             command += [source, target]


### PR DESCRIPTION
This PR bumps 2 revisions as those packages were not yet picked up by xbbs for a new version and fixes update-image.py to work with rsync 3.5.0 and newer.